### PR TITLE
fix: correct YAML list indentation in skill frontmatter

### DIFF
--- a/agentmail/SKILL.md
+++ b/agentmail/SKILL.md
@@ -3,7 +3,7 @@ name: agentmail
 description: AgentMail API for email inboxes. Use when user says "create email inbox",
   "send email", "check messages", or mentions "agentmail" or email for agents.
 vm0_secrets:
-- AGENTMAIL_TOKEN
+  - AGENTMAIL_TOKEN
 ---
 
 # AgentMail API

--- a/ahrefs/SKILL.md
+++ b/ahrefs/SKILL.md
@@ -3,7 +3,7 @@ name: ahrefs
 description: Ahrefs SEO API for backlink and keyword analysis. Use when user mentions
   "SEO", "backlinks", "domain rating", "keyword research", or asks about site metrics.
 vm0_secrets:
-- AHREFS_TOKEN
+  - AHREFS_TOKEN
 ---
 
 # Ahrefs API

--- a/airtable/SKILL.md
+++ b/airtable/SKILL.md
@@ -4,7 +4,7 @@ description: Airtable API for bases and records. Use when user mentions "Airtabl
   "airtable.com", shares an Airtable link, "create record", or asks about Airtable
   base.
 vm0_secrets:
-- AIRTABLE_TOKEN
+  - AIRTABLE_TOKEN
 ---
 
 # Airtable API

--- a/apify/SKILL.md
+++ b/apify/SKILL.md
@@ -3,7 +3,7 @@ name: apify
 description: Apify web scraping platform. Use when user mentions "scrape website",
   "web crawler", "scraping", or asks to "extract data from" a site.
 vm0_secrets:
-- APIFY_TOKEN
+  - APIFY_TOKEN
 ---
 
 # Apify

--- a/asana/SKILL.md
+++ b/asana/SKILL.md
@@ -3,7 +3,7 @@ name: asana
 description: Asana API for tasks and projects. Use when user mentions "Asana", "asana.com",
   shares an Asana link, "Asana task", or asks about Asana workspace.
 vm0_secrets:
-- ASANA_TOKEN
+  - ASANA_TOKEN
 ---
 
 # Asana API

--- a/atlassian/SKILL.md
+++ b/atlassian/SKILL.md
@@ -3,9 +3,9 @@ name: atlassian
 description: Atlassian API for Confluence and Jira. Use when user mentions "Confluence
   page", "Atlassian", or asks about wiki/documentation management.
 vm0_secrets:
-- ATLASSIAN_TOKEN
+  - ATLASSIAN_TOKEN
 vm0_vars:
-- ATLASSIAN_DOMAIN
+  - ATLASSIAN_DOMAIN
 - ATLASSIAN_EMAIL
 ---
 

--- a/axiom/SKILL.md
+++ b/axiom/SKILL.md
@@ -3,7 +3,7 @@ name: axiom
 description: Axiom observability API for logs and analytics. Use when user mentions
   "logs", "query logs", "Axiom", or asks about event analytics.
 vm0_secrets:
-- AXIOM_TOKEN
+  - AXIOM_TOKEN
 ---
 
 # Axiom

--- a/bitrix/SKILL.md
+++ b/bitrix/SKILL.md
@@ -3,7 +3,7 @@ name: bitrix
 description: Bitrix24 CRM API. Use when user mentions "Bitrix", "CRM", "Bitrix24 contacts",
   or asks about CRM management.
 vm0_secrets:
-- BITRIX_WEBHOOK_URL
+  - BITRIX_WEBHOOK_URL
 ---
 
 # Bitrix24 API

--- a/brave-search/SKILL.md
+++ b/brave-search/SKILL.md
@@ -3,7 +3,7 @@ name: brave-search
 description: Brave Search API for web search. Use when user says "search web", "Brave
   search", or asks to "find on web" without specifying Google.
 vm0_secrets:
-- BRAVE_API_KEY
+  - BRAVE_API_KEY
 ---
 
 # Brave Search API

--- a/bright-data/SKILL.md
+++ b/bright-data/SKILL.md
@@ -3,7 +3,7 @@ name: bright-data
 description: Bright Data proxy and web scraping API. Use when user mentions "Bright
   Data", "proxy", "web scraping at scale", or data collection.
 vm0_secrets:
-- BRIGHTDATA_TOKEN
+  - BRIGHTDATA_TOKEN
 ---
 
 # Bright Data Web Scraper API

--- a/browserbase/SKILL.md
+++ b/browserbase/SKILL.md
@@ -3,7 +3,7 @@ name: browserbase
 description: Browserbase API for headless browser automation. Use when user mentions
   "headless browser", "browser automation", or "Browserbase".
 vm0_secrets:
-- BROWSERBASE_TOKEN
+  - BROWSERBASE_TOKEN
 - BROWSERBASE_PROJECT_ID
 ---
 

--- a/browserless/SKILL.md
+++ b/browserless/SKILL.md
@@ -3,7 +3,7 @@ name: browserless
 description: Browserless API for headless Chrome. Use when user mentions "headless
   Chrome", "browserless", or needs browser automation.
 vm0_secrets:
-- BROWSERLESS_TOKEN
+  - BROWSERLESS_TOKEN
 ---
 
 # Browserless

--- a/canva/SKILL.md
+++ b/canva/SKILL.md
@@ -3,7 +3,7 @@ name: canva
 description: Canva API for design creation. Use when user mentions "Canva", "create
   design", "Canva template", or asks about design graphics.
 vm0_secrets:
-- CANVA_TOKEN
+  - CANVA_TOKEN
 ---
 
 # Canva API

--- a/chatwoot/SKILL.md
+++ b/chatwoot/SKILL.md
@@ -3,9 +3,9 @@ name: chatwoot
 description: Chatwoot API for customer support. Use when user mentions "Chatwoot",
   "conversations", "support chat", or customer messaging.
 vm0_secrets:
-- CHATWOOT_API_TOKEN
+  - CHATWOOT_API_TOKEN
 vm0_vars:
-- CHATWOOT_ACCOUNT_ID
+  - CHATWOOT_ACCOUNT_ID
 - CHATWOOT_BASE_URL
 ---
 

--- a/clickup/SKILL.md
+++ b/clickup/SKILL.md
@@ -3,7 +3,7 @@ name: clickup
 description: ClickUp API for tasks and spaces. Use when user mentions "ClickUp", "clickup.com",
   shares a ClickUp link, "ClickUp task", or asks about ClickUp workspace.
 vm0_secrets:
-- CLICKUP_TOKEN
+  - CLICKUP_TOKEN
 ---
 
 # ClickUp API

--- a/close/SKILL.md
+++ b/close/SKILL.md
@@ -3,7 +3,7 @@ name: close
 description: Close CRM API for sales management. Use when user mentions "Close CRM",
   "Close.io", "sales leads", or asks about sales pipeline.
 vm0_secrets:
-- CLOSE_TOKEN
+  - CLOSE_TOKEN
 ---
 
 # Close CRM API

--- a/cloudflare-tunnel/SKILL.md
+++ b/cloudflare-tunnel/SKILL.md
@@ -3,7 +3,7 @@ name: cloudflare-tunnel
 description: Cloudflare Tunnel API for secure tunnels. Use when user mentions "Cloudflare
   tunnel", "argo tunnel", or secure connectivity.
 vm0_secrets:
-- CF_ACCESS_CLIENT_ID
+  - CF_ACCESS_CLIENT_ID
 - CF_ACCESS_CLIENT_SECRET
 ---
 

--- a/cloudflare/SKILL.md
+++ b/cloudflare/SKILL.md
@@ -3,7 +3,7 @@ name: cloudflare
 description: Cloudflare API for DNS and zone management. Use when user mentions "Cloudflare",
   "DNS record", "zone", or "CDN settings".
 vm0_secrets:
-- CLOUDFLARE_TOKEN
+  - CLOUDFLARE_TOKEN
 ---
 
 # Cloudflare

--- a/cloudinary/SKILL.md
+++ b/cloudinary/SKILL.md
@@ -3,10 +3,10 @@ name: cloudinary
 description: Cloudinary API for image/video management. Use when user mentions "Cloudinary",
   "upload image", "transform image", or media assets.
 vm0_secrets:
-- CLOUDINARY_API_KEY
+  - CLOUDINARY_API_KEY
 - CLOUDINARY_API_SECRET
 vm0_vars:
-- CLOUDINARY_CLOUD_NAME
+  - CLOUDINARY_CLOUD_NAME
 ---
 
 # Cloudinary Media Hosting

--- a/cronlytic/SKILL.md
+++ b/cronlytic/SKILL.md
@@ -3,9 +3,9 @@ name: cronlytic
 description: Cronlytic API for cron job monitoring. Use when user mentions "cron job",
   "scheduled task monitoring", or "Cronlytic".
 vm0_secrets:
-- CRONLYTIC_API_KEY
+  - CRONLYTIC_API_KEY
 vm0_vars:
-- CRONLYTIC_USER_ID
+  - CRONLYTIC_USER_ID
 ---
 
 # Cronlytic

--- a/deel/SKILL.md
+++ b/deel/SKILL.md
@@ -3,7 +3,7 @@ name: deel
 description: Deel API for global payroll and contractors. Use when user mentions "Deel",
   "contractors", "global payroll", or "EOR".
 vm0_secrets:
-- DEEL_TOKEN
+  - DEEL_TOKEN
 ---
 
 # Deel API

--- a/deepseek/SKILL.md
+++ b/deepseek/SKILL.md
@@ -3,7 +3,7 @@ name: deepseek
 description: DeepSeek API for AI model inference. Use when user mentions "DeepSeek",
   "DeepSeek API", or asks about DeepSeek models.
 vm0_secrets:
-- DEEPSEEK_API_KEY
+  - DEEPSEEK_API_KEY
 ---
 
 # DeepSeek API

--- a/devto/SKILL.md
+++ b/devto/SKILL.md
@@ -3,7 +3,7 @@ name: devto
 description: Dev.to API for articles and posts. Use when user mentions "Dev.to", "publish
   article", "dev community", or asks about blog posts.
 vm0_secrets:
-- DEVTO_API_KEY
+  - DEVTO_API_KEY
 ---
 
 # Dev.to Publisher

--- a/dify/SKILL.md
+++ b/dify/SKILL.md
@@ -3,7 +3,7 @@ name: dify
 description: Dify API for LLM app building. Use when user mentions "Dify", "LLM app",
   "AI workflow", or asks about Dify platform.
 vm0_secrets:
-- DIFY_TOKEN
+  - DIFY_TOKEN
 ---
 
 # Dify API

--- a/discord-webhook/SKILL.md
+++ b/discord-webhook/SKILL.md
@@ -3,7 +3,7 @@ name: discord-webhook
 description: Discord Webhook API for sending messages. Use when user says "send Discord
   message", "Discord webhook", or "post to Discord".
 vm0_secrets:
-- DISCORD_WEBHOOK_URL
+  - DISCORD_WEBHOOK_URL
 ---
 
 # Discord Webhook

--- a/discord/SKILL.md
+++ b/discord/SKILL.md
@@ -4,7 +4,7 @@ description: Discord API for servers and messages. Use when user mentions "Disco
   "discord.com", "discord.gg", shares a Discord link, "Discord server", or asks about
   Discord bots.
 vm0_secrets:
-- DISCORD_BOT_TOKEN
+  - DISCORD_BOT_TOKEN
 ---
 
 # Discord Bot API

--- a/docusign/SKILL.md
+++ b/docusign/SKILL.md
@@ -3,7 +3,7 @@ name: docusign
 description: DocuSign API for electronic signatures. Use when user mentions "DocuSign",
   "e-signature", "sign document", or "send for signature".
 vm0_secrets:
-- DOCUSIGN_TOKEN
+  - DOCUSIGN_TOKEN
 ---
 
 # DocuSign eSignature API

--- a/dropbox/SKILL.md
+++ b/dropbox/SKILL.md
@@ -3,7 +3,7 @@ name: dropbox
 description: Dropbox API for file storage. Use when user mentions "Dropbox", "dropbox.com",
   shares a Dropbox link, "upload to Dropbox", or asks about cloud storage.
 vm0_secrets:
-- DROPBOX_TOKEN
+  - DROPBOX_TOKEN
 ---
 
 # Dropbox API

--- a/elevenlabs/SKILL.md
+++ b/elevenlabs/SKILL.md
@@ -3,7 +3,7 @@ name: elevenlabs
 description: ElevenLabs API for text-to-speech and voice. Use when user mentions "ElevenLabs",
   "text to speech", "voice cloning", or "AI voice".
 vm0_secrets:
-- ELEVENLABS_API_KEY
+  - ELEVENLABS_API_KEY
 ---
 
 # ElevenLabs API

--- a/explorium/SKILL.md
+++ b/explorium/SKILL.md
@@ -3,7 +3,7 @@ name: explorium
 description: Explorium API for external data enrichment. Use when user mentions "Explorium",
   "data enrichment", "business data", or external datasets.
 vm0_secrets:
-- EXPLORIUM_TOKEN
+  - EXPLORIUM_TOKEN
 ---
 
 # Explorium API

--- a/fal/SKILL.md
+++ b/fal/SKILL.md
@@ -3,7 +3,7 @@ name: fal
 description: Fal.ai API for AI image and video generation. Use when user mentions
   "Fal.ai", "AI image generation", "video generation", or "fal" models.
 vm0_secrets:
-- FAL_TOKEN
+  - FAL_TOKEN
 ---
 
 # fal.ai Image Generator

--- a/figma/SKILL.md
+++ b/figma/SKILL.md
@@ -4,7 +4,7 @@ description: Figma API for design files and assets. Use when user mentions "Figm
   "figma.com", shares a Figma link, "design specs", "export from Figma", or asks about
   designs.
 vm0_secrets:
-- FIGMA_TOKEN
+  - FIGMA_TOKEN
 ---
 
 # Figma API

--- a/firecrawl/SKILL.md
+++ b/firecrawl/SKILL.md
@@ -3,7 +3,7 @@ name: firecrawl
 description: Firecrawl API for web scraping and crawling. Use when user mentions "Firecrawl",
   "crawl website", "scrape site", or web extraction.
 vm0_secrets:
-- FIRECRAWL_TOKEN
+  - FIRECRAWL_TOKEN
 ---
 
 # Firecrawl

--- a/fireflies/SKILL.md
+++ b/fireflies/SKILL.md
@@ -3,7 +3,7 @@ name: fireflies
 description: Fireflies.ai API for meeting transcription. Use when user mentions "Fireflies",
   "meeting notes", "transcription", or "meeting summary".
 vm0_secrets:
-- FIREFLIES_TOKEN
+  - FIREFLIES_TOKEN
 ---
 
 # Fireflies

--- a/github-copilot/SKILL.md
+++ b/github-copilot/SKILL.md
@@ -3,7 +3,7 @@ name: github-copilot
 description: GitHub Copilot API for AI coding assistance. Use when user mentions "Copilot",
   "GitHub Copilot", "AI coding", or asks about Copilot features.
 vm0_secrets:
-- GITHUB_TOKEN
+  - GITHUB_TOKEN
 ---
 
 # GitHub Copilot API

--- a/github/SKILL.md
+++ b/github/SKILL.md
@@ -4,7 +4,7 @@ description: GitHub API for repos, issues, and PRs. Use when user mentions "GitH
   "github.com", shares a GitHub link, "create PR", "my issues", "repository", or asks
   about code hosting.
 vm0_secrets:
-- GH_TOKEN
+  - GH_TOKEN
 ---
 
 # GitHub Automation

--- a/gitlab/SKILL.md
+++ b/gitlab/SKILL.md
@@ -3,9 +3,9 @@ name: gitlab
 description: GitLab API for repos and CI/CD. Use when user mentions "GitLab", "gitlab.com",
   shares a GitLab link, "GitLab repo", or asks about GitLab projects.
 vm0_secrets:
-- GITLAB_TOKEN
+  - GITLAB_TOKEN
 vm0_vars:
-- GITLAB_HOST
+  - GITLAB_HOST
 ---
 
 # GitLab API

--- a/gmail/SKILL.md
+++ b/gmail/SKILL.md
@@ -3,7 +3,7 @@ name: gmail
 description: Gmail API for email management. Use when user says "check email", "send
   email", "search Gmail", "my inbox", or mentions Gmail messages.
 vm0_secrets:
-- GMAIL_TOKEN
+  - GMAIL_TOKEN
 ---
 
 # Gmail API

--- a/google-calendar/SKILL.md
+++ b/google-calendar/SKILL.md
@@ -4,7 +4,7 @@ description: Google Calendar API for scheduling. Use when user mentions "calenda
   "calendar.google.com", shares a calendar link, "schedule meeting", "check availability",
   or "when am I free".
 vm0_secrets:
-- GOOGLE_CALENDAR_TOKEN
+  - GOOGLE_CALENDAR_TOKEN
 ---
 
 # Google Calendar API

--- a/google-docs/SKILL.md
+++ b/google-docs/SKILL.md
@@ -4,7 +4,7 @@ description: Google Docs API for document editing. Use when user mentions "Googl
   Doc", "docs.google.com", shares a Doc link, "create document", or asks about document
   creation.
 vm0_secrets:
-- GOOGLE_DOCS_TOKEN
+  - GOOGLE_DOCS_TOKEN
 ---
 
 # Google Docs API

--- a/google-drive/SKILL.md
+++ b/google-drive/SKILL.md
@@ -4,7 +4,7 @@ description: Google Drive API for file management. Use when user mentions "Googl
   Drive", "drive.google.com", shares a Drive link, "upload file", or asks about cloud
   storage.
 vm0_secrets:
-- GOOGLE_DRIVE_TOKEN
+  - GOOGLE_DRIVE_TOKEN
 ---
 
 # Google Drive API

--- a/google-sheets/SKILL.md
+++ b/google-sheets/SKILL.md
@@ -4,7 +4,7 @@ description: Google Sheets API for spreadsheets. Use when user mentions "Google 
   "sheets.google.com", shares a spreadsheet link, "update sheet", or asks about Excel/Sheets
   data.
 vm0_secrets:
-- GOOGLE_SHEETS_TOKEN
+  - GOOGLE_SHEETS_TOKEN
 ---
 
 # Google Sheets API

--- a/granola/SKILL.md
+++ b/granola/SKILL.md
@@ -3,7 +3,7 @@ name: granola
 description: Granola API for meeting notes. Use when user mentions "Granola", "meeting
   notes", or AI note-taking.
 vm0_secrets:
-- GRANOLA_TOKEN
+  - GRANOLA_TOKEN
 ---
 
 # Granola

--- a/heygen/SKILL.md
+++ b/heygen/SKILL.md
@@ -3,7 +3,7 @@ name: heygen
 description: HeyGen API for AI video avatars. Use when user mentions "HeyGen", "AI
   avatar", "video avatar", or "AI presenter".
 vm0_secrets:
-- HEYGEN_TOKEN
+  - HEYGEN_TOKEN
 ---
 
 # HeyGen API

--- a/htmlcsstoimage/SKILL.md
+++ b/htmlcsstoimage/SKILL.md
@@ -3,9 +3,9 @@ name: htmlcsstoimage
 description: HTML/CSS to Image API for rendering. Use when user mentions "HTML to
   image", "render HTML", "screenshot", or "convert to image".
 vm0_secrets:
-- HCTI_API_KEY
+  - HCTI_API_KEY
 vm0_vars:
-- HCTI_USER_ID
+  - HCTI_USER_ID
 ---
 
 # HTMLCSStoImage API

--- a/hubspot/SKILL.md
+++ b/hubspot/SKILL.md
@@ -3,7 +3,7 @@ name: hubspot
 description: HubSpot CRM API for marketing and sales. Use when user mentions "HubSpot",
   "CRM", "HubSpot contacts", or asks about marketing automation.
 vm0_secrets:
-- HUBSPOT_TOKEN
+  - HUBSPOT_TOKEN
 ---
 
 # HubSpot CRM API

--- a/hugging-face/SKILL.md
+++ b/hugging-face/SKILL.md
@@ -3,7 +3,7 @@ name: hugging-face
 description: Hugging Face API for ML models. Use when user mentions "Hugging Face",
   "HF", "transformers", or asks about ML model inference.
 vm0_secrets:
-- HUGGING_FACE_TOKEN
+  - HUGGING_FACE_TOKEN
 ---
 
 # Hugging Face API

--- a/hume/SKILL.md
+++ b/hume/SKILL.md
@@ -3,7 +3,7 @@ name: hume
 description: Hume AI API for emotion analysis. Use when user mentions "Hume", "emotion
   AI", "sentiment analysis", or voice emotion detection.
 vm0_secrets:
-- HUME_TOKEN
+  - HUME_TOKEN
 ---
 
 # Hume AI API

--- a/imgur/SKILL.md
+++ b/imgur/SKILL.md
@@ -3,7 +3,7 @@ name: imgur
 description: Imgur API for image hosting. Use when user mentions "Imgur", "upload
   image", "image hosting", or asks about image sharing.
 vm0_secrets:
-- IMGUR_CLIENT_ID
+  - IMGUR_CLIENT_ID
 ---
 
 # Imgur Image Hosting

--- a/instagram/SKILL.md
+++ b/instagram/SKILL.md
@@ -4,9 +4,9 @@ description: Instagram API for posts and media. Use when user mentions "Instagra
   "instagram.com", shares an IG link, "Instagram post", or asks about social media
   content.
 vm0_secrets:
-- INSTAGRAM_ACCESS_TOKEN
+  - INSTAGRAM_ACCESS_TOKEN
 vm0_vars:
-- INSTAGRAM_BUSINESS_ACCOUNT_ID
+  - INSTAGRAM_BUSINESS_ACCOUNT_ID
 ---
 
 # Instagram API (Graph API)

--- a/instantly/SKILL.md
+++ b/instantly/SKILL.md
@@ -3,7 +3,7 @@ name: instantly
 description: Instantly.ai API for cold email campaigns. Use when user mentions "Instantly",
   "cold email", "email campaign", or outreach automation.
 vm0_secrets:
-- INSTANTLY_API_KEY
+  - INSTANTLY_API_KEY
 ---
 
 # Instantly API

--- a/intercom/SKILL.md
+++ b/intercom/SKILL.md
@@ -3,7 +3,7 @@ name: intercom
 description: Intercom API for customer messaging. Use when user mentions "Intercom",
   "customer chat", "messaging", or asks about Intercom conversations.
 vm0_secrets:
-- INTERCOM_TOKEN
+  - INTERCOM_TOKEN
 ---
 
 # Intercom API

--- a/intervals-icu/SKILL.md
+++ b/intervals-icu/SKILL.md
@@ -3,7 +3,7 @@ name: intervals-icu
 description: Intervals.icu API for fitness data. Use when user mentions "Intervals.icu",
   "cycling data", "fitness tracking", or workout analytics.
 vm0_secrets:
-- INTERVALS_ICU_TOKEN
+  - INTERVALS_ICU_TOKEN
 ---
 
 # Intervals.icu API

--- a/jam/SKILL.md
+++ b/jam/SKILL.md
@@ -3,7 +3,7 @@ name: jam
 description: Jam.dev API for bug reporting. Use when user mentions "Jam", "bug report",
   "screen recording", or asks about issue capture.
 vm0_secrets:
-- JAM_TOKEN
+  - JAM_TOKEN
 ---
 
 # Jam

--- a/jira/SKILL.md
+++ b/jira/SKILL.md
@@ -3,9 +3,9 @@ name: jira
 description: Jira API for issue tracking. Use when user mentions "Jira", "create ticket",
   "Jira issue", "sprint", or asks about Atlassian project management.
 vm0_secrets:
-- JIRA_API_TOKEN
+  - JIRA_API_TOKEN
 vm0_vars:
-- JIRA_DOMAIN
+  - JIRA_DOMAIN
 - JIRA_EMAIL
 ---
 

--- a/jotform/SKILL.md
+++ b/jotform/SKILL.md
@@ -3,7 +3,7 @@ name: jotform
 description: JotForm API for form management. Use when user mentions "JotForm", "forms",
   "submissions", or asks about form data.
 vm0_secrets:
-- JOTFORM_TOKEN
+  - JOTFORM_TOKEN
 ---
 
 # Jotform API

--- a/kommo/SKILL.md
+++ b/kommo/SKILL.md
@@ -3,9 +3,9 @@ name: kommo
 description: Kommo (formerly amoCRM) API. Use when user mentions "Kommo", "amoCRM",
   "CRM", or sales pipeline management.
 vm0_secrets:
-- KOMMO_API_KEY
+  - KOMMO_API_KEY
 vm0_vars:
-- KOMMO_SUBDOMAIN
+  - KOMMO_SUBDOMAIN
 ---
 
 # Kommo API

--- a/lark/SKILL.md
+++ b/lark/SKILL.md
@@ -3,9 +3,9 @@ name: lark
 description: Lark/Feishu API for collaboration. Use when user mentions "Lark", "Feishu",
   "Lark docs", or asks about ByteDance workspace tools.
 vm0_secrets:
-- LARK_APP_SECRET
+  - LARK_APP_SECRET
 vm0_vars:
-- LARK_APP_ID
+  - LARK_APP_ID
 ---
 
 # Lark (Feishu) API

--- a/line/SKILL.md
+++ b/line/SKILL.md
@@ -3,7 +3,7 @@ name: line
 description: LINE API for messaging. Use when user mentions "LINE", "LINE message",
   "LINE bot", or asks about LINE platform.
 vm0_secrets:
-- LINE_TOKEN
+  - LINE_TOKEN
 ---
 
 # LINE Messaging API

--- a/linear/SKILL.md
+++ b/linear/SKILL.md
@@ -3,7 +3,7 @@ name: linear
 description: Linear API for issue tracking. Use when user mentions "Linear", "linear.app",
   shares a Linear link, "~ENG-123", "create issue", or asks about Linear tasks.
 vm0_secrets:
-- LINEAR_TOKEN
+  - LINEAR_TOKEN
 ---
 
 # Linear API

--- a/mailchimp/SKILL.md
+++ b/mailchimp/SKILL.md
@@ -3,7 +3,7 @@ name: mailchimp
 description: Mailchimp API for email marketing. Use when user mentions "Mailchimp",
   "email campaign", "newsletter", or marketing automation.
 vm0_secrets:
-- MAILCHIMP_TOKEN
+  - MAILCHIMP_TOKEN
 ---
 
 # Mailchimp Marketing API

--- a/mailsac/SKILL.md
+++ b/mailsac/SKILL.md
@@ -3,7 +3,7 @@ name: mailsac
 description: MailSac API for disposable email testing. Use when user mentions "MailSac",
   "test email", "disposable email", or email testing.
 vm0_secrets:
-- MAILSAC_API_KEY
+  - MAILSAC_API_KEY
 ---
 
 # Mailsac

--- a/make/SKILL.md
+++ b/make/SKILL.md
@@ -3,7 +3,7 @@ name: make
 description: Make (Integromat) API for automation. Use when user mentions "Make",
   "Integromat", "automation", or workflow building.
 vm0_secrets:
-- MAKE_TOKEN
+  - MAKE_TOKEN
 ---
 
 # Make API

--- a/mercury/SKILL.md
+++ b/mercury/SKILL.md
@@ -3,7 +3,7 @@ name: mercury
 description: Mercury API for banking. Use when user mentions "Mercury", "business
   banking", "bank account", or fintech operations.
 vm0_secrets:
-- MERCURY_TOKEN
+  - MERCURY_TOKEN
 ---
 
 # Mercury Banking API

--- a/meta-ads/SKILL.md
+++ b/meta-ads/SKILL.md
@@ -3,7 +3,7 @@ name: meta-ads
 description: Meta Ads API for Facebook/Instagram advertising. Use when user mentions
   "Meta Ads", "Facebook Ads", "Instagram Ads", or ad campaigns.
 vm0_secrets:
-- META_ADS_TOKEN
+  - META_ADS_TOKEN
 ---
 
 # Meta Marketing API

--- a/metabase/SKILL.md
+++ b/metabase/SKILL.md
@@ -3,7 +3,7 @@ name: metabase
 description: Metabase API for business intelligence. Use when user mentions "Metabase",
   "dashboard", "BI", "SQL query", or data visualization.
 vm0_secrets:
-- METABASE_TOKEN
+  - METABASE_TOKEN
 ---
 
 # Metabase API

--- a/minimax/SKILL.md
+++ b/minimax/SKILL.md
@@ -3,7 +3,7 @@ name: minimax
 description: MiniMax API for AI models. Use when user mentions "MiniMax", "Chinese
   AI", or asks about MiniMax language models.
 vm0_secrets:
-- MINIMAX_API_KEY
+  - MINIMAX_API_KEY
 ---
 
 # MiniMax API

--- a/minio/SKILL.md
+++ b/minio/SKILL.md
@@ -3,10 +3,10 @@ name: minio
 description: MinIO API for S3-compatible storage. Use when user mentions "MinIO",
   "S3 storage", "object storage", or self-hosted S3.
 vm0_secrets:
-- MINIO_ACCESS_KEY
+  - MINIO_ACCESS_KEY
 - MINIO_SECRET_KEY
 vm0_vars:
-- MINIO_ENDPOINT
+  - MINIO_ENDPOINT
 ---
 
 # MinIO Object Storage

--- a/monday/SKILL.md
+++ b/monday/SKILL.md
@@ -3,7 +3,7 @@ name: monday
 description: Monday.com API for work management. Use when user mentions "Monday.com",
   "monday.com", shares a Monday link, "Monday board", or asks about Monday workspace.
 vm0_secrets:
-- MONDAY_TOKEN
+  - MONDAY_TOKEN
 ---
 
 # Monday.com API

--- a/neon/SKILL.md
+++ b/neon/SKILL.md
@@ -3,7 +3,7 @@ name: neon
 description: Neon API for serverless Postgres. Use when user mentions "Neon", "Neon
   database", "serverless Postgres", or asks about Neon projects.
 vm0_secrets:
-- NEON_TOKEN
+  - NEON_TOKEN
 ---
 
 # Neon API

--- a/notion/SKILL.md
+++ b/notion/SKILL.md
@@ -4,7 +4,7 @@ description: Notion API for pages and databases. Use when user mentions "Notion"
   "notion.so", "notion.site", shares a Notion link, "Notion page", "query Notion",
   or asks about Notion workspace.
 vm0_secrets:
-- NOTION_TOKEN
+  - NOTION_TOKEN
 ---
 
 # Notion API

--- a/openai/SKILL.md
+++ b/openai/SKILL.md
@@ -3,7 +3,7 @@ name: openai
 description: OpenAI API for GPT models. Use when user mentions "OpenAI", "GPT", "ChatGPT
   API", or asks about OpenAI models (do NOT use for Anthropic/Claude).
 vm0_secrets:
-- OPENAI_API_KEY
+  - OPENAI_API_KEY
 ---
 
 # OpenAI API

--- a/pdf4me/SKILL.md
+++ b/pdf4me/SKILL.md
@@ -3,7 +3,7 @@ name: pdf4me
 description: PDF4me API for PDF operations. Use when user mentions "PDF4me", "convert
   PDF", "PDF tools", or document conversion.
 vm0_secrets:
-- PDF4ME_API_KEY
+  - PDF4ME_API_KEY
 ---
 
 # PDF4ME

--- a/pdfco/SKILL.md
+++ b/pdfco/SKILL.md
@@ -3,7 +3,7 @@ name: pdfco
 description: PDF.co API for PDF processing. Use when user mentions "PDF.co", "extract
   PDF", "parse PDF", or PDF automation.
 vm0_secrets:
-- PDFCO_API_KEY
+  - PDFCO_API_KEY
 ---
 
 # PDF.co

--- a/pdforge/SKILL.md
+++ b/pdforge/SKILL.md
@@ -3,7 +3,7 @@ name: pdforge
 description: PDForge API for PDF generation. Use when user mentions "PDForge", "generate
   PDF", "PDF template", or document generation.
 vm0_secrets:
-- PDFORGE_API_KEY
+  - PDFORGE_API_KEY
 ---
 
 # PDForge API (PDF Noodle)

--- a/perplexity/SKILL.md
+++ b/perplexity/SKILL.md
@@ -3,7 +3,7 @@ name: perplexity
 description: Perplexity API for AI search. Use when user mentions "Perplexity", "AI
   search", or asks to search with citations.
 vm0_secrets:
-- PERPLEXITY_API_KEY
+  - PERPLEXITY_API_KEY
 ---
 
 # Perplexity AI

--- a/pikvm/SKILL.md
+++ b/pikvm/SKILL.md
@@ -3,7 +3,7 @@ name: pikvm
 description: PiKVM API for remote KVM. Use when user mentions "PiKVM", "KVM over IP",
   "remote server", or hardware management.
 vm0_secrets:
-- PIKVM_AUTH
+  - PIKVM_AUTH
 - PIKVM_URL
 ---
 

--- a/plausible/SKILL.md
+++ b/plausible/SKILL.md
@@ -3,7 +3,7 @@ name: plausible
 description: Plausible Analytics API for privacy-friendly stats. Use when user mentions
   "Plausible", "analytics", "page views", or website stats.
 vm0_secrets:
-- PLAUSIBLE_TOKEN
+  - PLAUSIBLE_TOKEN
 ---
 
 # Plausible Analytics API

--- a/podchaser/SKILL.md
+++ b/podchaser/SKILL.md
@@ -3,9 +3,9 @@ name: podchaser
 description: Podchaser API for podcast data. Use when user mentions "Podchaser", "podcast",
   "podcast search", or asks about podcast information.
 vm0_secrets:
-- PODCHASER_CLIENT_SECRET
+  - PODCHASER_CLIENT_SECRET
 vm0_vars:
-- PODCHASER_CLIENT_ID
+  - PODCHASER_CLIENT_ID
 ---
 
 # Podchaser API

--- a/posthog/SKILL.md
+++ b/posthog/SKILL.md
@@ -3,7 +3,7 @@ name: posthog
 description: PostHog API for product analytics. Use when user mentions "PostHog",
   "product analytics", "event tracking", or user analytics.
 vm0_secrets:
-- POSTHOG_TOKEN
+  - POSTHOG_TOKEN
 ---
 
 # PostHog API

--- a/prisma-postgres/SKILL.md
+++ b/prisma-postgres/SKILL.md
@@ -3,7 +3,7 @@ name: prisma-postgres
 description: Prisma Postgres API for database. Use when user mentions "Prisma Postgres",
   "Prisma database", or asks about Prisma acceleration.
 vm0_secrets:
-- PRISMA_POSTGRES_TOKEN
+  - PRISMA_POSTGRES_TOKEN
 ---
 
 # Prisma Postgres Management API

--- a/productlane/SKILL.md
+++ b/productlane/SKILL.md
@@ -3,7 +3,7 @@ name: productlane
 description: Productlane API for feedback management. Use when user mentions "Productlane",
   "feedback", "feature request", or product insights.
 vm0_secrets:
-- PRODUCTLANE_TOKEN
+  - PRODUCTLANE_TOKEN
 ---
 
 # Productlane API

--- a/pushinator/SKILL.md
+++ b/pushinator/SKILL.md
@@ -3,7 +3,7 @@ name: pushinator
 description: Pushinator API for push notifications. Use when user mentions "Pushinator",
   "push notification", "web push", or notifications.
 vm0_secrets:
-- PUSHINATOR_TOKEN
+  - PUSHINATOR_TOKEN
 ---
 
 # Pushinator API

--- a/qdrant/SKILL.md
+++ b/qdrant/SKILL.md
@@ -3,9 +3,9 @@ name: qdrant
 description: Qdrant API for vector search. Use when user mentions "Qdrant", "vector
   database", "semantic search", or embeddings storage.
 vm0_secrets:
-- QDRANT_TOKEN
+  - QDRANT_TOKEN
 vm0_vars:
-- QDRANT_URL
+  - QDRANT_URL
 ---
 
 # Qdrant API

--- a/qiita/SKILL.md
+++ b/qiita/SKILL.md
@@ -3,7 +3,7 @@ name: qiita
 description: Qiita API for Japanese tech articles. Use when user mentions "Qiita",
   "Japanese tech blog", or asks about Qiita posts.
 vm0_secrets:
-- QIITA_TOKEN
+  - QIITA_TOKEN
 ---
 
 # Qiita API

--- a/reportei/SKILL.md
+++ b/reportei/SKILL.md
@@ -3,7 +3,7 @@ name: reportei
 description: Reportei API for marketing reports. Use when user mentions "Reportei",
   "marketing report", "digital marketing", or report automation.
 vm0_secrets:
-- REPORTEI_TOKEN
+  - REPORTEI_TOKEN
 ---
 
 # Reportei

--- a/resend/SKILL.md
+++ b/resend/SKILL.md
@@ -3,7 +3,7 @@ name: resend
 description: Resend API for email delivery. Use when user mentions "Resend", "send
   email", "email API", or transactional email.
 vm0_secrets:
-- RESEND_TOKEN
+  - RESEND_TOKEN
 ---
 
 # Resend Email API

--- a/revenuecat/SKILL.md
+++ b/revenuecat/SKILL.md
@@ -3,7 +3,7 @@ name: revenuecat
 description: RevenueCat API for in-app purchases. Use when user mentions "RevenueCat",
   "in-app purchase", "subscription", or mobile monetization.
 vm0_secrets:
-- REVENUECAT_TOKEN
+  - REVENUECAT_TOKEN
 ---
 
 # RevenueCat API

--- a/runway/SKILL.md
+++ b/runway/SKILL.md
@@ -3,7 +3,7 @@ name: runway
 description: Runway ML API for AI video generation. Use when user mentions "Runway",
   "Runway ML", "AI video", "Gen-2", or video generation.
 vm0_secrets:
-- RUNWAY_TOKEN
+  - RUNWAY_TOKEN
 ---
 
 # Runway API

--- a/scrapeninja/SKILL.md
+++ b/scrapeninja/SKILL.md
@@ -3,7 +3,7 @@ name: scrapeninja
 description: ScrapeNinja API for web scraping. Use when user mentions "ScrapeNinja",
   "scrape", "web scraping", or data extraction.
 vm0_secrets:
-- SCRAPENINJA_TOKEN
+  - SCRAPENINJA_TOKEN
 ---
 
 # ScrapeNinja

--- a/sentry/SKILL.md
+++ b/sentry/SKILL.md
@@ -3,7 +3,7 @@ name: sentry
 description: Sentry API for error tracking. Use when user mentions "Sentry", "error
   tracking", "crash report", "exceptions", or asks about monitoring errors.
 vm0_secrets:
-- SENTRY_TOKEN
+  - SENTRY_TOKEN
 ---
 
 # Sentry API

--- a/serpapi/SKILL.md
+++ b/serpapi/SKILL.md
@@ -3,7 +3,7 @@ name: serpapi
 description: SerpApi for search engine results. Use when user mentions "SERP", "search
   results", "Google scrape", or search API.
 vm0_secrets:
-- SERPAPI_TOKEN
+  - SERPAPI_TOKEN
 ---
 
 # SerpApi

--- a/shortio/SKILL.md
+++ b/shortio/SKILL.md
@@ -3,9 +3,9 @@ name: shortio
 description: Short.io API for link shortening. Use when user mentions "Short.io",
   "link shortener", "short URL", or URL management.
 vm0_secrets:
-- SHORTIO_TOKEN
+  - SHORTIO_TOKEN
 vm0_vars:
-- SHORTIO_DOMAIN
+  - SHORTIO_DOMAIN
 ---
 
 # Short.io

--- a/similarweb/SKILL.md
+++ b/similarweb/SKILL.md
@@ -3,7 +3,7 @@ name: similarweb
 description: Similarweb API for web analytics. Use when user mentions "Similarweb",
   "website traffic", "competitor analysis", or market intelligence.
 vm0_secrets:
-- SIMILARWEB_TOKEN
+  - SIMILARWEB_TOKEN
 ---
 
 # SimilarWeb API

--- a/slack-webhook/SKILL.md
+++ b/slack-webhook/SKILL.md
@@ -3,7 +3,7 @@ name: slack-webhook
 description: Slack Webhook for posting messages. Use when user says "post to Slack",
   "Slack webhook", or "send Slack notification".
 vm0_secrets:
-- SLACK_WEBHOOK_URL
+  - SLACK_WEBHOOK_URL
 ---
 
 # Slack Incoming Webhook

--- a/slack/SKILL.md
+++ b/slack/SKILL.md
@@ -4,7 +4,7 @@ description: Slack API for messages and channels. Use when user mentions "Slack"
   "slack.com", shares a Slack link, "send to Slack", "Slack channel", or asks about
   workspace.
 vm0_secrets:
-- SLACK_TOKEN
+  - SLACK_TOKEN
 ---
 
 # Slack API

--- a/strava/SKILL.md
+++ b/strava/SKILL.md
@@ -3,7 +3,7 @@ name: strava
 description: Strava API for fitness activities. Use when user mentions "Strava", "running",
   "cycling", "activity", or asks about fitness tracking.
 vm0_secrets:
-- STRAVA_TOKEN
+  - STRAVA_TOKEN
 ---
 
 # Strava API

--- a/streak/SKILL.md
+++ b/streak/SKILL.md
@@ -3,7 +3,7 @@ name: streak
 description: Streak CRM API for Gmail. Use when user mentions "Streak", "Gmail CRM",
   "email CRM", or pipeline in Gmail.
 vm0_secrets:
-- STREAK_TOKEN
+  - STREAK_TOKEN
 ---
 
 # Streak CRM

--- a/stripe/SKILL.md
+++ b/stripe/SKILL.md
@@ -3,7 +3,7 @@ name: stripe
 description: Stripe API for payments. Use when user mentions "Stripe", "payment",
   "subscription", "billing", "invoice", or asks about payment processing.
 vm0_secrets:
-- STRIPE_TOKEN
+  - STRIPE_TOKEN
 ---
 
 # Stripe API

--- a/supabase/SKILL.md
+++ b/supabase/SKILL.md
@@ -4,9 +4,9 @@ description: Supabase API for Postgres and auth. Use when user mentions "Supabas
   "supabase.co", shares a Supabase link, "Supabase database", or asks about Supabase
   project.
 vm0_secrets:
-- SUPABASE_TOKEN
+  - SUPABASE_TOKEN
 vm0_vars:
-- SUPABASE_URL
+  - SUPABASE_URL
 - SUPABASE_PUBLISHABLE_KEY
 ---
 

--- a/supadata/SKILL.md
+++ b/supadata/SKILL.md
@@ -3,7 +3,7 @@ name: supadata
 description: Supadata API for YouTube/web data. Use when user mentions "Supadata",
   "YouTube data", "channel stats", or web scraping data.
 vm0_secrets:
-- SUPADATA_TOKEN
+  - SUPADATA_TOKEN
 ---
 
 # Supadata API

--- a/tavily/SKILL.md
+++ b/tavily/SKILL.md
@@ -3,7 +3,7 @@ name: tavily
 description: Tavily API for AI search. Use when user mentions "Tavily", "AI search",
   "research", or asks for cited search results.
 vm0_secrets:
-- TAVILY_TOKEN
+  - TAVILY_TOKEN
 ---
 
 # Tavily Search API

--- a/tldv/SKILL.md
+++ b/tldv/SKILL.md
@@ -3,7 +3,7 @@ name: tldv
 description: tl;dv API for meeting recordings. Use when user mentions "tl;dv", "meeting
   recording", "meeting summary", or asks about call analysis.
 vm0_secrets:
-- TLDV_TOKEN
+  - TLDV_TOKEN
 ---
 
 # tl;dv API

--- a/todoist/SKILL.md
+++ b/todoist/SKILL.md
@@ -3,7 +3,7 @@ name: todoist
 description: Todoist API for task management. Use when user mentions "Todoist", "my
   tasks", "create todo", or asks about Todoist projects.
 vm0_secrets:
-- TODOIST_TOKEN
+  - TODOIST_TOKEN
 ---
 
 # Todoist API

--- a/twenty/SKILL.md
+++ b/twenty/SKILL.md
@@ -3,9 +3,9 @@ name: twenty
 description: Twenty CRM API for customer management. Use when user mentions "Twenty",
   "Twenty CRM", "open source CRM", or asks about Twenty.
 vm0_secrets:
-- TWENTY_TOKEN
+  - TWENTY_TOKEN
 vm0_vars:
-- TWENTY_API_URL
+  - TWENTY_API_URL
 ---
 
 # Twenty CRM

--- a/vercel/SKILL.md
+++ b/vercel/SKILL.md
@@ -3,7 +3,7 @@ name: vercel
 description: Vercel API for deployments. Use when user mentions "Vercel", "vercel.app",
   "vercel.com", shares a Vercel link, "deploy", or asks about hosting.
 vm0_secrets:
-- VERCEL_TOKEN
+  - VERCEL_TOKEN
 ---
 
 # Vercel API

--- a/vm0-agent/SKILL.md
+++ b/vm0-agent/SKILL.md
@@ -3,7 +3,7 @@ name: vm0-agent
 description: VM0 Agent SDK for building agents. Use when user mentions "VM0 Agent",
   "agent SDK", "build agent", or asks about agent development.
 vm0_secrets:
-- VM0_TOKEN
+  - VM0_TOKEN
 ---
 
 # About VM0

--- a/vm0-cli/SKILL.md
+++ b/vm0-cli/SKILL.md
@@ -3,7 +3,7 @@ name: vm0-cli
 description: VM0 CLI for agent management. Use when user mentions "vm0 cli", "npx
   @vm0/cli", "vm0 command", or asks about CLI operations.
 vm0_secrets:
-- VM0_TOKEN
+  - VM0_TOKEN
 ---
 
 # VM0 CLI

--- a/vm0-computer/SKILL.md
+++ b/vm0-computer/SKILL.md
@@ -3,7 +3,7 @@ name: vm0-computer
 description: VM0 Computer API for secure sandbox. Use when user mentions "VM0 Computer",
   "secure sandbox", "browser sandbox", or asks about computer use.
 vm0_secrets:
-- COMPUTER_CONNECTOR_BRIDGE_TOKEN
+  - COMPUTER_CONNECTOR_BRIDGE_TOKEN
 - COMPUTER_CONNECTOR_DOMAIN
 ---
 

--- a/vm0/SKILL.md
+++ b/vm0/SKILL.md
@@ -3,7 +3,7 @@ name: vm0
 description: VM0 platform API for agents. Use when user mentions "VM0", "vm0 agent",
   "deploy agent", or asks about VM0 platform operations.
 vm0_secrets:
-- VM0_TOKEN
+  - VM0_TOKEN
 ---
 
 # VM0 Agent Self-Management

--- a/webflow/SKILL.md
+++ b/webflow/SKILL.md
@@ -3,7 +3,7 @@ name: webflow
 description: Webflow API for CMS and sites. Use when user mentions "Webflow", "webflow.com",
   "webflow.io", shares a Webflow link, "update Webflow", or asks about Webflow site.
 vm0_secrets:
-- WEBFLOW_TOKEN
+  - WEBFLOW_TOKEN
 ---
 
 # Webflow API

--- a/wix/SKILL.md
+++ b/wix/SKILL.md
@@ -3,7 +3,7 @@ name: wix
 description: Wix API for website management. Use when user mentions "Wix", "wix.com",
   "wixsite.com", shares a Wix link, "Wix site", or asks about Wix CMS.
 vm0_secrets:
-- WIX_TOKEN
+  - WIX_TOKEN
 ---
 
 # Wix API

--- a/wrike/SKILL.md
+++ b/wrike/SKILL.md
@@ -3,7 +3,7 @@ name: wrike
 description: Wrike API for project management. Use when user mentions "Wrike", "wrike.com",
   shares a Wrike link, "Wrike task", or asks about Wrike workspace.
 vm0_secrets:
-- WRIKE_TOKEN
+  - WRIKE_TOKEN
 ---
 
 # Wrike API

--- a/x/SKILL.md
+++ b/x/SKILL.md
@@ -4,7 +4,7 @@ description: X (Twitter) API for tweets and profiles. Use when user mentions "X"
   "Twitter", "x.com", "twitter.com", shares a tweet link, "check X", or asks about
   social media posts.
 vm0_secrets:
-- X_ACCESS_TOKEN
+  - X_ACCESS_TOKEN
 ---
 
 # X (Twitter) API

--- a/xero/SKILL.md
+++ b/xero/SKILL.md
@@ -3,7 +3,7 @@ name: xero
 description: Xero API for accounting. Use when user mentions "Xero", "accounting",
   "invoices", "bookkeeping", or asks about financial management.
 vm0_secrets:
-- XERO_TOKEN
+  - XERO_TOKEN
 ---
 
 # Xero Accounting API

--- a/youtube/SKILL.md
+++ b/youtube/SKILL.md
@@ -4,7 +4,7 @@ description: YouTube API for videos and channels. Use when user mentions "YouTub
   "youtube.com", "youtu.be", shares a video link, "channel stats", or asks about video
   content.
 vm0_secrets:
-- YOUTUBE_TOKEN
+  - YOUTUBE_TOKEN
 ---
 
 # YouTube Data API

--- a/zapier/SKILL.md
+++ b/zapier/SKILL.md
@@ -3,7 +3,7 @@ name: zapier
 description: Zapier API for workflow automation. Use when user mentions "Zapier",
   "zap", "automation", or asks about connecting apps.
 vm0_secrets:
-- ZAPIER_TOKEN
+  - ZAPIER_TOKEN
 ---
 
 # Zapier AI Actions API

--- a/zapsign/SKILL.md
+++ b/zapsign/SKILL.md
@@ -3,7 +3,7 @@ name: zapsign
 description: ZapSign API for e-signatures. Use when user mentions "ZapSign", "e-signature",
   "sign document", or Brazilian e-signature.
 vm0_secrets:
-- ZAPSIGN_TOKEN
+  - ZAPSIGN_TOKEN
 ---
 
 # ZapSign

--- a/zendesk/SKILL.md
+++ b/zendesk/SKILL.md
@@ -3,9 +3,9 @@ name: zendesk
 description: Zendesk API for customer support. Use when user mentions "Zendesk", "support
   ticket", "customer service", or help desk.
 vm0_secrets:
-- ZENDESK_API_TOKEN
+  - ZENDESK_API_TOKEN
 vm0_vars:
-- ZENDESK_EMAIL
+  - ZENDESK_EMAIL
 - ZENDESK_SUBDOMAIN
 ---
 

--- a/zeptomail/SKILL.md
+++ b/zeptomail/SKILL.md
@@ -3,7 +3,7 @@ name: zeptomail
 description: ZeptoMail API for transactional email. Use when user mentions "ZeptoMail",
   "transactional email", "send email", or Zoho email.
 vm0_secrets:
-- ZEPTOMAIL_API_KEY
+  - ZEPTOMAIL_API_KEY
 ---
 
 # Zoho ZeptoMail


### PR DESCRIPTION
## Problem

The previous PR accidentally removed indentation from vm0_secrets and vm0_vars list items, resulting in invalid YAML format.

## Before (incorrect)


## After (correct)


## Changes

- Fixed 120 skills with proper 2-space indentation for list items
- Ensures valid YAML parsing by all standard parsers

## Verification

Tested that frontmatter can be correctly parsed as valid YAML.