### PR TITLE
fix(notion): migrate database query to data_sources endpoint

### DIFF
--- a/notion/SKILL.md
+++ b/notion/SKILL.md
@@ -90,17 +90,17 @@ Write to `/tmp/notion_request.json`:
 Replace `<your-database-id>` with your actual database ID and run:
 
 ```bash
-curl -s -X POST "https://api.notion.com/v1/databases/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header "Notion-Version: 2022-06-28" --header "Content-Type: application/json" -d @/tmp/notion_request.json | jq '.results[] | {id, properties}'
+curl -s -X POST "https://api.notion.com/v1/data_sources/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header "Notion-Version: 2022-06-28" --header "Content-Type: application/json" -d @/tmp/notion_request.json | jq '.results[] | {id, properties}'
 ```
 
-Docs: https://developers.notion.com/reference/post-database-query
+Docs: https://developers.notion.com/reference/query-a-data-source
 
 ### Query with Filter
 
 Replace `<your-database-id>` with your actual database ID:
 
 ```bash
-curl -s -X POST "https://api.notion.com/v1/databases/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header 'Notion-Version: 2022-06-28' --header 'Content-Type: application/json' -d @- << 'EOF'
+curl -s -X POST "https://api.notion.com/v1/data_sources/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header 'Notion-Version: 2022-06-28' --header 'Content-Type: application/json' -d @- << 'EOF'
 {
   "filter": {
   "property": "Status",
@@ -117,7 +117,7 @@ EOF
 Replace `<your-database-id>` with your actual database ID:
 
 ```bash
-curl -s -X POST "https://api.notion.com/v1/databases/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header 'Notion-Version: 2022-06-28' --header 'Content-Type: application/json' -d @- << 'EOF'
+curl -s -X POST "https://api.notion.com/v1/data_sources/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header 'Notion-Version: 2022-06-28' --header 'Content-Type: application/json' -d @- << 'EOF'
 {
   "filter": {
   "and": [
@@ -413,7 +413,7 @@ Write to `/tmp/notion_request.json`:
 
 ```bash
 # First request
-curl -s -X POST "https://api.notion.com/v1/databases/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header "Notion-Version: 2022-06-28" --header "Content-Type: application/json" -d @/tmp/notion_request.json
+curl -s -X POST "https://api.notion.com/v1/data_sources/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header "Notion-Version: 2022-06-28" --header "Content-Type: application/json" -d @/tmp/notion_request.json
 # Response includes: {"next_cursor": "abc123", "has_more": true}
 ```
 
@@ -428,7 +428,7 @@ Write to `/tmp/notion_request.json`:
 
 ```bash
 # Next page
-curl -s -X POST "https://api.notion.com/v1/databases/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header "Notion-Version: 2022-06-28" --header "Content-Type: application/json" -d @/tmp/notion_request.json
+curl -s -X POST "https://api.notion.com/v1/data_sources/<your-database-id>/query" --header "Authorization: Bearer $NOTION_TOKEN" --header "Notion-Version: 2022-06-28" --header "Content-Type: application/json" -d @/tmp/notion_request.json
 ```
 
 ## Rate Limits


### PR DESCRIPTION
## Summary

Replace deprecated `POST /v1/databases/{database_id}/query` with `POST /v1/data_sources/{data_source_id}/query` in the Notion SKILL.md.

## Problem

The old endpoint (`/v1/databases/{id}/query`) was deprecated in Notion API version 2025-09-03 and is not in the firewall, so AI agents using this skill would get firewall denials when querying databases.

## Fix

- Replace all 5 occurrences of `/v1/databases/{id}/query` → `/v1/data_sources/{id}/query`
- Update docs link to `query-a-data-source`
- The new endpoint is already in the firewall under `read_content` permission

All 9 endpoints verified against firewall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)