### PR TITLE
fix: correct YAML list indentation in 11 SKILL.md frontmatters

### DIFF
--- a/atlassian/SKILL.md
+++ b/atlassian/SKILL.md
@@ -6,7 +6,7 @@ vm0_secrets:
   - ATLASSIAN_TOKEN
 vm0_vars:
   - ATLASSIAN_DOMAIN
-- ATLASSIAN_EMAIL
+  - ATLASSIAN_EMAIL
 ---
 
 # Atlassian API

--- a/browserbase/SKILL.md
+++ b/browserbase/SKILL.md
@@ -4,7 +4,7 @@ description: Browserbase API for headless browser automation. Use when user ment
   "headless browser", "browser automation", or "Browserbase".
 vm0_secrets:
   - BROWSERBASE_TOKEN
-- BROWSERBASE_PROJECT_ID
+  - BROWSERBASE_PROJECT_ID
 ---
 
 # Browserbase

--- a/chatwoot/SKILL.md
+++ b/chatwoot/SKILL.md
@@ -6,7 +6,7 @@ vm0_secrets:
   - CHATWOOT_API_TOKEN
 vm0_vars:
   - CHATWOOT_ACCOUNT_ID
-- CHATWOOT_BASE_URL
+  - CHATWOOT_BASE_URL
 ---
 
 # Chatwoot

--- a/cloudflare-tunnel/SKILL.md
+++ b/cloudflare-tunnel/SKILL.md
@@ -4,7 +4,7 @@ description: Cloudflare Tunnel API for secure tunnels. Use when user mentions "C
   tunnel", "argo tunnel", or secure connectivity.
 vm0_secrets:
   - CF_ACCESS_CLIENT_ID
-- CF_ACCESS_CLIENT_SECRET
+  - CF_ACCESS_CLIENT_SECRET
 ---
 
 # Cloudflare Tunnel / Access Authentication

--- a/cloudinary/SKILL.md
+++ b/cloudinary/SKILL.md
@@ -4,7 +4,7 @@ description: Cloudinary API for image/video management. Use when user mentions "
   "upload image", "transform image", or media assets.
 vm0_secrets:
   - CLOUDINARY_API_KEY
-- CLOUDINARY_API_SECRET
+  - CLOUDINARY_API_SECRET
 vm0_vars:
   - CLOUDINARY_CLOUD_NAME
 ---

--- a/jira/SKILL.md
+++ b/jira/SKILL.md
@@ -6,7 +6,7 @@ vm0_secrets:
   - JIRA_API_TOKEN
 vm0_vars:
   - JIRA_DOMAIN
-- JIRA_EMAIL
+  - JIRA_EMAIL
 ---
 
 # Jira API

--- a/minio/SKILL.md
+++ b/minio/SKILL.md
@@ -4,7 +4,7 @@ description: MinIO API for S3-compatible storage. Use when user mentions "MinIO"
   "S3 storage", "object storage", or self-hosted S3.
 vm0_secrets:
   - MINIO_ACCESS_KEY
-- MINIO_SECRET_KEY
+  - MINIO_SECRET_KEY
 vm0_vars:
   - MINIO_ENDPOINT
 ---

--- a/pikvm/SKILL.md
+++ b/pikvm/SKILL.md
@@ -4,7 +4,7 @@ description: PiKVM API for remote KVM. Use when user mentions "PiKVM", "KVM over
   "remote server", or hardware management.
 vm0_secrets:
   - PIKVM_AUTH
-- PIKVM_URL
+  - PIKVM_URL
 ---
 
 # PiKVM Remote Control

--- a/supabase/SKILL.md
+++ b/supabase/SKILL.md
@@ -7,7 +7,7 @@ vm0_secrets:
   - SUPABASE_TOKEN
 vm0_vars:
   - SUPABASE_URL
-- SUPABASE_PUBLISHABLE_KEY
+  - SUPABASE_PUBLISHABLE_KEY
 ---
 
 # Supabase REST API

--- a/vm0-computer/SKILL.md
+++ b/vm0-computer/SKILL.md
@@ -4,7 +4,7 @@ description: VM0 Computer API for secure sandbox. Use when user mentions "VM0 Co
   "secure sandbox", "browser sandbox", or asks about computer use.
 vm0_secrets:
   - COMPUTER_CONNECTOR_BRIDGE_TOKEN
-- COMPUTER_CONNECTOR_DOMAIN
+  - COMPUTER_CONNECTOR_DOMAIN
 ---
 
 # VM0 Computer Connector

--- a/zendesk/SKILL.md
+++ b/zendesk/SKILL.md
@@ -6,7 +6,7 @@ vm0_secrets:
   - ZENDESK_API_TOKEN
 vm0_vars:
   - ZENDESK_EMAIL
-- ZENDESK_SUBDOMAIN
+  - ZENDESK_SUBDOMAIN
 ---
 
 # Zendesk API


### PR DESCRIPTION
## Summary
- Fix YAML parse errors in 11 SKILL.md files where `vm0_secrets`/`vm0_vars` list items were missing the 2-space indent
- Affected files: atlassian, browserbase, chatwoot, cloudflare-tunnel, cloudinary, jira, minio, pikvm, supabase, vm0-computer, zendesk

## Test plan
- [x] Validated all SKILL.md files pass YAML parsing locally
- [ ] CI frontmatter validation workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)