### PR TITLE
docs: unify connector prerequisites to use vm0.ai Settings → Connectors

### DIFF
--- a/github/SKILL.md
+++ b/github/SKILL.md
@@ -21,7 +21,9 @@ This Skill helps you manage GitHub operations using the `gh` CLI, including repo
 
 ## Authentication
 
-The `GITHUB_TOKEN` environment variable is pre-configured. Verify with:
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **GitHub**. vm0 will automatically inject the required token.
+
+Verify with:
 ```bash
 gh auth status
 ```
@@ -129,17 +131,7 @@ gh pr view <number> --repo <owner>/<repo> --json title,state,reviews,checks
 
 ## Prerequisites
 
-This Skill requires the GitHub CLI (`gh`) to be installed and authenticated:
-```bash
-gh auth status
-```
-
-If not authenticated, run:
-```bash
-gh auth login
-```
-
-Alternatively, set the `GITHUB_TOKEN` environment variable with a personal access token.
+This Skill requires the GitHub CLI (`gh`) to be installed. Token is automatically provided by vm0 — connect GitHub in [vm0.ai](https://vm0.ai) **Settings → Connectors**.
 
 **Important:** When using environment variables in commands with pipes, wrap the command in `bash -c '...'` to avoid variable substitution issues:
 ```bash

--- a/gmail/SKILL.md
+++ b/gmail/SKILL.md
@@ -26,6 +26,10 @@ Use this skill when you need to:
 
 ---
 
+## Prerequisites
+
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Gmail**. vm0 will automatically inject the required `GMAIL_TOKEN` environment variable.
+
 ---
 
 > **Important:** When using `$VAR` in a command that pipes to another command, wrap the command containing `$VAR` in `bash -c '...'`. Due to a Claude Code bug, environment variables are silently cleared when pipes are used directly.

--- a/google-calendar/SKILL.md
+++ b/google-calendar/SKILL.md
@@ -30,19 +30,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-Obtain an OAuth 2.0 access token with the required scope:
-
-1. Go to https://developers.google.com/oauthplayground/
-2. In the left panel, enter scope: `https://www.googleapis.com/auth/calendar`
-3. Click **Authorize APIs** → sign in with your Google account
-4. Click **Exchange authorization code for tokens**
-5. Copy the **Access token**
-
-```bash
-export GOOGLE_CALENDAR_TOKEN="your-access-token"
-```
-
-> Note: Access tokens expire after ~1 hour. Repeat the above steps to refresh.
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Google Calendar**. vm0 will automatically inject the required `GOOGLE_CALENDAR_TOKEN` environment variable.
 
 ---
 

--- a/google-docs/SKILL.md
+++ b/google-docs/SKILL.md
@@ -29,19 +29,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-Obtain an OAuth 2.0 access token with the required scope:
-
-1. Go to https://developers.google.com/oauthplayground/
-2. In the left panel, enter scope: `https://www.googleapis.com/auth/documents`
-3. Click **Authorize APIs** → sign in with your Google account
-4. Click **Exchange authorization code for tokens**
-5. Copy the **Access token**
-
-```bash
-export GOOGLE_DOCS_TOKEN="your-access-token"
-```
-
-> Note: Access tokens expire after ~1 hour. Repeat the above steps to refresh.
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Google Docs**. vm0 will automatically inject the required `GOOGLE_DOCS_TOKEN` environment variable.
 
 ---
 

--- a/google-drive/SKILL.md
+++ b/google-drive/SKILL.md
@@ -31,19 +31,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-Obtain an OAuth 2.0 access token with the required scope:
-
-1. Go to https://developers.google.com/oauthplayground/
-2. In the left panel, enter scope: `https://www.googleapis.com/auth/drive`
-3. Click **Authorize APIs** → sign in with your Google account
-4. Click **Exchange authorization code for tokens**
-5. Copy the **Access token**
-
-```bash
-export GOOGLE_DRIVE_TOKEN="your-access-token"
-```
-
-> Note: Access tokens expire after ~1 hour. Repeat the above steps to refresh.
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Google Drive**. vm0 will automatically inject the required `GOOGLE_DRIVE_TOKEN` environment variable.
 
 ---
 

--- a/google-sheets/SKILL.md
+++ b/google-sheets/SKILL.md
@@ -28,19 +28,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-Obtain an OAuth 2.0 access token with the required scope:
-
-1. Go to https://developers.google.com/oauthplayground/
-2. In the left panel, enter scope: `https://www.googleapis.com/auth/spreadsheets`
-3. Click **Authorize APIs** → sign in with your Google account
-4. Click **Exchange authorization code for tokens**
-5. Copy the **Access token**
-
-```bash
-export GOOGLE_SHEETS_TOKEN="your-access-token"
-```
-
-> Note: Access tokens expire after ~1 hour. Repeat the above steps to refresh.
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Google Sheets**. vm0 will automatically inject the required `GOOGLE_SHEETS_TOKEN` environment variable.
 
 ---
 

--- a/linear/SKILL.md
+++ b/linear/SKILL.md
@@ -28,13 +28,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-1. Log in to [Linear](https://linear.app/) and go to Settings
-2. Navigate to **Security & access** → **Personal API keys**
-3. Create a new API key with appropriate permissions
-
-```bash
-export LINEAR_API_KEY="lin_api_..."
-```
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Linear**. vm0 will automatically inject the required `LINEAR_API_KEY` environment variable.
 
 ### Rate Limits
 

--- a/notion/SKILL.md
+++ b/notion/SKILL.md
@@ -19,17 +19,9 @@ Manage pages, databases, and content blocks in Notion workspaces.
 
 ## Prerequisites
 
-```bash
-export NOTION_TOKEN=ntn_your-integration-token
-```
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Notion**. vm0 will automatically inject the required `NOTION_TOKEN` environment variable.
 
-### Get API Key
-
-1. Go to https://www.notion.so/profile/integrations
-2. Click "New integration"
-3. Name your integration and select workspace
-4. Copy the "Internal Integration Secret" (`ntn_...` or `secret_...`)
-5. **Important**: Share pages/databases with the integration via "Add connections" in Notion
+**Important**: Share pages/databases with the integration via "Add connections" in Notion.
 
 ### Page ID Format
 

--- a/slack/SKILL.md
+++ b/slack/SKILL.md
@@ -19,16 +19,7 @@ Send messages, read channels, and interact with Slack workspaces.
 
 ## Prerequisites
 
-```bash
-export SLACK_TOKEN=xoxp-your-user-token
-```
-
-### Token Types
-
-Slack has two types of tokens:
-
-- **User token** (`xoxp-...`) — Acts as a specific user. Required for accessing DMs, private channels the user is in, and user-specific actions. Obtained via OAuth on behalf of a user.
-- **Bot token** (`xoxb-...`) — Acts as a bot app. Can only access channels the bot has been invited to. Obtained by installing a Slack app to a workspace.
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **Slack**. vm0 will automatically inject the required `SLACK_TOKEN` environment variable.
 
 ## Core APIs
 

--- a/x/SKILL.md
+++ b/x/SKILL.md
@@ -27,8 +27,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-1. Connect your X account via the vm0 platform (OAuth connector)
-2. The `X_ACCESS_TOKEN` environment variable is automatically configured
+Go to [vm0.ai](https://vm0.ai) **Settings → Connectors** and connect **X (Twitter)**. vm0 will automatically inject the required `X_ACCESS_TOKEN` environment variable.
 
 Verify authentication:
 


### PR DESCRIPTION
Replace manual token setup instructions (OAuth Playground, API key creation, export commands) with unified approach: connect the service in vm0.ai Settings → Connectors, and vm0 auto-injects the required token.

Affected skills: github, gmail, google-calendar, google-docs, google-drive, google-sheets, linear, notion, slack, x