### PR TITLE
Fix SerpAPI skill examples for Maps and jq quoting

### DIFF
--- a/serpapi/SKILL.md
+++ b/serpapi/SKILL.md
@@ -61,7 +61,7 @@ Base URL: `https://serpapi.com/search`
 Search Google and get structured JSON results:
 
 ```bash
-bash -c 'curl -s "https://serpapi.com/search?engine=google&q=artificial+intelligence&api_key=${SERPAPI_API_KEY}"' | jq '.organic_results[:3] | .[] | {title, link, snippet}
+bash -c 'curl -s "https://serpapi.com/search?engine=google&q=artificial+intelligence&api_key=${SERPAPI_API_KEY}"' | jq '.organic_results[:3] | .[] | {title, link, snippet}'
 ```
 
 ---
@@ -86,7 +86,7 @@ bash -c 'curl -s "https://serpapi.com/search?engine=google&q=best+coffee+shops&l
 Search for images:
 
 ```bash
-bash -c 'curl -s "https://serpapi.com/search?engine=google_images&q=sunset+beach&api_key=${SERPAPI_API_KEY}"' | jq '.images_results[:3] | .[] | {title, original, thumbnail}
+bash -c 'curl -s "https://serpapi.com/search?engine=google_images&q=sunset+beach&api_key=${SERPAPI_API_KEY}"' | jq '.images_results[:3] | .[] | {title, original, thumbnail}'
 ```
 
 ---
@@ -96,7 +96,7 @@ bash -c 'curl -s "https://serpapi.com/search?engine=google_images&q=sunset+beach
 Search news articles:
 
 ```bash
-bash -c 'curl -s "https://serpapi.com/search?engine=google_news&q=technology&api_key=${SERPAPI_API_KEY}"' | jq '.news_results[:3] | .[] | {title, link, source, date}
+bash -c 'curl -s "https://serpapi.com/search?engine=google_news&q=technology&api_key=${SERPAPI_API_KEY}"' | jq '.news_results[:3] | .[] | {title, link, source, date}'
 ```
 
 ---
@@ -106,7 +106,7 @@ bash -c 'curl -s "https://serpapi.com/search?engine=google_news&q=technology&api
 Search products:
 
 ```bash
-bash -c 'curl -s "https://serpapi.com/search?engine=google_shopping&q=wireless+headphones&api_key=${SERPAPI_API_KEY}"' | jq '.shopping_results[:3] | .[] | {title, price, source}
+bash -c 'curl -s "https://serpapi.com/search?engine=google_shopping&q=wireless+headphones&api_key=${SERPAPI_API_KEY}"' | jq '.shopping_results[:3] | .[] | {title, price, source}'
 ```
 
 ---
@@ -116,7 +116,7 @@ bash -c 'curl -s "https://serpapi.com/search?engine=google_shopping&q=wireless+h
 Search YouTube videos:
 
 ```bash
-bash -c 'curl -s "https://serpapi.com/search?engine=youtube&search_query=python+tutorial&api_key=${SERPAPI_API_KEY}"' | jq '.video_results[:3] | .[] | {title, link, channel, views}
+bash -c 'curl -s "https://serpapi.com/search?engine=youtube&search_query=python+tutorial&api_key=${SERPAPI_API_KEY}"' | jq '.video_results[:3] | .[] | {title, link, channel, views}'
 ```
 
 ---
@@ -126,7 +126,20 @@ bash -c 'curl -s "https://serpapi.com/search?engine=youtube&search_query=python+
 Search local businesses:
 
 ```bash
-bash -c 'curl -s "https://serpapi.com/search?engine=google_maps&q=restaurants&ll=@40.7128,-74.0060,15z&api_key=${SERPAPI_API_KEY}"' | jq '.local_results[:3] | .[] | {title, rating, address}
+bash -c 'curl -s "https://serpapi.com/search?engine=google_maps&q=restaurants&ll=@40.7128,-74.0060,15z&api_key=${SERPAPI_API_KEY}"' | jq '.local_results[:3] | .[] | {title, rating, address}'
+```
+
+If using `location` with Google Maps, include `z` or `m`:
+
+```bash
+bash -c 'curl -s "https://serpapi.com/search?engine=google_maps&q=3PL&location=Dallas-Fort+Worth,+Texas&z=14&api_key=${SERPAPI_API_KEY}"'
+```
+
+Defensive local-results extraction:
+
+```bash
+bash -c 'curl -s "https://serpapi.com/search?engine=google_maps&q=3PL&ll=@32.7767,-96.7970,14z&api_key=${SERPAPI_API_KEY}"' \
+  | jq 'if has("error") then .error else (.local_results[:5] | map({title,address,phone,website,link,type})) end'
 ```
 
 **Parameters:**
@@ -153,7 +166,7 @@ bash -c 'curl -s "https://serpapi.com/search?engine=google&q=machine+learning&st
 Check your API usage and credits:
 
 ```bash
-bash -c 'curl -s "https://serpapi.com/account?api_key=${SERPAPI_API_KEY}"' | jq '{plan_name, searches_per_month, this_month_usage}
+bash -c 'curl -s "https://serpapi.com/account?api_key=${SERPAPI_API_KEY}"' | jq '{plan_name, searches_per_month, this_month_usage}'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fixed unterminated jq expressions in multiple SerpAPI examples (bash quoting).
- Added note that Google Maps `location` requires `z` or `m` parameter.
- Added defensive local-results extraction example to avoid `.local_results` null/shape errors.

## Validation
- Confirmed upstream endpoint returns errors for missing `z`/`m` with `location`.
- Confirmed local_results shape is array in this endpoint and previously-used `location` queries failed with `400`.

## Notes
- No behavior changes outside example snippets/documentation.