### PR TITLE
chore: update sentry skill prerequisites

### DIFF
--- a/sentry/SKILL.md
+++ b/sentry/SKILL.md
@@ -28,15 +28,14 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-Connect your Sentry account via the vm0 platform (OAuth connector). The `SENTRY_TOKEN` environment variable is automatically configured.
+1. Connect your Sentry account at [vm0 Settings > Connectors](https://app.vm0.ai/settings/connectors) and click **sentry**
+2. The `SENTRY_TOKEN` environment variable is automatically configured
 
 Verify authentication:
 
 ```bash
 bash -c 'curl -s "https://sentry.io/api/0/organizations/" -H "Authorization: Bearer $SENTRY_TOKEN"' | jq '.[0] | {slug, name}'
 ```
-
-Expected response: Your organization information (slug, name).
 
 ### Discovering Your Organization Slug
 


### PR DESCRIPTION
## Summary
- Update Sentry skill prerequisites to direct users to vm0 Settings > Connectors page
- Consistent with other public connector skills (X, Figma, Strava)
- Sentry connector feature flag is being removed in vm0-ai/vm0#3634

## Changes
- Replace generic "Connect via vm0 platform" text with specific link to Settings > Connectors
- Use numbered list format matching the X connector skill pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)