### PR TITLE
feat(vm0-computer): add computer connector skill

### DIFF
--- a/vm0-computer/SKILL.md
+++ b/vm0-computer/SKILL.md
@@ -101,7 +101,7 @@ curl -s "http://127.0.0.1:8080/notes.txt"
 
 ### 3. Upload a File to the Local Machine
 
-Write a local sandbox file to the user's `~/Downloads`:
+Write a local sandbox file to remote:
 
 ```bash
 curl -s -X PUT "http://127.0.0.1:8080/output-report.txt" --header "Content-Type: text/plain" --data-binary @/home/user/output-report.txt


### PR DESCRIPTION
## Summary

- Adds `vm0-computer/SKILL.md` — a new skill for accessing the user's local filesystem from within a VM0 sandbox via the VM0 Computer Connector
- The skill uses a secure WebDAV tunnel (ngrok) established by `vm0 connector connect computer` on the user's local machine
- Covers all key WebDAV operations: list directory (PROPFIND), download (GET), upload (PUT), delete (DELETE), create directory (MKCOL)

## Details

The Computer Connector exposes `~/Downloads` as a WebDAV endpoint at `https://webdav.$COMPUTER_CONNECTOR_DOMAIN/`. Authentication uses the `x-vm0-token` header with `$COMPUTER_CONNECTOR_BRIDGE_TOKEN`.

All examples follow the `bash -c '...'` wrapper pattern required to avoid the Claude Code pipe + env var bug.

## Test plan

- [ ] Run `vm0 connector connect computer` locally
- [ ] Deploy a test agent with the skill and explicit env var declarations in `vm0.yaml`
- [ ] Verify PROPFIND lists `~/Downloads` contents
- [ ] Verify GET downloads a file into the sandbox
- [ ] Verify PUT writes a file back to `~/Downloads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)