### PR TITLE
feat: add anthropic-managed-agents skill

### DIFF
--- a/anthropic-managed-agents/SKILL.md
+++ b/anthropic-managed-agents/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: anthropic-managed-agents
+description: Anthropic Managed Agents API for programmatically creating, running, and streaming AI agents on Anthropic's cloud infrastructure. Use when the user mentions "Managed Agents", "Anthropic agent sessions", or needs to create/run/stream an Anthropic agent with tool use (bash, git, web), attach GitHub repositories, or inject secrets via Vault. Do NOT use for standard Claude Messages API — use the Claude API skill instead.
+---
+
+# Anthropic Managed Agents API
+
+Use the Anthropic Managed Agents API via direct `curl` calls to **create agent definitions, provision cloud environments, run agent sessions, stream output in real time, and manage vault credentials**.
+
+> Official API reference: `https://docs.anthropic.com/en/api/beta`
+
+---
+
+## When to Use
+
+Use this skill when you need to:
+
+- **Create an agent** — define a model, system prompt, and toolset once; reuse across many sessions
+- **Run agent sessions** — launch a session against a cloud environment with a GitHub repo or uploaded file mounted
+- **Stream session output** — read tool calls, text output, and status changes as they happen
+- **Manage environments** — configure container networking and pre-installed packages
+- **Inject secrets** — store credentials in a Vault and reference them in sessions without exposing plaintext
+
+---
+
+## Prerequisites
+
+1. Get an Anthropic API key from [console.anthropic.com](https://console.anthropic.com/) → API Keys
+2. Ensure your account has Managed Agents access (currently in beta)
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+### Common headers (include in every request)
+
+```bash
+-H "x-api-key: $ANTHROPIC_API_KEY"
+-H "anthropic-version: 2023-06-01"
+-H "anthropic-beta: managed-agents-2026-04-01"
+-H "Content-Type: application/json"
+```
+
+### Pricing
+
+Sessions are billed as standard Claude API usage (input/output tokens). See [pricing](https://www.anthropic.com/pricing) for current rates per model.
+
+---
+
+## How to Use
+
+All examples assume `ANTHROPIC_API_KEY` is set. The base URL is `https://api.anthropic.com`.
+
+---
+
+### 1. Create an Agent
+
+An agent is a reusable configuration (model + system prompt + toolset). Create it once; use it across many sessions.
+
+Write to `/tmp/agent_create.json`:
+
+```json
+{
+  "model": "claude-sonnet-4-6",
+  "name": "Code Review Agent",
+  "description": "Reviews pull requests and suggests improvements",
+  "system": "You are an expert code reviewer. Analyze the code in the mounted repository, identify issues, and provide actionable feedback.",
+  "tools": [
+    {
+      "type": "agent_toolset_20260401"
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://api.anthropic.com/v1/agents" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/agent_create.json | jq '{id: .id, name: .name}'
+```
+
+Save the returned `id` (e.g., `agent_011CZk...`) for use in sessions.
+
+**Built-in tools in `agent_toolset_20260401`:** `bash`, `edit`, `read`, `write`, `glob`, `grep`, `web_fetch`, `web_search`
+
+**Available models:** `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`
+
+---
+
+### 2. List Agents
+
+```bash
+curl -s "https://api.anthropic.com/v1/agents" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {id: .id, name: .name, model: .model}'
+```
+
+---
+
+### 3. Get an Agent
+
+```bash
+curl -s "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" | jq '.'
+```
+
+---
+
+### 4. Delete an Agent
+
+```bash
+curl -s -X DELETE "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01"
+```
+
+---
+
+### 5. Create an Environment
+
+An environment defines the container configuration (network policy, packages) that sessions run in. Create once, reuse across sessions.
+
+Write to `/tmp/env_create.json`:
+
+```json
+{
+  "name": "Default Cloud Environment",
+  "description": "Standard environment with unrestricted network access",
+  "config": {
+    "type": "cloud",
+    "networking": {
+      "type": "unrestricted"
+    },
+    "packages": {
+      "pip": ["requests", "pandas"],
+      "npm": ["typescript"]
+    }
+  }
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://api.anthropic.com/v1/environments" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/env_create.json | jq '{id: .id, name: .name}'
+```
+
+Save the returned `id` (e.g., `env_011...`) for session creation.
+
+**Network options:**
+- `{"type": "unrestricted"}` — full internet access
+- `{"type": "limited", "allow_package_managers": true, "allow_mcp_servers": true, "allowed_hosts": ["api.github.com"]}` — restricted outbound
+
+---
+
+### 6. Create a Session (Start a Task)
+
+A session runs one task: it mounts resources (repos, files), runs the agent, and produces output. Each session is a separate container.
+
+Write to `/tmp/session_create.json`:
+
+```json
+{
+  "agent": "agent_011CZk...",
+  "environment_id": "env_011...",
+  "title": "Review PR #42",
+  "resources": [
+    {
+      "type": "github_repository",
+      "url": "https://github.com/your-org/your-repo",
+      "authorization_token": "ghp_xxx",
+      "checkout": {
+        "type": "branch",
+        "name": "feature/your-branch"
+      }
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://api.anthropic.com/v1/sessions" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/session_create.json | jq '{id: .id, status: .status}'
+```
+
+**Resource types:**
+- `github_repository` — mounts a GitHub repo; requires `url`, `authorization_token` (GitHub PAT), and optional `checkout` (branch or commit SHA). Defaults to repo's default branch.
+- `file` — mounts a file uploaded via the Files API; requires `file_id`.
+
+**Checkout options:**
+- `{"type": "branch", "name": "main"}`
+- `{"type": "commit", "sha": "abc123..."}`
+
+**With Vault secrets:**
+```json
+{
+  "agent": "agent_011CZk...",
+  "environment_id": "env_011...",
+  "resources": [...],
+  "vault_ids": ["vault_abc..."]
+}
+```
+
+---
+
+### 7. Stream Session Output
+
+Stream real-time SSE events from a running session. The stream stays open until the session completes.
+
+```bash
+curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/stream" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Accept: text/event-stream"
+```
+
+Events are Server-Sent Events (SSE). Each event has a `type` field:
+- `text` — agent text output
+- `tool_call` — tool invocation (bash command, file read, etc.)
+- `tool_result` — tool output
+- `status_change` — session status transitions (`running` → `idle` → `terminated`)
+- `usage` — token usage statistics
+
+Parse text output only:
+
+```bash
+curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/stream" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Accept: text/event-stream" | grep '^data:' | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if line.startswith('data: '):
+        try:
+            ev = json.loads(line[6:])
+            if ev.get('type') == 'text':
+                print(ev.get('text', ''), end='', flush=True)
+        except:
+            pass
+"
+```
+
+---
+
+### 8. Get Session Status
+
+```bash
+curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" | jq '{id: .id, status: .status, title: .title}'
+```
+
+**Session statuses:** `running`, `idle`, `terminated`
+
+---
+
+### 9. List Sessions
+
+```bash
+# List all sessions for an agent
+curl -s "https://api.anthropic.com/v1/sessions?agent_id=<AGENT_ID>&limit=10" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {id: .id, status: .status, title: .title}'
+```
+
+Supports filters: `agent_id`, `agent_version`, `created_at[gt/gte/lt/lte]`, `include_archived`, `order` (`asc`/`desc`), `limit`, `page`.
+
+---
+
+### 10. Full End-to-End Example: Code Review Workflow
+
+```bash
+# Step 1: Create agent (one-time setup)
+AGENT_ID=$(curl -s -X POST "https://api.anthropic.com/v1/agents" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-6",
+    "name": "Code Reviewer",
+    "system": "Review the code changes in the repository and provide detailed feedback on correctness, style, and potential issues.",
+    "tools": [{"type": "agent_toolset_20260401"}]
+  }' | jq -r '.id')
+echo "Agent: $AGENT_ID"
+
+# Step 2: Create environment (one-time setup)
+ENV_ID=$(curl -s -X POST "https://api.anthropic.com/v1/environments" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Default", "config": {"type": "cloud", "networking": {"type": "unrestricted"}}}' | jq -r '.id')
+echo "Environment: $ENV_ID"
+
+# Step 3: Start a session for this PR review task
+SESSION_ID=$(curl -s -X POST "https://api.anthropic.com/v1/sessions" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"agent\": \"$AGENT_ID\",
+    \"environment_id\": \"$ENV_ID\",
+    \"title\": \"Code Review\",
+    \"resources\": [{
+      \"type\": \"github_repository\",
+      \"url\": \"https://github.com/your-org/your-repo\",
+      \"authorization_token\": \"$GITHUB_TOKEN\",
+      \"checkout\": {\"type\": \"branch\", \"name\": \"feature/my-feature\"}
+    }]
+  }" | jq -r '.id')
+echo "Session: $SESSION_ID"
+
+# Step 4: Stream the output until complete
+curl -s "https://api.anthropic.com/v1/sessions/$SESSION_ID/stream" \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Accept: text/event-stream" | grep '^data:' | python3 -c "
+import sys, json
+for line in sys.stdin:
+    line = line.strip()
+    if line.startswith('data: '):
+        try:
+            ev = json.loads(line[6:])
+            t = ev.get('type', '')
+            if t == 'text':
+                print(ev.get('text', ''), end='', flush=True)
+            elif t == 'status_change':
+                print(f\"\n[Status: {ev.get('status')}]\", flush=True)
+        except:
+            pass
+"
+```
+
+---
+
+## Guidelines
+
+1. **Agent lifecycle**: Create an agent once; reuse its ID for all sessions. Agents are versioned — each update increments the version.
+2. **Environment lifecycle**: Create an environment once per container config. Reference the same `env_id` across many sessions.
+3. **Sessions are single-use**: Each session runs one task in an isolated container. For follow-up questions, create a new session.
+4. **Stream before polling**: Use the SSE stream (`/stream`) to get real-time output. Only fall back to `GET /v1/sessions/{id}` for status checks after the stream closes.
+5. **GitHub auth**: Pass a GitHub PAT with `repo` scope as `authorization_token` in repository resources. The token is used only for that session.
+6. **Vaults for secrets**: Store long-lived credentials (API keys, tokens) in a Vault and pass `vault_ids` instead of embedding secrets in session payloads.
+7. **Model selection**: Use `claude-sonnet-4-6` for most coding tasks (speed + quality balance). Use `claude-opus-4-6` for complex multi-file refactors.
+8. **Beta header required**: All Managed Agents endpoints require `anthropic-beta: managed-agents-2026-04-01`. Requests without it will fail.
+9. **Billing**: Sessions consume Claude API credits (tokens), not claude.ai subscription quota. Monitor usage in [Claude Console](https://console.anthropic.com/).

--- a/anthropic-managed-agents/SKILL.md
+++ b/anthropic-managed-agents/SKILL.md
@@ -29,13 +29,13 @@ Use this skill when you need to:
 2. Ensure your account has Managed Agents access (currently in beta)
 
 ```bash
-export ANTHROPIC_TOKEN="sk-ant-..."
+export ANTHROPIC_MANAGED_AGENTS_TOKEN="sk-ant-..."
 ```
 
 ### Common headers (include in every request)
 
 ```bash
--H "x-api-key: $ANTHROPIC_TOKEN"
+-H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN"
 -H "anthropic-version: 2023-06-01"
 -H "anthropic-beta: managed-agents-2026-04-01"
 -H "Content-Type: application/json"
@@ -49,7 +49,7 @@ Sessions are billed as standard Claude API usage (input/output tokens). See [pri
 
 ## How to Use
 
-All examples assume `ANTHROPIC_TOKEN` is set. The base URL is `https://api.anthropic.com`.
+All examples assume `ANTHROPIC_MANAGED_AGENTS_TOKEN` is set. The base URL is `https://api.anthropic.com`.
 
 ---
 
@@ -77,7 +77,7 @@ Then run:
 
 ```bash
 curl -s -X POST "https://api.anthropic.com/v1/agents" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -96,7 +96,7 @@ Save the returned `id` (e.g., `agent_011CZk...`) for use in sessions.
 
 ```bash
 curl -s "https://api.anthropic.com/v1/agents" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {id: .id, name: .name, model: .model}'
 ```
@@ -107,7 +107,7 @@ curl -s "https://api.anthropic.com/v1/agents" \
 
 ```bash
 curl -s "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.'
 ```
@@ -118,7 +118,7 @@ curl -s "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
 
 ```bash
 curl -s -X DELETE "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01"
 ```
@@ -152,7 +152,7 @@ Then run:
 
 ```bash
 curl -s -X POST "https://api.anthropic.com/v1/environments" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -196,7 +196,7 @@ Then run:
 
 ```bash
 curl -s -X POST "https://api.anthropic.com/v1/sessions" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -229,7 +229,7 @@ Stream real-time SSE events from a running session. The stream stays open until 
 
 ```bash
 curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events/stream" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Accept: text/event-stream"
@@ -247,7 +247,7 @@ Parse agent message text output only:
 
 ```bash
 curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events/stream" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Accept: text/event-stream" | grep '^data:' | python3 -c "
@@ -273,7 +273,7 @@ While a session is idle (waiting), send follow-up messages or tool results:
 
 ```bash
 curl -s -X POST "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -293,7 +293,7 @@ Replay all events from a completed or running session:
 
 ```bash
 curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {type: .type, id: .id}'
 ```
@@ -304,7 +304,7 @@ curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events" \
 
 ```bash
 curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '{id: .id, status: .status, title: .title}'
 ```
@@ -318,7 +318,7 @@ curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>" \
 ```bash
 # List all sessions for an agent
 curl -s "https://api.anthropic.com/v1/sessions?agent_id=<AGENT_ID>&limit=10" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {id: .id, status: .status, title: .title}'
 ```
@@ -332,7 +332,7 @@ Supports filters: `agent_id`, `agent_version`, `created_at[gt/gte/lt/lte]`, `inc
 ```bash
 # Step 1: Create agent (one-time setup)
 AGENT_ID=$(curl -s -X POST "https://api.anthropic.com/v1/agents" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -346,7 +346,7 @@ echo "Agent: $AGENT_ID"
 
 # Step 2: Create environment (one-time setup)
 ENV_ID=$(curl -s -X POST "https://api.anthropic.com/v1/environments" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -355,7 +355,7 @@ echo "Environment: $ENV_ID"
 
 # Step 3: Start a session for this PR review task
 SESSION_ID=$(curl -s -X POST "https://api.anthropic.com/v1/sessions" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -374,7 +374,7 @@ echo "Session: $SESSION_ID"
 
 # Step 4: Stream the output until complete
 curl -s "https://api.anthropic.com/v1/sessions/$SESSION_ID/events/stream" \
-  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "x-api-key: $ANTHROPIC_MANAGED_AGENTS_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Accept: text/event-stream" | grep '^data:' | python3 -c "

--- a/anthropic-managed-agents/SKILL.md
+++ b/anthropic-managed-agents/SKILL.md
@@ -29,13 +29,13 @@ Use this skill when you need to:
 2. Ensure your account has Managed Agents access (currently in beta)
 
 ```bash
-export ANTHROPIC_API_KEY="sk-ant-..."
+export ANTHROPIC_TOKEN="sk-ant-..."
 ```
 
 ### Common headers (include in every request)
 
 ```bash
--H "x-api-key: $ANTHROPIC_API_KEY"
+-H "x-api-key: $ANTHROPIC_TOKEN"
 -H "anthropic-version: 2023-06-01"
 -H "anthropic-beta: managed-agents-2026-04-01"
 -H "Content-Type: application/json"
@@ -49,7 +49,7 @@ Sessions are billed as standard Claude API usage (input/output tokens). See [pri
 
 ## How to Use
 
-All examples assume `ANTHROPIC_API_KEY` is set. The base URL is `https://api.anthropic.com`.
+All examples assume `ANTHROPIC_TOKEN` is set. The base URL is `https://api.anthropic.com`.
 
 ---
 
@@ -77,7 +77,7 @@ Then run:
 
 ```bash
 curl -s -X POST "https://api.anthropic.com/v1/agents" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -96,7 +96,7 @@ Save the returned `id` (e.g., `agent_011CZk...`) for use in sessions.
 
 ```bash
 curl -s "https://api.anthropic.com/v1/agents" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {id: .id, name: .name, model: .model}'
 ```
@@ -107,7 +107,7 @@ curl -s "https://api.anthropic.com/v1/agents" \
 
 ```bash
 curl -s "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.'
 ```
@@ -118,7 +118,7 @@ curl -s "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
 
 ```bash
 curl -s -X DELETE "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01"
 ```
@@ -152,7 +152,7 @@ Then run:
 
 ```bash
 curl -s -X POST "https://api.anthropic.com/v1/environments" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -196,7 +196,7 @@ Then run:
 
 ```bash
 curl -s -X POST "https://api.anthropic.com/v1/sessions" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -223,30 +223,31 @@ curl -s -X POST "https://api.anthropic.com/v1/sessions" \
 
 ---
 
-### 7. Stream Session Output
+### 7. Stream Session Events
 
 Stream real-time SSE events from a running session. The stream stays open until the session completes.
 
 ```bash
-curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/stream" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events/stream" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Accept: text/event-stream"
 ```
 
 Events are Server-Sent Events (SSE). Each event has a `type` field:
-- `text` — agent text output
-- `tool_call` — tool invocation (bash command, file read, etc.)
-- `tool_result` — tool output
-- `status_change` — session status transitions (`running` → `idle` → `terminated`)
-- `usage` — token usage statistics
+- `agent.message` — agent text output
+- `agent.tool_use` — tool invocation (bash command, file read, etc.)
+- `agent.tool_result` — tool output
+- `agent.thinking` — extended thinking progress signal
+- `agent.mcp_tool_use` — MCP tool invocation
+- `agent.mcp_tool_result` — MCP tool output
 
-Parse text output only:
+Parse agent message text output only:
 
 ```bash
-curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/stream" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events/stream" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Accept: text/event-stream" | grep '^data:' | python3 -c "
@@ -256,11 +257,45 @@ for line in sys.stdin:
     if line.startswith('data: '):
         try:
             ev = json.loads(line[6:])
-            if ev.get('type') == 'text':
-                print(ev.get('text', ''), end='', flush=True)
+            # agent.message events contain content blocks with text
+            if ev.get('type') == 'agent.message':
+                for block in ev.get('content', []):
+                    if block.get('type') == 'text':
+                        print(block.get('text', ''), end='', flush=True)
         except:
             pass
 "
+```
+
+### 7b. Send Events to a Session (Follow-up Messages)
+
+While a session is idle (waiting), send follow-up messages or tool results:
+
+```bash
+curl -s -X POST "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "events": [
+      {
+        "type": "user.message",
+        "content": [{"type": "text", "text": "Now focus on the security implications."}]
+      }
+    ]
+  }'
+```
+
+### 7c. List Past Events
+
+Replay all events from a completed or running session:
+
+```bash
+curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {type: .type, id: .id}'
 ```
 
 ---
@@ -269,7 +304,7 @@ for line in sys.stdin:
 
 ```bash
 curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '{id: .id, status: .status, title: .title}'
 ```
@@ -283,7 +318,7 @@ curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>" \
 ```bash
 # List all sessions for an agent
 curl -s "https://api.anthropic.com/v1/sessions?agent_id=<AGENT_ID>&limit=10" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {id: .id, status: .status, title: .title}'
 ```
@@ -297,7 +332,7 @@ Supports filters: `agent_id`, `agent_version`, `created_at[gt/gte/lt/lte]`, `inc
 ```bash
 # Step 1: Create agent (one-time setup)
 AGENT_ID=$(curl -s -X POST "https://api.anthropic.com/v1/agents" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -311,7 +346,7 @@ echo "Agent: $AGENT_ID"
 
 # Step 2: Create environment (one-time setup)
 ENV_ID=$(curl -s -X POST "https://api.anthropic.com/v1/environments" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -320,7 +355,7 @@ echo "Environment: $ENV_ID"
 
 # Step 3: Start a session for this PR review task
 SESSION_ID=$(curl -s -X POST "https://api.anthropic.com/v1/sessions" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Content-Type: application/json" \
@@ -338,8 +373,8 @@ SESSION_ID=$(curl -s -X POST "https://api.anthropic.com/v1/sessions" \
 echo "Session: $SESSION_ID"
 
 # Step 4: Stream the output until complete
-curl -s "https://api.anthropic.com/v1/sessions/$SESSION_ID/stream" \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
+curl -s "https://api.anthropic.com/v1/sessions/$SESSION_ID/events/stream" \
+  -H "x-api-key: $ANTHROPIC_TOKEN" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" \
   -H "Accept: text/event-stream" | grep '^data:' | python3 -c "
@@ -366,7 +401,7 @@ for line in sys.stdin:
 1. **Agent lifecycle**: Create an agent once; reuse its ID for all sessions. Agents are versioned — each update increments the version.
 2. **Environment lifecycle**: Create an environment once per container config. Reference the same `env_id` across many sessions.
 3. **Sessions are single-use**: Each session runs one task in an isolated container. For follow-up questions, create a new session.
-4. **Stream before polling**: Use the SSE stream (`/stream`) to get real-time output. Only fall back to `GET /v1/sessions/{id}` for status checks after the stream closes.
+4. **Stream before polling**: Use the SSE stream (`/events/stream`) to get real-time output. Only fall back to `GET /v1/sessions/{id}` for status checks after the stream closes.
 5. **GitHub auth**: Pass a GitHub PAT with `repo` scope as `authorization_token` in repository resources. The token is used only for that session.
 6. **Vaults for secrets**: Store long-lived credentials (API keys, tokens) in a Vault and pass `vault_ids` instead of embedding secrets in session payloads.
 7. **Model selection**: Use `claude-sonnet-4-6` for most coding tasks (speed + quality balance). Use `claude-opus-4-6` for complex multi-file refactors.


### PR DESCRIPTION
## Summary

- Adds a new `anthropic-managed-agents` skill for the Anthropic Managed Agents API (currently in beta)
- Covers the full lifecycle: agents → environments → sessions → streaming output
- Includes vault-based secret injection, GitHub repo mounting, and network configuration
- Full end-to-end code review workflow example included

## What this skill enables

Zero can now:
- Create reusable agent definitions (model + system prompt + toolset)
- Provision cloud environments with custom packages and network policies
- Start sessions that mount GitHub repos and run the agent in an isolated container
- Stream real-time SSE output (text, tool calls, status changes)
- Pass secrets via Vault without embedding them in payloads

## API coverage

| Resource | Operations |
|---|---|
| Agents | Create, List, Get, Delete |
| Environments | Create (with network + packages config) |
| Sessions | Create (with GitHub repo / file resources), List, Get, Stream |
| Vault | Referenced in session creation (`vault_ids`) |

## Related research

Discussed in #dev — Zero's prior research recommended this connector over the Routines connector as the primary Anthropic connector, because it supports synchronous output streaming and dynamic repo mounting, vs. Routines which is fire-and-forget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)