### PR TITLE
fix: remove printenv and bash -c workarounds across skills

### DIFF
--- a/docs/bad-smell.md
+++ b/docs/bad-smell.md
@@ -289,6 +289,32 @@ https://example.com/path?param=value&other=123
 
 ---
 
+## 6. `printenv` and `bash -c` Wrappers
+
+**Problem:** Using `$(printenv VAR)` instead of `$VAR`, or wrapping curl in `bash -c '...'`, was a workaround for an old Claude Code bug that silently cleared environment variables in pipelines. That bug is fixed — these patterns are now unnecessary noise.
+
+### ❌ Bad Case
+
+```bash
+curl -s "https://api.example.com/data" \
+  -H "Authorization: Bearer $(printenv API_TOKEN)" | jq '.data'
+```
+
+```bash
+bash -c 'curl -s "https://api.example.com/data" -H "Authorization: Bearer $API_TOKEN" | jq ".data"'
+```
+
+### ✅ Good Case
+
+```bash
+curl -s "https://api.example.com/data" \
+  -H "Authorization: Bearer $API_TOKEN" | jq '.data'
+```
+
+**Pattern Rule:** Always use `$VAR` directly. Never use `$(printenv VAR)` or wrap commands in `bash -c '...'`.
+
+---
+
 ## Quick Checklist
 
 When writing SKILL.md, verify:
@@ -298,3 +324,4 @@ When writing SKILL.md, verify:
 - [ ] Use placeholder text (`<your-context-id>`) instead of shell variables (`$CONTEXT_ID`) in URLs
 - [ ] Always use `-d @/tmp/filename.json` for JSON data, never `-d '{"key": "value"}'`
 - [ ] Always use `--data-urlencode "key@/tmp/file.txt"` for parameters with special characters
+- [ ] Use `$VAR` directly, never `$(printenv VAR)` or `bash -c '...'` wrappers

--- a/doppler/SKILL.md
+++ b/doppler/SKILL.md
@@ -21,15 +21,13 @@ Go to [vm0.ai](https://app.vm0.ai) **Settings → Connectors** and connect **Dop
 
 Your `DOPPLER_TOKEN` must be a **Service Token** (format: `dp.st.*`). Service tokens are scoped to a specific project and config.
 
-> **Important:** When using `$(printenv DOPPLER_TOKEN)` in commands that contain a pipe (`|`), always use `$(printenv ...)` syntax — a known Claude Code issue silently clears `$VAR` references in pipelines.
-
 ## Core APIs
 
 ### Fetch a Single Secret by Name
 
 ```bash
 curl -s "https://api.doppler.com/v3/configs/config/secret" \
-  -H "Authorization: Bearer $(printenv DOPPLER_TOKEN)" \
+  -H "Authorization: Bearer $DOPPLER_TOKEN" \
   -G \
   --data-urlencode "project=<project-slug>" \
   --data-urlencode "config=<config-name>" \
@@ -44,7 +42,7 @@ Replace `<project-slug>` with your Doppler project slug, `<config-name>` with th
 
 ```bash
 curl -s "https://api.doppler.com/v3/configs/config/secrets" \
-  -H "Authorization: Bearer $(printenv DOPPLER_TOKEN)" \
+  -H "Authorization: Bearer $DOPPLER_TOKEN" \
   -G \
   --data-urlencode "project=<project-slug>" \
   --data-urlencode "config=<config-name>" | jq '.secrets | to_entries[] | {name: .key, raw: .value.raw, computed: .value.computed}'
@@ -56,7 +54,7 @@ curl -s "https://api.doppler.com/v3/configs/config/secrets" \
 
 ```bash
 curl -s "https://api.doppler.com/v3/configs/config/secrets/download" \
-  -H "Authorization: Bearer $(printenv DOPPLER_TOKEN)" \
+  -H "Authorization: Bearer $DOPPLER_TOKEN" \
   -G \
   --data-urlencode "project=<project-slug>" \
   --data-urlencode "config=<config-name>" \
@@ -71,7 +69,7 @@ Returns a flat key/value JSON object of all secrets.
 
 ```bash
 curl -s "https://api.doppler.com/v3/projects" \
-  -H "Authorization: Bearer $(printenv DOPPLER_TOKEN)" | jq '.projects[] | {id, name, slug}'
+  -H "Authorization: Bearer $DOPPLER_TOKEN" | jq '.projects[] | {id, name, slug}'
 ```
 
 ---
@@ -80,7 +78,7 @@ curl -s "https://api.doppler.com/v3/projects" \
 
 ```bash
 curl -s "https://api.doppler.com/v3/configs" \
-  -H "Authorization: Bearer $(printenv DOPPLER_TOKEN)" \
+  -H "Authorization: Bearer $DOPPLER_TOKEN" \
   -G \
   --data-urlencode "project=<project-slug>" | jq '.configs[] | {name, environment, locked}'
 ```

--- a/infisical/SKILL.md
+++ b/infisical/SKILL.md
@@ -19,8 +19,6 @@ Infisical is an open-source secrets manager. This skill enables fetching individ
 
 Go to [vm0.ai](https://app.vm0.ai) **Settings → Connectors** and connect **Infisical**. vm0 will automatically inject `INFISICAL_CLIENT_ID` and `INFISICAL_CLIENT_SECRET` environment variables.
 
-> **Important:** When using `$(printenv VAR)` in commands that contain a pipe (`|`), always use `$(printenv ...)` syntax — a known Claude Code issue silently clears `$VAR` references in pipelines.
-
 ## Core APIs
 
 ### 1. Obtain an Access Token

--- a/jira/SKILL.md
+++ b/jira/SKILL.md
@@ -59,7 +59,7 @@ Base URL: `https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3`
 Verify your authentication:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/myself" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
@@ -71,7 +71,7 @@ curl -s -X GET "${JIRA_BASE}/myself" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "
 Get all projects you have access to:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/project" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
@@ -84,7 +84,7 @@ Get details for a specific project:
 
 ```bash
 PROJECT_KEY="PROJ"
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/project/${PROJECT_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
@@ -97,7 +97,7 @@ List available issue types (Task, Bug, Story, etc.):
 
 ```bash
 PROJECT_KEY="PROJ"
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/project/${PROJECT_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
@@ -121,7 +121,7 @@ Write to `/tmp/jira_request.json`:
 Then run:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X POST "${JIRA_BASE}/search/jql" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json | jq '.issues[] | {key, summary: .fields.summary, status: .fields.status.name, assignee: .fields.assignee.displayName, priority: .fields.priority.name}'
 ```
@@ -143,7 +143,7 @@ Get full details of an issue:
 
 ```bash
 ISSUE_KEY="PROJ-123"
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/issue/${ISSUE_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
@@ -181,7 +181,7 @@ Write to `/tmp/jira_request.json`:
 Then run:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X POST "${JIRA_BASE}/issue" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
@@ -221,7 +221,7 @@ Write to `/tmp/jira_request.json`:
 Then run:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X POST "${JIRA_BASE}/issue" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
@@ -251,7 +251,7 @@ Write to `/tmp/jira_request.json`:
 Then run:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X PUT "${JIRA_BASE}/issue/${ISSUE_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
@@ -266,7 +266,7 @@ Get possible status transitions for an issue:
 
 ```bash
 ISSUE_KEY="PROJ-123"
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/issue/${ISSUE_KEY}/transitions" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
@@ -295,7 +295,7 @@ Write to `/tmp/jira_request.json`:
 Then run:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X POST "${JIRA_BASE}/issue/${ISSUE_KEY}/transitions" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
@@ -334,7 +334,7 @@ Write to `/tmp/jira_request.json`:
 Then run:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X POST "${JIRA_BASE}/issue/${ISSUE_KEY}/comment" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
@@ -347,7 +347,7 @@ List all comments on an issue:
 
 ```bash
 ISSUE_KEY="PROJ-123"
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/issue/${ISSUE_KEY}/comment" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
@@ -374,7 +374,7 @@ Write to `/tmp/jira_request.json`:
 Then run:
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X PUT "${JIRA_BASE}/issue/${ISSUE_KEY}/assignee" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
@@ -392,7 +392,7 @@ john
 ```
 
 ```bash
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -G "${JIRA_BASE}/user/search" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --data-urlencode "query@/tmp/jira_search.txt"
 ```
@@ -405,7 +405,7 @@ Delete an issue (use with caution):
 
 ```bash
 ISSUE_KEY="PROJ-123"
-JIRA_BASE="https://$(printenv JIRA_DOMAIN | sed 's/\.atlassian\.net$//').atlassian.net/rest/api/3"
+JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X DELETE "${JIRA_BASE}/issue/${ISSUE_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN"
 ```

--- a/pika/SKILL.md
+++ b/pika/SKILL.md
@@ -16,8 +16,6 @@ Go to [vm0.ai](https://app.vm0.ai) **Settings → Connectors** and connect **Pik
 
 To get a Developer Key: visit [pika.me/dev](https://www.pika.me/dev/) and create a key (format: `dk_...`).
 
-> **Important:** When using `$(printenv PIKA_TOKEN)` in commands that contain a pipe (`|`), always use `$(printenv ...)` syntax — a known Claude Code issue silently clears `$VAR` references in pipelines.
-
 ## Base URL
 
 ```
@@ -29,7 +27,7 @@ https://srkibaanghvsriahb.pika.art
 All requests use a `DevKey` header:
 
 ```
-Authorization: DevKey $(printenv PIKA_TOKEN)
+Authorization: DevKey $PIKA_TOKEN
 ```
 
 ---
@@ -40,7 +38,7 @@ Authorization: DevKey $(printenv PIKA_TOKEN)
 
 ```bash
 curl -s "https://srkibaanghvsriahb.pika.art/developer/balance" \
-  -H "Authorization: DevKey $(printenv PIKA_TOKEN)" | jq '.data // .'
+  -H "Authorization: DevKey $PIKA_TOKEN" | jq '.data // .'
 ```
 
 Returns `{ "balance": <int> }`. Minimum 100 credits required before joining a meeting.
@@ -51,7 +49,7 @@ Returns `{ "balance": <int> }`. Minimum 100 credits required before joining a me
 
 ```bash
 curl -s -X POST "https://srkibaanghvsriahb.pika.art/proxy/realtime/meeting-session" \
-  -H "Authorization: DevKey $(printenv PIKA_TOKEN)" \
+  -H "Authorization: DevKey $PIKA_TOKEN" \
   -H "X-Skill-Name: pikastream" \
   -F "meet_url=<google-meet-or-zoom-url>" \
   -F "bot_name=<display-name>" \
@@ -79,7 +77,7 @@ Returns: `{ "session_id": "...", "platform": "...", "status": "created" }`
 
 ```bash
 curl -s "https://srkibaanghvsriahb.pika.art/proxy/realtime/session/<session_id>" \
-  -H "Authorization: DevKey $(printenv PIKA_TOKEN)" | jq '{status, video_worker_connected, meeting_bot_connected}'
+  -H "Authorization: DevKey $PIKA_TOKEN" | jq '{status, video_worker_connected, meeting_bot_connected}'
 ```
 
 | `status` | Meaning |
@@ -97,7 +95,7 @@ Poll every 2 seconds. The bot is ready when `status == "ready"` or both `video_w
 
 ```bash
 curl -s -X DELETE "https://srkibaanghvsriahb.pika.art/proxy/realtime/session/<session_id>" \
-  -H "Authorization: DevKey $(printenv PIKA_TOKEN)" | jq '.'
+  -H "Authorization: DevKey $PIKA_TOKEN" | jq '.'
 ```
 
 Returns: `{ "session_id": "...", "closed": true }`
@@ -110,18 +108,26 @@ Billing stops when this call completes.
 
 ```bash
 curl -s "https://srkibaanghvsriahb.pika.art/developer/topup/products" \
-  -H "Authorization: DevKey $(printenv PIKA_TOKEN)" | jq '.data // . | .products[]? | {name, numCredits, productId}'
+  -H "Authorization: DevKey $PIKA_TOKEN" | jq '.data // . | .products[]? | {name, numCredits, productId}'
 ```
 
 ---
 
 ### Create Topup Checkout
 
+Write to `/tmp/pika_topup.json`:
+
+```json
+{
+  "product_id": "<productId>"
+}
+```
+
 ```bash
 curl -s -X POST "https://srkibaanghvsriahb.pika.art/developer/topup" \
-  -H "Authorization: DevKey $(printenv PIKA_TOKEN)" \
+  -H "Authorization: DevKey $PIKA_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"product_id": "<productId>"}' | jq '.data // . | {checkout_url}'
+  -d @/tmp/pika_topup.json | jq '.data // . | {checkout_url}'
 ```
 
 Returns a `checkout_url`. Share with the user to complete payment, then poll `/developer/balance` until balance ≥ 100.

--- a/podchaser/SKILL.md
+++ b/podchaser/SKILL.md
@@ -29,8 +29,6 @@ Use this skill when you need to:
 
 The `PODCHASER_TOKEN` environment variable is automatically injected by the connector.
 
-> **Important:** When using `$(printenv PODCHASER_TOKEN)` in commands that contain a pipe (`|`), always use `$(printenv ...)` syntax — a known Claude Code issue silently clears `$VAR` references in pipelines.
-
 ---
 
 ## How to Use
@@ -50,7 +48,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 3. Get Podcast Details
@@ -70,7 +68,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 4. Search Episodes
@@ -88,7 +86,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 5. Get Podcast Episodes
@@ -106,7 +104,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 6. Get Episode Details
@@ -124,7 +122,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 7. Get Podcast Categories
@@ -142,7 +140,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 8. Filter Podcasts by Category
@@ -160,7 +158,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 9. Get Chart Rankings
@@ -178,7 +176,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 10. Get Creator/Host Information
@@ -196,7 +194,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ### 11. Preview Query Cost
@@ -214,7 +212,7 @@ Write to `/tmp/podchaser_request.json`:
 Then run:
 
 ```bash
-curl -s -X POST "https://api.podchaser.com/graphql/cost" --header "Content-Type: application/json" --header "Authorization: Bearer $(printenv PODCHASER_TOKEN)" -d @/tmp/podchaser_request.json
+curl -s -X POST "https://api.podchaser.com/graphql/cost" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
 ---

--- a/reddit/SKILL.md
+++ b/reddit/SKILL.md
@@ -19,14 +19,12 @@ Access Reddit discussions, posts, and content through the Reddit API.
 
 The `REDDIT_TOKEN` environment variable is automatically injected by the connector via OAuth.
 
-> **Important:** When using `$(printenv REDDIT_TOKEN)` in commands that contain a pipe (`|`), always use `$(printenv ...)` syntax — a known Claude Code issue silently clears `$VAR` references in pipelines.
-
 ## Core APIs
 
 ### Get Current User
 
 ```bash
-curl -s "https://oauth.reddit.com/api/v1/me" -H "Authorization: Bearer $(printenv REDDIT_TOKEN)" -H "User-Agent: vm0:skill:v1" | jq '{name, total_karma, created_utc}'
+curl -s "https://oauth.reddit.com/api/v1/me" -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: vm0:skill:v1" | jq '{name, total_karma, created_utc}'
 ```
 
 ### Search Posts
@@ -34,7 +32,7 @@ curl -s "https://oauth.reddit.com/api/v1/me" -H "Authorization: Bearer $(printen
 Search Reddit for posts matching a query:
 
 ```bash
-curl -s "https://oauth.reddit.com/search?q=<query>&sort=relevance&limit=10" -H "Authorization: Bearer $(printenv REDDIT_TOKEN)" -H "User-Agent: vm0:skill:v1" | jq '.data.children[] | {title: .data.title, subreddit: .data.subreddit, score: .data.score, url: .data.url}'
+curl -s "https://oauth.reddit.com/search?q=<query>&sort=relevance&limit=10" -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: vm0:skill:v1" | jq '.data.children[] | {title: .data.title, subreddit: .data.subreddit, score: .data.score, url: .data.url}'
 ```
 
 Replace `<query>` with your search term (URL-encoded).
@@ -44,7 +42,7 @@ Replace `<query>` with your search term (URL-encoded).
 Get hot/new/top posts from a subreddit:
 
 ```bash
-curl -s "https://oauth.reddit.com/r/<subreddit>/hot?limit=10" -H "Authorization: Bearer $(printenv REDDIT_TOKEN)" -H "User-Agent: vm0:skill:v1" | jq '.data.children[] | {title: .data.title, score: .data.score, num_comments: .data.num_comments, url: .data.url}'
+curl -s "https://oauth.reddit.com/r/<subreddit>/hot?limit=10" -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: vm0:skill:v1" | jq '.data.children[] | {title: .data.title, score: .data.score, num_comments: .data.num_comments, url: .data.url}'
 ```
 
 Replace `<subreddit>` with the subreddit name (e.g., `programming`). Change `hot` to `new`, `top`, or `rising` for different sorts.
@@ -52,7 +50,7 @@ Replace `<subreddit>` with the subreddit name (e.g., `programming`). Change `hot
 ### Get Post Comments
 
 ```bash
-curl -s "https://oauth.reddit.com/r/<subreddit>/comments/<post-id>?limit=10" -H "Authorization: Bearer $(printenv REDDIT_TOKEN)" -H "User-Agent: vm0:skill:v1" | jq '.[1].data.children[] | {author: .data.author, body: .data.body, score: .data.score}'
+curl -s "https://oauth.reddit.com/r/<subreddit>/comments/<post-id>?limit=10" -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: vm0:skill:v1" | jq '.[1].data.children[] | {author: .data.author, body: .data.body, score: .data.score}'
 ```
 
 Replace `<subreddit>` and `<post-id>` with the actual values.
@@ -60,7 +58,7 @@ Replace `<subreddit>` and `<post-id>` with the actual values.
 ### Get Subreddit Info
 
 ```bash
-curl -s "https://oauth.reddit.com/r/<subreddit>/about" -H "Authorization: Bearer $(printenv REDDIT_TOKEN)" -H "User-Agent: vm0:skill:v1" | jq '{name: .data.display_name, title: .data.title, subscribers: .data.subscribers, description: .data.public_description}'
+curl -s "https://oauth.reddit.com/r/<subreddit>/about" -H "Authorization: Bearer $REDDIT_TOKEN" -H "User-Agent: vm0:skill:v1" | jq '{name: .data.display_name, title: .data.title, subscribers: .data.subscribers, description: .data.public_description}'
 ```
 
 ## Guidelines


### PR DESCRIPTION
## Summary

- Claude Code has fixed the bug that silently cleared `$VAR` in pipelines — `$(printenv VAR)` and `bash -c '...'` wrappers are no longer needed
- Replace all `$(printenv VAR)` with `$VAR` across 6 skills
- Remove stale "Important" warning notes about the old workaround
- Add **Bad Smell #6** to `docs/bad-smell.md` documenting `printenv`/`bash -c` as anti-patterns
- Also fixed one inline JSON (`-d '{"product_id": "..."}'`) in `pika/SKILL.md` → file-based pattern

## Files changed

| File | Change |
|------|--------|
| `jira/SKILL.md` | `$(printenv JIRA_DOMAIN \| sed ...)` → `${JIRA_DOMAIN%.atlassian.net}` (15 occurrences) |
| `pika/SKILL.md` | `$(printenv PIKA_TOKEN)` → `$PIKA_TOKEN` + fix inline JSON |
| `reddit/SKILL.md` | `$(printenv REDDIT_TOKEN)` → `$REDDIT_TOKEN` |
| `podchaser/SKILL.md` | `$(printenv PODCHASER_TOKEN)` → `$PODCHASER_TOKEN` |
| `doppler/SKILL.md` | `$(printenv DOPPLER_TOKEN)` → `$DOPPLER_TOKEN` |
| `infisical/SKILL.md` | Remove stale warning note |
| `docs/bad-smell.md` | Add Bad Smell #6 + checklist item |

## Test plan

- [ ] Verify all curl commands in affected skills use plain `$TOKEN` syntax
- [ ] Verify no `printenv` or `bash -c` patterns remain (`grep -r "printenv\|bash -c" */SKILL.md`)
- [ ] Verify `bad-smell.md` checklist includes the new item