### PR TITLE
feat(vercel): expand skill with 22 API examples

### DIFF
--- a/vercel/SKILL.md
+++ b/vercel/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: vercel
-description: Vercel API via curl. Use this skill to manage deployments, projects, domains, and environment variables on Vercel.
+description: Vercel API via curl. Use this skill to manage deployments, projects, domains, environment variables, and webhooks on Vercel.
 vm0_secrets:
   - VERCEL_TOKEN
 ---
 
 # Vercel API
 
-Use the Vercel API via direct `curl` calls to manage **deployments, projects, domains, and environment variables**.
+Use the Vercel API via direct `curl` calls to manage **deployments, projects, domains, environment variables, and webhooks**.
 
 > Official docs: `https://vercel.com/docs/rest-api`
 
@@ -17,10 +17,11 @@ Use the Vercel API via direct `curl` calls to manage **deployments, projects, do
 
 Use this skill when you need to:
 
-- **List and manage projects** - view, create, and configure projects
-- **Monitor deployments** - list deployments and check their status
-- **Manage domains** - list, add, and configure domains
-- **Handle environment variables** - create, update, and delete env vars
+- **List and manage projects** - view, create, delete, and configure projects
+- **Monitor and control deployments** - list, redeploy, promote to production, cancel, and view build logs
+- **Manage domains** - list, add, and remove domains from projects
+- **Handle environment variables** - list, create, and delete env vars
+- **Manage webhooks** - create, list, and delete webhooks for deployment events
 
 ---
 
@@ -83,7 +84,35 @@ PROJECT=my-project bash -c 'curl -s "https://api.vercel.com/v9/projects/$PROJECT
 
 ---
 
-### 4. List Deployments
+### 4. Create Project
+
+Create a new project:
+
+```bash
+bash -c 'curl -s -X POST "https://api.vercel.com/v11/projects" -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" -d "{\"name\":\"my-new-project\",\"framework\":\"nextjs\"}"' | jq '{id, name, framework}'
+```
+
+Only `name` is required. Optional fields: `framework`, `buildCommand`, `outputDirectory`, `rootDirectory`, `installCommand`.
+
+---
+
+### 5. Delete Project
+
+Delete a project:
+
+> **Warning:** This permanently deletes the project and all its deployments.
+
+> **Note:** Replace `my-project` with the project name or ID.
+
+```bash
+PROJECT=my-project bash -c 'curl -s -X DELETE "https://api.vercel.com/v9/projects/$PROJECT" -H "Authorization: Bearer $VERCEL_TOKEN" -w "\nHTTP Status: %{http_code}\n"'
+```
+
+Returns `204 No Content` on success.
+
+---
+
+### 6. List Deployments
 
 Get recent deployments:
 
@@ -93,7 +122,7 @@ bash -c 'curl -s "https://api.vercel.com/v6/deployments?limit=10" -H "Authorizat
 
 ---
 
-### 5. List Deployments for a Project
+### 7. List Deployments for a Project
 
 Get deployments for a specific project:
 
@@ -105,7 +134,7 @@ PROJECT=my-project bash -c 'curl -s "https://api.vercel.com/v6/deployments?proje
 
 ---
 
-### 6. Get Deployment Details
+### 8. Get Deployment Details
 
 Get details for a specific deployment:
 
@@ -117,7 +146,59 @@ DEPLOY_ID=dpl_xxx bash -c 'curl -s "https://api.vercel.com/v13/deployments/$DEPL
 
 ---
 
-### 7. List Domains
+### 9. Get Deployment Build Logs
+
+Get build logs for a deployment:
+
+> **Note:** Replace `dpl_xxx` with an actual deployment ID. Use `limit=-1` to get all logs.
+
+```bash
+DEPLOY_ID=dpl_xxx bash -c 'curl -s "https://api.vercel.com/v3/deployments/$DEPLOY_ID/events?limit=-1" -H "Authorization: Bearer $VERCEL_TOKEN"' | jq '.[] | select(.type == "command" or .type == "stdout" or .type == "stderr") | {type, text: .payload.text}'
+```
+
+---
+
+### 10. Redeploy a Deployment
+
+Trigger a redeployment of a previous deployment:
+
+> **Note:** Replace `my-project` with your project name and `dpl_xxx` with the deployment ID to redeploy.
+
+```bash
+PROJECT=my-project DEPLOY_ID=dpl_xxx bash -c 'curl -s -X POST "https://api.vercel.com/v13/deployments" -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" -d "{\"name\":\"$PROJECT\",\"deploymentId\":\"$DEPLOY_ID\",\"target\":\"production\"}"' | jq '{id, url, readyState, target}'
+```
+
+Add `"withLatestCommit": true` to force using the latest commit instead of the original deployment's commit.
+
+---
+
+### 11. Promote Deployment to Production
+
+Point all production domains to a specific deployment (rollback):
+
+> **Note:** Replace `prj_xxx` with your project ID and `dpl_xxx` with the deployment ID to promote.
+
+```bash
+PROJECT_ID=prj_xxx DEPLOY_ID=dpl_xxx bash -c 'curl -s -X POST "https://api.vercel.com/v1/projects/$PROJECT_ID/rollback/$DEPLOY_ID" -H "Authorization: Bearer $VERCEL_TOKEN" -w "\nHTTP Status: %{http_code}\n"'
+```
+
+Returns `201 Created` on success.
+
+---
+
+### 12. Cancel Deployment
+
+Cancel a deployment that is currently `BUILDING` or `QUEUED`. Deployments already in `READY` state cannot be canceled.
+
+> **Note:** Replace `dpl_xxx` with an actual deployment ID of a building/queued deployment.
+
+```bash
+DEPLOY_ID=dpl_xxx bash -c 'curl -s -X PATCH "https://api.vercel.com/v12/deployments/$DEPLOY_ID/cancel" -H "Authorization: Bearer $VERCEL_TOKEN"' | jq '{id, readyState}'
+```
+
+---
+
+### 13. List Domains
 
 Get all domains:
 
@@ -127,7 +208,7 @@ bash -c 'curl -s "https://api.vercel.com/v5/domains" -H "Authorization: Bearer $
 
 ---
 
-### 8. List Project Domains
+### 14. List Project Domains
 
 Get domains configured for a specific project:
 
@@ -139,19 +220,45 @@ PROJECT=my-project bash -c 'curl -s "https://api.vercel.com/v9/projects/$PROJECT
 
 ---
 
-### 9. List Environment Variables
+### 15. Add Domain to Project
+
+Add a domain to a project:
+
+> **Note:** Replace `my-project` with your project name or ID and `example.com` with the domain to add.
+
+```bash
+PROJECT=my-project bash -c 'curl -s -X POST "https://api.vercel.com/v10/projects/$PROJECT/domains" -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" -d "{\"name\":\"example.com\"}"' | jq '{name, verified, verification}'
+```
+
+If `verified` is `false`, complete the DNS verification challenge shown in the `verification` array.
+
+---
+
+### 16. Remove Domain from Project
+
+Remove a domain from a project:
+
+> **Note:** Replace `my-project` with your project name or ID and `example.com` with the domain.
+
+```bash
+PROJECT=my-project DOMAIN=example.com bash -c 'curl -s -X DELETE "https://api.vercel.com/v9/projects/$PROJECT/domains/$DOMAIN" -H "Authorization: Bearer $VERCEL_TOKEN" -w "\nHTTP Status: %{http_code}\n"'
+```
+
+---
+
+### 17. List Environment Variables
 
 Get environment variables for a project:
 
 > **Note:** Replace `my-project` with your actual project name or ID.
 
 ```bash
-PROJECT=my-project bash -c 'curl -s "https://api.vercel.com/v9/projects/$PROJECT/env" -H "Authorization: Bearer $VERCEL_TOKEN"' | jq '.envs[] | {key, target, type}'
+PROJECT=my-project bash -c 'curl -s "https://api.vercel.com/v9/projects/$PROJECT/env" -H "Authorization: Bearer $VERCEL_TOKEN"' | jq '.envs[] | {id, key, target, type}'
 ```
 
 ---
 
-### 10. Create Environment Variable
+### 18. Create Environment Variable
 
 Add an environment variable to a project:
 
@@ -163,15 +270,55 @@ PROJECT=my-project bash -c 'curl -s -X POST "https://api.vercel.com/v10/projects
 
 ---
 
-### 11. Cancel Deployment
+### 19. Delete Environment Variable
 
-Cancel a deployment that is currently `BUILDING` or `QUEUED`. Deployments already in `READY` state cannot be canceled.
+Delete an environment variable from a project:
 
-> **Note:** Replace `dpl_xxx` with an actual deployment ID of a building/queued deployment.
+> **Note:** Replace `my-project` with the project name or ID. Get the env var `id` from "List Environment Variables" output.
 
 ```bash
-DEPLOY_ID=dpl_xxx bash -c 'curl -s -X PATCH "https://api.vercel.com/v12/deployments/$DEPLOY_ID/cancel" -H "Authorization: Bearer $VERCEL_TOKEN"' | jq '{id, readyState}'
+PROJECT=my-project ENV_ID=xxx bash -c 'curl -s -X DELETE "https://api.vercel.com/v9/projects/$PROJECT/env/$ENV_ID" -H "Authorization: Bearer $VERCEL_TOKEN"' | jq '{id, key}'
 ```
+
+---
+
+### 20. List Webhooks
+
+Get all webhooks:
+
+```bash
+bash -c 'curl -s "https://api.vercel.com/v1/webhooks" -H "Authorization: Bearer $VERCEL_TOKEN"' | jq '.[] | {id, url, events, projectIds}'
+```
+
+---
+
+### 21. Create Webhook
+
+Create a webhook for deployment events:
+
+> **Note:** Replace the `url` with your webhook endpoint. Optionally scope to specific projects with `projectIds`.
+
+```bash
+bash -c 'curl -s -X POST "https://api.vercel.com/v1/webhooks" -H "Authorization: Bearer $VERCEL_TOKEN" -H "Content-Type: application/json" -d "{\"url\":\"https://example.com/webhook\",\"events\":[\"deployment.created\",\"deployment.succeeded\",\"deployment.error\"]}"' | jq '{id, url, events, secret}'
+```
+
+The `secret` is only returned at creation time. Save it to verify webhook payloads via the `x-vercel-signature` header.
+
+Common events: `deployment.created`, `deployment.succeeded`, `deployment.error`, `deployment.canceled`, `deployment.ready`, `project.created`, `project.removed`.
+
+---
+
+### 22. Delete Webhook
+
+Delete a webhook:
+
+> **Note:** Replace `hook_xxx` with the webhook ID from "List Webhooks" output.
+
+```bash
+HOOK_ID=hook_xxx bash -c 'curl -s -X DELETE "https://api.vercel.com/v1/webhooks/$HOOK_ID" -H "Authorization: Bearer $VERCEL_TOKEN" -w "\nHTTP Status: %{http_code}\n"'
+```
+
+Returns `204 No Content` on success.
 
 ---
 
@@ -190,5 +337,5 @@ DEPLOY_ID=dpl_xxx bash -c 'curl -s -X PATCH "https://api.vercel.com/v12/deployme
 ## Guidelines
 
 1. **Pagination**: Use `?limit=N&until=<timestamp>` for paginated results
-3. **Rate limits**: Vercel has rate limits; implement backoff for 429 responses
-4. **Project references**: You can use either project ID or project name in most endpoints
+2. **Rate limits**: Vercel has rate limits; implement backoff for 429 responses
+3. **Project references**: You can use either project ID or project name in most endpoints


### PR DESCRIPTION
## Summary
- Expanded from 11 to 22 examples covering the full Vercel REST API surface
- New examples: create/delete project, redeploy, promote to production, build logs, add/remove domain, delete env var, list/create/delete webhooks
- All endpoints verified against official Vercel REST API docs

## Test plan
- [ ] Run `vm0 cook` with vercel skill to verify all examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)