### PR TITLE
refactor: strip all SKILL.md files to Troubleshooting + examples only

### DIFF
--- a/account-reconciliation/SKILL.md
+++ b/account-reconciliation/SKILL.md
@@ -3,14 +3,6 @@ name: account-reconciliation
 description: Perform account reconciliations comparing general ledger balances against subledgers, bank statements, or external records. Use for bank reconciliation, GL-to-subledger reconciliation, intercompany reconciliation, balance sheet reconciliation, reconciling item analysis, outstanding item aging, or clearing open items.
 ---
 
-# Account Reconciliation
-
-Frameworks, procedures, and governance standards for reconciling ledger accounts to supporting detail, external statements, and counterparty records.
-
-## Prerequisites
-
-Connect the **Account Reconciliation** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Reconciliation Categories
 
 ### General Ledger vs. Subledger

--- a/agentmail/SKILL.md
+++ b/agentmail/SKILL.md
@@ -4,27 +4,9 @@ description: AgentMail API for email inboxes. Use when user says "create email i
   "send email", "check messages", or mentions "agentmail" or email for agents.
 ---
 
-# AgentMail API
+## Troubleshooting
 
-Create and manage email inboxes for AI agents. Send, receive, and reply to emails in threads via AgentMail's REST API.
-
-> Official docs: https://docs.agentmail.to
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Create email inboxes for AI agents on the fly
-- Send emails and reply to conversation threads
-- Manage drafts with scheduled sending
-- Set up webhooks for real-time email event notifications
-- Register and verify custom sending domains
-- Organize inboxes with pods
-- Track email delivery metrics
-
----
+If requests fail, run `zero doctor check-connector --env-name AGENTMAIL_TOKEN` or `zero doctor check-connector --url https://api.agentmail.to/v0/inboxes --method POST`
 
 ## Scenarios
 
@@ -113,14 +95,6 @@ An AI agent triages inbound emails and routes them appropriately.
 6. **Forward to the right team** by sending a new email from a different inbox or notifying via webhook
 7. **Review unhandled messages**: `GET /v0/inboxes/{inbox-id}/messages?labels=needs-review`
 
----
-
-## Prerequisites
-
-Connect the **AgentMail** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name AGENTMAIL_TOKEN` or `zero doctor check-connector --url https://api.agentmail.to/v0/inboxes --method POST`
-
 ## Inboxes
 
 ### Create Inbox
@@ -164,8 +138,6 @@ curl -s -X PATCH "https://api.agentmail.to/v0/inboxes/{inbox-id}" --header "Auth
 ```bash
 curl -s -X DELETE "https://api.agentmail.to/v0/inboxes/{inbox-id}" --header "Authorization: Bearer $AGENTMAIL_TOKEN"
 ```
-
----
 
 ## Messages
 
@@ -341,8 +313,6 @@ Returns a `download_url` (temporary pre-signed URL) and `expires_at`. Download t
 curl -s -o attachment.bin "{download-url}"
 ```
 
----
-
 ## Threads
 
 ### List Threads
@@ -376,8 +346,6 @@ curl -s "https://api.agentmail.to/v0/inboxes/{inbox-id}/threads/{thread-id}/atta
 ```bash
 curl -s -X DELETE "https://api.agentmail.to/v0/inboxes/{inbox-id}/threads/{thread-id}" --header "Authorization: Bearer $AGENTMAIL_TOKEN"
 ```
-
----
 
 ## Drafts
 
@@ -460,8 +428,6 @@ curl -s -X POST "https://api.agentmail.to/v0/inboxes/{inbox-id}/drafts/{draft-id
 curl -s -X DELETE "https://api.agentmail.to/v0/inboxes/{inbox-id}/drafts/{draft-id}" --header "Authorization: Bearer $AGENTMAIL_TOKEN"
 ```
 
----
-
 ## Webhooks
 
 ### Create Webhook
@@ -538,8 +504,6 @@ curl -s -X PATCH "https://api.agentmail.to/v0/webhooks/{webhook-id}" --header "A
 curl -s -X DELETE "https://api.agentmail.to/v0/webhooks/{webhook-id}" --header "Authorization: Bearer $AGENTMAIL_TOKEN"
 ```
 
----
-
 ## Domains
 
 ### Create Domain
@@ -578,8 +542,6 @@ Domain status values: `NOT_STARTED`, `PENDING`, `INVALID`, `FAILED`, `VERIFYING`
 curl -s -X DELETE "https://api.agentmail.to/v0/domains/{domain-id}" --header "Authorization: Bearer $AGENTMAIL_TOKEN"
 ```
 
----
-
 ## Pods
 
 Pods are organizational groups for inboxes.
@@ -608,8 +570,6 @@ curl -s "https://api.agentmail.to/v0/pods/{pod-id}" --header "Authorization: Bea
 curl -s -X DELETE "https://api.agentmail.to/v0/pods/{pod-id}" --header "Authorization: Bearer $AGENTMAIL_TOKEN"
 ```
 
----
-
 ## Metrics
 
 ### Get Delivery Metrics
@@ -625,8 +585,6 @@ curl -s "https://api.agentmail.to/v0/metrics?start_timestamp=2025-01-01T00:00:00
 ```
 
 Supported event types: `message.sent`, `message.delivered`, `message.bounced`, `message.delayed`, `message.rejected`, `message.complained`, `message.received`
-
----
 
 ## API Keys
 
@@ -649,8 +607,6 @@ The `api_key` value is only returned once at creation time. Save it immediately.
 ```bash
 curl -s -X DELETE "https://api.agentmail.to/v0/api-keys/{api-key}" --header "Authorization: Bearer $AGENTMAIL_TOKEN"
 ```
-
----
 
 ## Webhook Event Payload
 
@@ -682,8 +638,6 @@ When a webhook fires, AgentMail sends a POST request with this JSON payload:
 
 Your endpoint should return HTTP 200 immediately and process the payload asynchronously.
 
----
-
 ## Send Parameters Reference
 
 | Parameter | Type | Description |
@@ -699,8 +653,6 @@ Your endpoint should return HTTP 200 immediately and process the payload asynchr
 | `attachments` | object[] | Attachments (with `filename`, `content_type`, `content` as base64 or `url`) |
 | `headers` | object | Custom email headers |
 
----
-
 ## Response Codes
 
 | Status | Description |
@@ -712,8 +664,6 @@ Your endpoint should return HTTP 200 immediately and process the payload asynchr
 | `403` | Forbidden (sending not allowed) |
 | `404` | Resource not found |
 
----
-
 ## Guidelines
 
 1. **Always send both text and HTML**: Provide both formats for best deliverability across email clients
@@ -723,8 +673,6 @@ Your endpoint should return HTTP 200 immediately and process the payload asynchr
 5. **Custom domains improve deliverability**: Set up verified custom domains for production use
 6. **Default domain**: Without a custom domain, inboxes use `@agentmail.to`
 7. **Webhook response**: Return HTTP 200 immediately from webhook endpoints; process payloads asynchronously
-
----
 
 ## API Reference
 

--- a/agentphone/SKILL.md
+++ b/agentphone/SKILL.md
@@ -5,23 +5,9 @@ homepage: https://agentphone.to
 docs: https://docs.agentphone.to
 ---
 
-# AgentPhone
+## Troubleshooting
 
-AgentPhone is an API-first telephony platform for AI agents. Give your agents phone numbers, voice calls, and SMS — all managed through a simple API.
-
-**Base URL:** `https://api.agentphone.to/v1`
-
-**Docs:** [docs.agentphone.to](https://docs.agentphone.to)
-
-**Console:** [agentphone.to](https://agentphone.to)
-
----
-
-## Prerequisites
-
-Connect the **AgentPhone** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name AGENTPHONE_TOKEN` or `zero doctor check-connector --url https://api.agentphone.to/v1/agents --method POST`
+If requests fail, run `zero doctor check-connector --env-name AGENTPHONE_TOKEN` or `zero doctor check-connector --url https://api.agentphone.to/v1/agents --method POST`
 
 ## How It Works
 
@@ -51,8 +37,6 @@ Agents operate in one of two modes:
 
 - **`hosted`** — The built-in LLM handles the conversation autonomously using the agent's `system_prompt`. No server required. This is the easiest way to get started — just set a prompt and make a call.
 - **`webhook`** (default) — Inbound call/SMS events are forwarded to your webhook URL for custom handling. Use this when you need full control over the conversation logic.
-
----
 
 ## Quick Start
 
@@ -179,7 +163,6 @@ curl https://api.agentphone.to/v1/calls/call_def456/transcript \
 }
 ```
 
-
 ## Rules
 
 These rules are important. Read them carefully.
@@ -209,7 +192,6 @@ Always use **E.164 format** for phone numbers: `+` followed by country code and 
 - If no agents exist, guide the user to create one before attempting calls
 - Agent setup order: **Create agent → Buy number → Set webhook (if needed) → Make calls**
 
-
 ## Authentication
 
 All API requests require your API key in the `Authorization` header:
@@ -219,7 +201,6 @@ Authorization: Bearer $AGENTPHONE_TOKEN
 ```
 
 Get your API key at [agentphone.to](https://agentphone.to).
-
 
 ## API Reference
 
@@ -247,7 +228,6 @@ curl https://api.agentphone.to/v1/usage \
   }
 }
 ```
-
 
 ### Agents
 
@@ -414,7 +394,6 @@ curl https://api.agentphone.to/v1/agents/voices \
 }
 ```
 
-
 ### Phone Numbers
 
 #### Buy a Phone Number
@@ -485,7 +464,6 @@ curl "https://api.agentphone.to/v1/numbers?limit=20" \
 curl -X DELETE https://api.agentphone.to/v1/numbers/NUMBER_ID \
   -H "Authorization: Bearer $AGENTPHONE_TOKEN"
 ```
-
 
 ### Voice Calls
 
@@ -678,7 +656,6 @@ TOOL_HANDLERS = {
     "search_orders": lambda args: search_order_db(args["query"]),
 }
 
-
 def run_tool_call(user_message: str, history: list) -> str:
     """Run Claude with tools and return the final text response."""
     messages = [{"role": "user", "content": user_message}]
@@ -709,7 +686,6 @@ def run_tool_call(user_message: str, history: list) -> str:
             return " ".join(b.text for b in response.content if hasattr(b, "text"))
 
     return "Sorry, I'm having trouble processing that."
-
 
 @app.post("/webhook")
 def webhook():
@@ -826,7 +802,6 @@ app.listen(3000);
 
 > **Tip: Why interim chunks matter for tool calls** — Without the interim chunk, the caller hears dead silence while your LLM decides which tool to call, the external API responds, and the LLM summarises the result. With streaming, they hear "Let me check on that" within milliseconds — just like a human assistant would.
 
-
 #### Troubleshooting voice calls
 
 ##### Caller hears silence after speaking
@@ -864,7 +839,6 @@ Common causes:
 
 **Fix:** Check the `channel` field in the webhook payload. For `"voice"`, always return `{"text": "..."}`. For `"sms"`, a `200 OK` is sufficient.
 
-
 #### Call recording
 
 Call recording is an optional add-on that saves audio recordings of your voice calls. When enabled, completed calls include a `recordingUrl` field with a link to the audio file.
@@ -877,7 +851,6 @@ Call recording is an optional add-on that saves audio recordings of your voice c
 Enable recording from the **Billing** page in the dashboard. See [Usage & Billing](https://docs.agentphone.to/documentation/guides/usage#call-recording-add-on) for pricing.
 
 > **Note:** Recordings are captured automatically for all calls while the add-on is active. If you disable the add-on, existing recordings are preserved but `recordingUrl` will be null until you re-enable it.
-
 
 #### List All Calls
 
@@ -1028,7 +1001,6 @@ curl https://api.agentphone.to/v1/calls/CALL_ID/transcript \
   -H "Authorization: Bearer $AGENTPHONE_TOKEN"
 ```
 
-
 ### Messages & Conversations
 
 #### Get Messages for a Number
@@ -1105,7 +1077,6 @@ curl "https://api.agentphone.to/v1/conversations/CONVERSATION_ID?messageLimit=50
 |-----------|------|----------|---------|-------------|
 | `messageLimit` | `number` | No | 50 | Max messages to return (1-100) |
 
-
 ### Webhooks (Project-Level)
 
 The project-level webhook receives events for **all agents** unless overridden by an agent-specific webhook.
@@ -1180,7 +1151,6 @@ curl -X POST https://api.agentphone.to/v1/webhooks/test \
   -H "Authorization: Bearer $AGENTPHONE_TOKEN"
 ```
 
-
 ### Webhooks (Per-Agent)
 
 Route a specific agent's events to a different URL. When set, the agent's events go here instead of the project-level webhook.
@@ -1220,7 +1190,6 @@ curl -X POST https://api.agentphone.to/v1/agents/AGENT_ID/webhook/test \
   -H "Authorization: Bearer $AGENTPHONE_TOKEN"
 ```
 
-
 ### Usage & Limits
 
 ```bash
@@ -1255,7 +1224,6 @@ curl "https://api.agentphone.to/v1/usage/daily?days=7" \
 curl "https://api.agentphone.to/v1/usage/monthly?months=3" \
   -H "Authorization: Bearer $AGENTPHONE_TOKEN"
 ```
-
 
 ## Webhook Events
 
@@ -1293,7 +1261,6 @@ Voice webhooks have a **30-second default timeout** (configurable from 5–120 s
 ### Verifying signatures
 
 Each webhook request includes a signature header. Use the `secret` from your webhook setup to verify the payload hasn't been tampered with.
-
 
 ## Response Format
 
@@ -1336,7 +1303,6 @@ Each webhook request includes a signature header. Use the `secret` from your web
 | `429` | Rate limited |
 | `500` | Server error |
 
-
 ## Ideas: What You Can Build
 
 Now that your agent has a phone number, here are things you can do:
@@ -1352,7 +1318,6 @@ Now that your agent has a phone number, here are things you can do:
 - **Personal assistant** — Give your AI a phone number so it can handle calls and texts on your behalf — scheduling, reminders, and follow-ups.
 
 These are starting points. Having your own phone number means your agent can do anything a human can do over the phone, autonomously.
-
 
 ## Additional Resources
 

--- a/ahrefs/SKILL.md
+++ b/ahrefs/SKILL.md
@@ -4,25 +4,9 @@ description: Ahrefs SEO API for backlink and keyword analysis. Use when user men
   "SEO", "backlinks", "domain rating", "keyword research", or asks about site metrics.
 ---
 
-# Ahrefs API
+## Troubleshooting
 
-Access SEO data including backlink profiles, domain ratings, organic keywords, and site metrics with the Ahrefs API v3.
-
-> Official docs: `https://docs.ahrefs.com`
-
-## Prerequisites
-
-Connect the **Ahrefs** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name AHREFS_TOKEN` or `zero doctor check-connector --url https://api.ahrefs.com/v3/site-explorer/domain-rating --method GET`
-
-## When to Use
-
-- Check domain or URL rating
-- Analyze backlink profiles and referring domains
-- Research organic keywords and rankings
-- Get site traffic estimates
-- Monitor competitor SEO metrics
+If requests fail, run `zero doctor check-connector --env-name AHREFS_TOKEN` or `zero doctor check-connector --url https://api.ahrefs.com/v3/site-explorer/domain-rating --method GET`
 
 ## Core APIs
 
@@ -36,8 +20,6 @@ curl -s "https://api.ahrefs.com/v3/site-explorer/domain-rating?target=<target-do
 
 Docs: https://docs.ahrefs.com/reference/domain-rating
 
----
-
 ### Get Backlinks Overview
 
 Replace `<target-domain>` with the actual domain:
@@ -45,8 +27,6 @@ Replace `<target-domain>` with the actual domain:
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/backlinks-stats?target=<target-domain>&date=2026-03-01&mode=subdomains" --header "Authorization: Bearer $AHREFS_TOKEN" | jq '{live, all_time, live_refdomains, all_time_refdomains}'
 ```
-
----
 
 ### Get Backlinks
 
@@ -58,8 +38,6 @@ curl -s "https://api.ahrefs.com/v3/site-explorer/all-backlinks?target=<target-do
 
 Docs: https://docs.ahrefs.com/reference/all-backlinks
 
----
-
 ### Get Referring Domains
 
 Replace `<target-domain>` with the actual domain:
@@ -67,8 +45,6 @@ Replace `<target-domain>` with the actual domain:
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/refdomains?target=<target-domain>&date=2026-03-01&mode=subdomains&limit=10&select=domain,domain_rating,backlinks,first_seen,last_seen" --header "Authorization: Bearer $AHREFS_TOKEN" | jq '.refdomains[] | {domain, domain_rating, backlinks}'
 ```
-
----
 
 ### Get Organic Keywords
 
@@ -80,8 +56,6 @@ curl -s "https://api.ahrefs.com/v3/site-explorer/organic-keywords?target=<target
 
 Docs: https://docs.ahrefs.com/reference/organic-keywords
 
----
-
 ### Get Organic Traffic Overview
 
 Replace `<target-domain>` with the actual domain:
@@ -89,8 +63,6 @@ Replace `<target-domain>` with the actual domain:
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/metrics?target=<target-domain>&date=2026-03-01&mode=subdomains" --header "Authorization: Bearer $AHREFS_TOKEN" | jq '{organic_traffic, organic_keywords, organic_cost, paid_traffic, paid_keywords}'
 ```
-
----
 
 ### Get URL Rating
 
@@ -100,8 +72,6 @@ Get URL rating for a specific page. Replace `<target-url>` with the full URL:
 curl -s "https://api.ahrefs.com/v3/site-explorer/url-rating?target=<target-url>&date=2026-03-01" --header "Authorization: Bearer $AHREFS_TOKEN" | jq '{url_rating, ahrefs_rank}'
 ```
 
----
-
 ### Get Top Pages
 
 Get top pages by organic traffic. Replace `<target-domain>` with the actual domain:
@@ -109,8 +79,6 @@ Get top pages by organic traffic. Replace `<target-domain>` with the actual doma
 ```bash
 curl -s "https://api.ahrefs.com/v3/site-explorer/top-pages?target=<target-domain>&date=2026-03-01&country=us&mode=subdomains&limit=10&select=url,traffic,keywords,top_keyword,position" --header "Authorization: Bearer $AHREFS_TOKEN" | jq '.pages[] | {url, traffic, keywords, top_keyword, position}'
 ```
-
----
 
 ### Keywords Explorer - Volume
 
@@ -129,15 +97,11 @@ Write to `/tmp/ahrefs_request.json`:
 curl -s -X POST "https://api.ahrefs.com/v3/keywords-explorer/volume?select=keyword,volume,difficulty,cpc,global_volume" --header "Authorization: Bearer $AHREFS_TOKEN" --header "Content-Type: application/json" -d @/tmp/ahrefs_request.json | jq '.keywords[] | {keyword, volume, difficulty, cpc}'
 ```
 
----
-
 ### Get Limits (Check API Usage)
 
 ```bash
 curl -s "https://api.ahrefs.com/v3/subscription-info" --header "Authorization: Bearer $AHREFS_TOKEN" | jq '{rows_limit, rows_left, subscription}'
 ```
-
----
 
 ## Guidelines
 

--- a/airtable/SKILL.md
+++ b/airtable/SKILL.md
@@ -5,25 +5,9 @@ description: Airtable API for bases and records. Use when user mentions "Airtabl
   base.
 ---
 
-# Airtable API
+## Troubleshooting
 
-Manage bases, tables, records, and comments in Airtable.
-
-> Official docs: `https://airtable.com/developers/web/api/introduction`
-
-## Prerequisites
-
-Connect the **Airtable** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name AIRTABLE_TOKEN` or `zero doctor check-connector --url https://api.airtable.com/v0/meta/whoami --method GET`
-
-## When to Use
-
-- List and inspect Airtable bases and tables
-- Read, create, update, and delete records
-- Manage table schemas (fields, views)
-- Read and write record comments
-- Get current user info
+If requests fail, run `zero doctor check-connector --env-name AIRTABLE_TOKEN` or `zero doctor check-connector --url https://api.airtable.com/v0/meta/whoami --method GET`
 
 ## Core APIs
 

--- a/analysis-qa/SKILL.md
+++ b/analysis-qa/SKILL.md
@@ -3,14 +3,6 @@ name: analysis-qa
 description: Quality-check a data analysis before sharing — verify joins, aggregations, denominators, time ranges, and metric definitions. Detect pitfalls like survivorship bias, average-of-averages, join explosion, timezone mismatches, incomplete periods, and selection bias. Includes documentation templates for reproducible analyses.
 ---
 
-# Analysis QA
-
-Pre-delivery review process for catching errors, validating results, and ensuring analyses are reproducible and trustworthy.
-
-## Prerequisites
-
-Connect the **Analysis QA** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Review Checklist
 
 Work through every section below before presenting findings to stakeholders.
@@ -167,6 +159,7 @@ JOIN line_items li ON o.id = li.order_id;  -- 3,500 (unexpected inflation)
 Every substantial analysis should ship with this documentation:
 
 ```markdown
+
 ## Analysis: [Title]
 
 ### Business Question

--- a/anthropic-managed-agents/SKILL.md
+++ b/anthropic-managed-agents/SKILL.md
@@ -3,37 +3,13 @@ name: anthropic-managed-agents
 description: Anthropic Managed Agents API for programmatically creating, running, and streaming AI agents on Anthropic's cloud infrastructure. Use when the user mentions "Managed Agents", "Anthropic agent sessions", or needs to create/run/stream an Anthropic agent with tool use (bash, git, web), attach GitHub repositories, or inject secrets via Vault. Do NOT use for standard Claude Messages API — use the Claude API skill instead.
 ---
 
-# Anthropic Managed Agents API
+## Troubleshooting
 
-Use the Anthropic Managed Agents API via direct `curl` calls to **create agent definitions, provision cloud environments, run agent sessions, stream output in real time, and manage vault credentials**.
-
-> Official API reference: `https://docs.anthropic.com/en/api/beta`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Create an agent** — define a model, system prompt, and toolset once; reuse across many sessions
-- **Run agent sessions** — launch a session against a cloud environment with a GitHub repo or uploaded file mounted
-- **Stream session output** — read tool calls, text output, and status changes as they happen
-- **Manage environments** — configure container networking and pre-installed packages
-- **Inject secrets** — store credentials in a Vault and reference them in sessions without exposing plaintext
-
----
-
-## Prerequisites
-
-Connect the **Anthropic Managed Agents** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ANTHROPIC_MANAGED_AGENTS_TOKEN` or `zero doctor check-connector --url https://api.anthropic.com/v1/agents --method POST`
+If requests fail, run `zero doctor check-connector --env-name ANTHROPIC_MANAGED_AGENTS_TOKEN` or `zero doctor check-connector --url https://api.anthropic.com/v1/agents --method POST`
 
 ## How to Use
 
 All examples assume `ANTHROPIC_MANAGED_AGENTS_TOKEN` is set. The base URL is `https://api.anthropic.com`.
-
----
 
 ### 1. Create an Agent
 
@@ -72,8 +48,6 @@ Save the returned `id` (e.g., `agent_011CZk...`) for use in sessions.
 
 **Available models:** `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5`
 
----
-
 ### 2. List Agents
 
 ```bash
@@ -82,8 +56,6 @@ curl -s "https://api.anthropic.com/v1/agents" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {id: .id, name: .name, model: .model}'
 ```
-
----
 
 ### 3. Get an Agent
 
@@ -94,8 +66,6 @@ curl -s "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.'
 ```
 
----
-
 ### 4. Delete an Agent
 
 ```bash
@@ -104,8 +74,6 @@ curl -s -X DELETE "https://api.anthropic.com/v1/agents/<AGENT_ID>" \
   -H "anthropic-version: 2023-06-01" \
   -H "anthropic-beta: managed-agents-2026-04-01"
 ```
-
----
 
 ### 5. Create an Environment
 
@@ -146,8 +114,6 @@ Save the returned `id` (e.g., `env_011...`) for session creation.
 **Network options:**
 - `{"type": "unrestricted"}` — full internet access
 - `{"type": "limited", "allow_package_managers": true, "allow_mcp_servers": true, "allowed_hosts": ["api.github.com"]}` — restricted outbound
-
----
 
 ### 6. Create a Session (Start a Task)
 
@@ -202,8 +168,6 @@ curl -s -X POST "https://api.anthropic.com/v1/sessions" \
   "vault_ids": ["vault_abc..."]
 }
 ```
-
----
 
 ### 7. Stream Session Events
 
@@ -280,8 +244,6 @@ curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>/events" \
   -H "anthropic-beta: managed-agents-2026-04-01" | jq '.data[] | {type: .type, id: .id}'
 ```
 
----
-
 ### 8. Get Session Status
 
 ```bash
@@ -292,8 +254,6 @@ curl -s "https://api.anthropic.com/v1/sessions/<SESSION_ID>" \
 ```
 
 **Session statuses:** `running`, `idle`, `terminated`
-
----
 
 ### 9. List Sessions
 
@@ -306,8 +266,6 @@ curl -s "https://api.anthropic.com/v1/sessions?agent_id=<AGENT_ID>&limit=10" \
 ```
 
 Supports filters: `agent_id`, `agent_version`, `created_at[gt/gte/lt/lte]`, `include_archived`, `order` (`asc`/`desc`), `limit`, `page`.
-
----
 
 ### 10. Full End-to-End Example: Code Review Workflow
 
@@ -375,8 +333,6 @@ for line in sys.stdin:
             pass
 "
 ```
-
----
 
 ## Guidelines
 

--- a/apify/SKILL.md
+++ b/apify/SKILL.md
@@ -4,31 +4,9 @@ description: Apify web scraping platform. Use when user mentions "scrape website
   "web crawler", "scraping", or asks to "extract data from" a site.
 ---
 
-# Apify
+## Troubleshooting
 
-Web scraping and automation platform. Run pre-built Actors (scrapers) or create your own. Access thousands of ready-to-use scrapers for popular websites.
-
-> Official docs: https://docs.apify.com/api/v2
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Scrape data from websites (Amazon, Google, LinkedIn, Twitter, etc.)
-- Run pre-built web scrapers without coding
-- Extract structured data from any website
-- Automate web tasks at scale
-- Store and retrieve scraped data
-
----
-
-## Prerequisites
-
-Connect the **Apify** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name APIFY_TOKEN` or `zero doctor check-connector --url https://api.apify.com/v2/acts/apify~web-scraper/runs --method POST`
+If requests fail, run `zero doctor check-connector --env-name APIFY_TOKEN` or `zero doctor check-connector --url https://api.apify.com/v2/acts/apify~web-scraper/runs --method POST`
 
 ## How to Use
 
@@ -282,8 +260,6 @@ Browse public Actors:
 curl -s "https://api.apify.com/v2/store?limit=20&category=ECOMMERCE" --header "Authorization: Bearer $APIFY_TOKEN" | jq '.data.items[] | {name, username, title}'
 ```
 
----
-
 ## Popular Actors Reference
 
 | Actor ID | Description |
@@ -300,8 +276,6 @@ curl -s "https://api.apify.com/v2/store?limit=20&category=ECOMMERCE" --header "A
 
 Find more at: https://apify.com/store
 
----
-
 ## Run Options
 
 | Parameter | Type | Description |
@@ -311,8 +285,6 @@ Find more at: https://apify.com/store
 | `maxItems` | number | Max items to return (for sync endpoints) |
 | `build` | string | Actor build tag (default: "latest") |
 | `waitForFinish` | number | Wait time in seconds (for async runs) |
-
----
 
 ## Response Format
 
@@ -331,8 +303,6 @@ Find more at: https://apify.com/store
   }
 }
 ```
-
----
 
 ## Guidelines
 

--- a/apollo/SKILL.md
+++ b/apollo/SKILL.md
@@ -3,15 +3,9 @@ name: apollo
 description: Apollo.io API for B2B prospecting and cold outreach automation. Use when user mentions "Apollo", "Apollo.io", "prospect", "cold email", "people search", "contact enrichment", "email sequence", or "outreach automation".
 ---
 
-# Apollo Skill
+## Troubleshooting
 
-Apollo.io is a B2B sales intelligence platform. Use this skill to search for contacts and companies, enrich contact data (including emails), and add contacts to outreach sequences.
-
-## Prerequisites
-
-Connect the **Apollo** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name APOLLO_TOKEN` or `zero doctor check-connector --url https://api.apollo.io/api/v1/mixed_people/api_search --method POST`
+If requests fail, run `zero doctor check-connector --env-name APOLLO_TOKEN` or `zero doctor check-connector --url https://api.apollo.io/api/v1/mixed_people/api_search --method POST`
 
 ## Authentication
 

--- a/asana/SKILL.md
+++ b/asana/SKILL.md
@@ -4,34 +4,9 @@ description: Asana API for tasks and projects. Use when user mentions "Asana", "
   shares an Asana link, "Asana task", or asks about Asana workspace.
 ---
 
-# Asana API
+## Troubleshooting
 
-Manage tasks, projects, sections, tags, portfolios, and goals in Asana workspaces via the REST API.
-
-> Official docs: `https://developers.asana.com/reference/rest-api-reference`
-
----
-
-## Prerequisites
-
-Connect the **Asana** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ASANA_TOKEN` or `zero doctor check-connector --url https://app.asana.com/api/1.0/users/me --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- List workspaces and get current user info
-- Create, update, delete, and search tasks
-- Manage projects and sections within projects
-- Add tags to tasks and manage tags
-- List portfolios and goals
-- Add followers or assignees to tasks
-
----
-
----
+If requests fail, run `zero doctor check-connector --env-name ASANA_TOKEN` or `zero doctor check-connector --url https://app.asana.com/api/1.0/users/me --method GET`
 
 ## How to Use
 
@@ -40,8 +15,6 @@ All examples below assume you have `ASANA_TOKEN` set.
 Base URL: `https://app.asana.com/api/1.0`
 
 Asana wraps all responses in a `data` field. Use `jq '.data'` to extract the actual content.
-
----
 
 ## User & Workspaces
 
@@ -56,8 +29,6 @@ curl -s "https://app.asana.com/api/1.0/users/me" --header "Authorization: Bearer
 ```bash
 curl -s "https://app.asana.com/api/1.0/workspaces" --header "Authorization: Bearer $ASANA_TOKEN" | jq '.data[] | {gid, name}'
 ```
-
----
 
 ## Projects
 
@@ -114,8 +85,6 @@ curl -s -X PUT "https://app.asana.com/api/1.0/projects/<project-gid>" --header "
 ```bash
 curl -s -X DELETE "https://app.asana.com/api/1.0/projects/<project-gid>" --header "Authorization: Bearer $ASANA_TOKEN"
 ```
-
----
 
 ## Tasks
 
@@ -216,8 +185,6 @@ curl -s -X DELETE "https://app.asana.com/api/1.0/tasks/<task-gid>" --header "Aut
 curl -s "https://app.asana.com/api/1.0/workspaces/<workspace-gid>/tasks/search?text=<search-text>&opt_fields=name,completed,assignee.name,due_on" --header "Authorization: Bearer $ASANA_TOKEN" | jq '.data[] | {gid, name, completed}'
 ```
 
----
-
 ## Sections
 
 ### List Sections in a Project
@@ -257,8 +224,6 @@ Write to `/tmp/asana_request.json`:
 ```bash
 curl -s -X POST "https://app.asana.com/api/1.0/sections/<section-gid>/addTask" --header "Authorization: Bearer $ASANA_TOKEN" --header "Content-Type: application/json" -d @/tmp/asana_request.json
 ```
-
----
 
 ## Tags
 
@@ -317,8 +282,6 @@ Write to `/tmp/asana_request.json`:
 curl -s -X POST "https://app.asana.com/api/1.0/tasks/<task-gid>/removeTag" --header "Authorization: Bearer $ASANA_TOKEN" --header "Content-Type: application/json" -d @/tmp/asana_request.json
 ```
 
----
-
 ## Portfolios
 
 ### List Portfolios
@@ -333,8 +296,6 @@ curl -s "https://app.asana.com/api/1.0/portfolios?workspace=<workspace-gid>&owne
 curl -s "https://app.asana.com/api/1.0/portfolios/<portfolio-gid>/items?opt_fields=name,created_at" --header "Authorization: Bearer $ASANA_TOKEN" | jq '.data[] | {gid, name}'
 ```
 
----
-
 ## Goals
 
 ### List Goals
@@ -342,8 +303,6 @@ curl -s "https://app.asana.com/api/1.0/portfolios/<portfolio-gid>/items?opt_fiel
 ```bash
 curl -s "https://app.asana.com/api/1.0/goals?workspace=<workspace-gid>&opt_fields=name,status,due_on,owner.name" --header "Authorization: Bearer $ASANA_TOKEN" | jq '.data[] | {gid, name, status, due_on}'
 ```
-
----
 
 ## Subtasks
 
@@ -369,8 +328,6 @@ Write to `/tmp/asana_request.json`:
 ```bash
 curl -s -X POST "https://app.asana.com/api/1.0/tasks/<task-gid>/subtasks" --header "Authorization: Bearer $ASANA_TOKEN" --header "Content-Type: application/json" -d @/tmp/asana_request.json | jq '.data | {gid, name}'
 ```
-
----
 
 ## Guidelines
 

--- a/atlassian/SKILL.md
+++ b/atlassian/SKILL.md
@@ -4,34 +4,9 @@ description: Atlassian API for Confluence and Jira. Use when user mentions "Conf
   page", "Atlassian", or asks about wiki/documentation management.
 ---
 
-# Atlassian API
+## Troubleshooting
 
-Use the Atlassian Cloud REST APIs to manage Jira issues and Confluence pages.
-
-> Official docs:
-> - Jira: https://developer.atlassian.com/cloud/jira/platform/rest/v3/
-> - Confluence v2: https://developer.atlassian.com/cloud/confluence/rest/v2/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Create, update, and search Jira issues using JQL
-- Transition Jira issues through workflow states
-- Manage Jira comments, labels, worklogs, and attachments
-- Create and update Confluence pages and blog posts
-- Search Confluence content using CQL
-- Manage Confluence spaces, labels, and comments
-
----
-
-## Prerequisites
-
-Connect the **Atlassian** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ATLASSIAN_TOKEN` or `zero doctor check-connector --url https://your-domain.atlassian.net/rest/api/3/myself --method GET`
+If requests fail, run `zero doctor check-connector --env-name ATLASSIAN_TOKEN` or `zero doctor check-connector --url https://your-domain.atlassian.net/rest/api/3/myself --method GET`
 
 ## Jira — User
 
@@ -52,8 +27,6 @@ curl -s -G "https://$ATLASSIAN_DOMAIN.atlassian.net/rest/api/3/user/search" \
   --data-urlencode "query=john"
 ```
 
----
-
 ## Jira — Projects
 
 ### List Projects
@@ -71,8 +44,6 @@ curl -s "https://$ATLASSIAN_DOMAIN.atlassian.net/rest/api/3/project/<project-key
   -u "$ATLASSIAN_EMAIL:$ATLASSIAN_TOKEN" \
   --header "Accept: application/json"
 ```
-
----
 
 ## Jira — Issues
 
@@ -203,8 +174,6 @@ curl -s -X POST "https://$ATLASSIAN_DOMAIN.atlassian.net/rest/api/3/issue/<issue
   -d "{\"timeSpentSeconds\": 3600, \"comment\": {\"type\": \"doc\", \"version\": 1, \"content\": [{\"type\": \"paragraph\", \"content\": [{\"type\": \"text\", \"text\": \"Investigated and fixed the issue.\"}]}]}}"
 ```
 
----
-
 ## Confluence — Spaces (v2)
 
 ### List Spaces
@@ -246,8 +215,6 @@ curl -s "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/api/v2/spaces/<space-id>/p
   -u "$ATLASSIAN_EMAIL:$ATLASSIAN_TOKEN" \
   --header "Accept: application/json"
 ```
-
----
 
 ## Confluence — Pages (v2)
 
@@ -347,8 +314,6 @@ curl -s "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/api/v2/pages/<page-id>/anc
   --header "Accept: application/json"
 ```
 
----
-
 ## Confluence — Comments (v2)
 
 ### List Footer Comments
@@ -383,8 +348,6 @@ curl -s -X PUT "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/api/v2/footer-comme
 curl -s -X DELETE "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/api/v2/footer-comments/<comment-id>" \
   -u "$ATLASSIAN_EMAIL:$ATLASSIAN_TOKEN"
 ```
-
----
 
 ## Confluence — Blog Posts (v2)
 
@@ -429,8 +392,6 @@ curl -s -X DELETE "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/api/v2/blogposts
   -u "$ATLASSIAN_EMAIL:$ATLASSIAN_TOKEN"
 ```
 
----
-
 ## Confluence — Labels (v2)
 
 ### List Labels
@@ -449,8 +410,6 @@ curl -s "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/api/v2/labels/<label-id>/p
   --header "Accept: application/json"
 ```
 
----
-
 ## Confluence — Search (v1)
 
 > **Note:** CQL search is only available via the v1 API. There is no v2 equivalent.
@@ -467,8 +426,6 @@ curl -s -G "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/rest/api/search" \
 
 Common CQL: `type=page AND space=DEV`, `text~"search term"`, `creator=currentUser()`, `lastModified >= "2026-01-01"`, `label="meeting-notes"`, `ancestor=12345`.
 
----
-
 ## Confluence — Attachments (v1)
 
 ### Upload Attachment
@@ -479,8 +436,6 @@ curl -s -X POST "https://$ATLASSIAN_DOMAIN.atlassian.net/wiki/rest/api/content/<
   --header "X-Atlassian-Token: nocheck" \
   -F "file=@document.pdf"
 ```
-
----
 
 ## Atlassian Document Format (ADF)
 
@@ -507,8 +462,6 @@ Jira API v3 uses ADF for rich text fields (`description`, `comment.body`):
 
 Confluence uses XHTML for page bodies: `<p>`, `<h1>`-`<h6>`, `<strong>`, `<em>`, `<ul>/<ol>`, `<table>`, `<ac:structured-macro>`.
 
----
-
 ## Guidelines
 
 1. **JQL for Jira searches**: Powerful filtering by any field combination.
@@ -521,8 +474,6 @@ Confluence uses XHTML for page bodies: `<p>`, `<h1>`-`<h6>`, `<strong>`, `<em>`,
 8. **Pagination**: Jira uses `startAt` + `maxResults`. Confluence v2 uses cursor-based pagination with `cursor` and `limit`.
 9. **Rate limits**: Back off on 429 responses.
 10. **Confluence v2 API**: This skill uses `/wiki/api/v2` for pages, spaces, comments, blog posts. CQL search and attachments still use v1 (`/wiki/rest/api`).
-
----
 
 ## How to Look Up More API Details
 

--- a/audit-readiness/SKILL.md
+++ b/audit-readiness/SKILL.md
@@ -3,14 +3,6 @@ name: audit-readiness
 description: Prepare for internal and external audits with SOX 404 control testing, sample selection, workpaper documentation, and deficiency evaluation. Use for SOX compliance, control testing methodology, audit sample selection, audit workpaper preparation, control deficiency classification, material weakness evaluation, ITGC testing, remediation tracking, or audit evidence standards.
 ---
 
-# Audit Readiness
-
-SOX 404 compliance methodology, sampling strategies, evidence and workpaper standards, deficiency severity evaluation, and control taxonomy for maintaining audit-ready internal controls over financial reporting (ICFR).
-
-## Prerequisites
-
-Connect the **Audit Readiness** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## SOX 404 Testing Lifecycle
 
 ### End-to-End Phases

--- a/axiom/SKILL.md
+++ b/axiom/SKILL.md
@@ -4,33 +4,9 @@ description: Axiom observability API for logs and analytics. Use when user menti
   "logs", "query logs", "Axiom", or asks about event analytics.
 ---
 
-# Axiom
+## Troubleshooting
 
-Axiom is a cloud-native observability platform for storing, querying, and analyzing log and event data at scale. Use the REST API to ingest data, run queries using APL (Axiom Processing Language), and manage datasets, monitors, dashboards, annotations, and notifiers.
-
-> Official docs: https://axiom.co/docs/restapi/introduction
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Send logs, metrics, or event data to Axiom
-- Query and analyze data using APL (Axiom Processing Language)
-- Manage datasets, fields, and virtual fields
-- Create and manage monitors and notifiers (alerts)
-- Manage dashboards and saved queries
-- Create annotations (deployment markers, incidents, etc.)
-- Manage organization users and RBAC
-
----
-
-## Prerequisites
-
-Connect the **Axiom** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name AXIOM_TOKEN` or `zero doctor check-connector --url https://api.axiom.co/v2/datasets --method GET`
+If requests fail, run `zero doctor check-connector --env-name AXIOM_TOKEN` or `zero doctor check-connector --url https://api.axiom.co/v2/datasets --method GET`
 
 ## Datasets
 
@@ -107,8 +83,6 @@ curl -s -X PUT "https://api.axiom.co/v2/datasets/<dataset-id>/fields/<field-id>"
   -d "{\"description\": \"Response time in ms\", \"unit\": \"ms\"}"
 ```
 
----
-
 ## Ingest
 
 ### Ingest JSON
@@ -130,8 +104,6 @@ curl -s -X POST "https://us-east-1.aws.edge.axiom.co/v1/datasets/<dataset-name>/
 ```
 
 > **Tip:** Batch multiple events in a single request for better performance. Events without `_time` field will use server receive time.
-
----
 
 ## Queries (APL)
 
@@ -166,8 +138,6 @@ curl -s -X POST "https://api.axiom.co/v1/datasets/_apl?format=tabular" \
 | `['dataset'] \| summarize avg(duration_ms) by bin(_time, 1h)` | Hourly average |
 | `['dataset'] \| sort by _time desc \| limit 100` | Latest 100 events |
 | `['dataset'] \| where _time > ago(1h)` | Events in last hour |
-
----
 
 ## Monitors
 
@@ -217,8 +187,6 @@ curl -s -X DELETE "https://api.axiom.co/v2/monitors/<monitor-id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
 
----
-
 ## Notifiers
 
 ### List Notifiers
@@ -262,8 +230,6 @@ curl -s -X DELETE "https://api.axiom.co/v2/notifiers/<notifier-id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
 
----
-
 ## Annotations
 
 ### List Annotations
@@ -304,8 +270,6 @@ curl -s -X PUT "https://api.axiom.co/v2/annotations/<annotation-id>" \
 curl -s -X DELETE "https://api.axiom.co/v2/annotations/<annotation-id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
-
----
 
 ## Dashboards
 
@@ -348,8 +312,6 @@ curl -s -X DELETE "https://api.axiom.co/v2/dashboards/uid/<dashboard-uid>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
 
----
-
 ## Starred Queries
 
 ### List Starred Queries
@@ -383,8 +345,6 @@ curl -s -X PUT "https://api.axiom.co/v2/apl-starred-queries/<id>" \
 curl -s -X DELETE "https://api.axiom.co/v2/apl-starred-queries/<id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
-
----
 
 ## Virtual Fields
 
@@ -420,8 +380,6 @@ curl -s -X DELETE "https://api.axiom.co/v2/vfields/<id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
 
----
-
 ## Views (Saved Views)
 
 ### List Views
@@ -456,8 +414,6 @@ curl -s -X DELETE "https://api.axiom.co/v2/views/<id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
 
----
-
 ## Organization & Users
 
 ### Get Organization
@@ -487,8 +443,6 @@ curl -s "https://api.axiom.co/v2/users" \
 curl -s "https://api.axiom.co/v2/users/<user-id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
-
----
 
 ## API Tokens
 
@@ -522,8 +476,6 @@ curl -s -X DELETE "https://api.axiom.co/v2/tokens/<token-id>" \
   --header "Authorization: Bearer $AXIOM_TOKEN"
 ```
 
----
-
 ## Guidelines
 
 1. **Use Edge URLs for Ingest**: Always use the edge endpoint (`us-east-1.aws.edge.axiom.co` or `eu-central-1.aws.edge.axiom.co`) for data ingestion, not `api.axiom.co`.
@@ -534,8 +486,6 @@ curl -s -X DELETE "https://api.axiom.co/v2/tokens/<token-id>" \
 6. **Data Formats**: JSON array is recommended for ingest; NDJSON and CSV are also supported.
 7. **Dataset Names**: In APL queries, use `['dataset-name']` syntax (square brackets + quotes) for dataset names.
 8. **Monitors + Notifiers**: Monitors define alert conditions (APL query + threshold); notifiers define delivery channels (Slack, email, PagerDuty, etc.). Link them via `notifierIds`.
-
----
 
 ## How to Look Up More API Details
 

--- a/bitrix/SKILL.md
+++ b/bitrix/SKILL.md
@@ -4,36 +4,9 @@ description: Bitrix24 CRM API. Use when user mentions "Bitrix", "CRM", "Bitrix24
   or asks about CRM management.
 ---
 
-# Bitrix24 API
-
-Use the Bitrix24 REST API via direct `curl` calls to **manage CRM, tasks, and users** in your Bitrix24 workspace.
-
-> Official docs: `https://apidocs.bitrix24.com/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage CRM leads** (create, update, list, delete)
-- **Manage CRM deals** and sales funnels
-- **Manage CRM contacts** and companies
-- **Create and manage tasks**
-- **Get user information**
-- **Automate business workflows**
-
----
-
-## Prerequisites
-
-Connect the **Bitrix24** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 All examples assume `BITRIX_WEBHOOK_URL` is set to your webhook base URL.
-
----
 
 ### 1. Get Current User
 
@@ -55,8 +28,6 @@ curl -s -X GET "$BITRIX_WEBHOOK_URL/user.current.json"
 }
 ```
 
----
-
 ### 2. List Users
 
 Get a list of users in the workspace:
@@ -64,8 +35,6 @@ Get a list of users in the workspace:
 ```bash
 curl -s -X GET "$BITRIX_WEBHOOK_URL/user.get.json" | jq '.result[] | {ID, NAME, LAST_NAME, EMAIL}'
 ```
-
----
 
 ## CRM - Leads
 
@@ -98,8 +67,6 @@ curl -s -X POST "$BITRIX_WEBHOOK_URL/crm.lead.add.json" --header "Content-Type: 
 }
 ```
 
----
-
 ### 4. Get a Lead
 
 Replace `<your-lead-id>` with the actual lead ID:
@@ -107,8 +74,6 @@ Replace `<your-lead-id>` with the actual lead ID:
 ```bash
 curl -s -X GET "$BITRIX_WEBHOOK_URL/crm.lead.get.json?id=<your-lead-id>"
 ```
-
----
 
 ### 5. List Leads
 
@@ -133,8 +98,6 @@ Then run:
 curl -s -X POST "$BITRIX_WEBHOOK_URL/crm.lead.list.json" --header "Content-Type: application/json" -d @/tmp/bitrix_request.json
 ```
 
----
-
 ### 6. Update a Lead
 
 Write to `/tmp/bitrix_request.json`:
@@ -155,8 +118,6 @@ Then run:
 curl -s -X POST "$BITRIX_WEBHOOK_URL/crm.lead.update.json" --header "Content-Type: application/json" -d @/tmp/bitrix_request.json
 ```
 
----
-
 ### 7. Delete a Lead
 
 Replace `<your-lead-id>` with the actual lead ID:
@@ -164,8 +125,6 @@ Replace `<your-lead-id>` with the actual lead ID:
 ```bash
 curl -s -X GET "$BITRIX_WEBHOOK_URL/crm.lead.delete.json?id=<your-lead-id>"
 ```
-
----
 
 ## CRM - Contacts
 
@@ -190,15 +149,11 @@ Then run:
 curl -s -X POST "$BITRIX_WEBHOOK_URL/crm.contact.add.json" --header "Content-Type: application/json" -d @/tmp/bitrix_request.json
 ```
 
----
-
 ### 9. List Contacts
 
 ```bash
 curl -s -X GET "$BITRIX_WEBHOOK_URL/crm.contact.list.json" | jq '.result[] | {ID, NAME, LAST_NAME}'
 ```
-
----
 
 ## CRM - Deals
 
@@ -223,15 +178,11 @@ Then run:
 curl -s -X POST "$BITRIX_WEBHOOK_URL/crm.deal.add.json" --header "Content-Type: application/json" -d @/tmp/bitrix_request.json
 ```
 
----
-
 ### 11. List Deals
 
 ```bash
 curl -s -X GET "$BITRIX_WEBHOOK_URL/crm.deal.list.json" | jq '.result[] | {ID, TITLE, STAGE_ID, OPPORTUNITY}'
 ```
-
----
 
 ### 12. Update Deal Stage
 
@@ -251,8 +202,6 @@ Then run:
 ```bash
 curl -s -X POST "$BITRIX_WEBHOOK_URL/crm.deal.update.json" --header "Content-Type: application/json" -d @/tmp/bitrix_request.json
 ```
-
----
 
 ## Tasks
 
@@ -277,15 +226,11 @@ Then run:
 curl -s -X POST "$BITRIX_WEBHOOK_URL/tasks.task.add.json" --header "Content-Type: application/json" -d @/tmp/bitrix_request.json
 ```
 
----
-
 ### 14. List Tasks
 
 ```bash
 curl -s -X GET "$BITRIX_WEBHOOK_URL/tasks.task.list.json" | jq '.result.tasks[] | {id, title, status}'
 ```
-
----
 
 ### 15. Complete a Task
 
@@ -294,8 +239,6 @@ Replace `<your-task-id>` with the actual task ID:
 ```bash
 curl -s -X GET "$BITRIX_WEBHOOK_URL/tasks.task.complete.json?taskId=<your-task-id>"
 ```
-
----
 
 ## Get Field Definitions
 
@@ -312,8 +255,6 @@ curl -s -X GET "$BITRIX_WEBHOOK_URL/crm.contact.fields.json"
 curl -s -X GET "$BITRIX_WEBHOOK_URL/crm.deal.fields.json"
 ```
 
----
-
 ## Common Parameters
 
 | Parameter | Description |
@@ -322,8 +263,6 @@ curl -s -X GET "$BITRIX_WEBHOOK_URL/crm.deal.fields.json"
 | `select` | Fields to return (e.g., `["ID", "TITLE"]`) |
 | `order` | Sort order (e.g., `{"ID": "DESC"}`) |
 | `start` | Pagination offset |
-
----
 
 ## Guidelines
 

--- a/brand-guidelines/SKILL.md
+++ b/brand-guidelines/SKILL.md
@@ -3,14 +3,6 @@ name: brand-guidelines
 description: Define, document, and enforce brand voice, tone, messaging pillars, style rules, and terminology standards. Trigger on requests about brand consistency, voice documentation, tone of voice guides, style guide creation, messaging frameworks, terminology governance, inclusive language, or reviewing content for brand compliance.
 ---
 
-# Brand Guidelines
-
-Methods for establishing, maintaining, and applying a cohesive brand identity across all written communications.
-
-## Prerequisites
-
-Connect the **Brand Guidelines** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Building a Brand Voice Document
 
 A thorough voice reference covers the following areas. Use this structure to help teams articulate their voice from scratch or to interpret an existing voice configuration.

--- a/brave-search/SKILL.md
+++ b/brave-search/SKILL.md
@@ -4,31 +4,9 @@ description: Brave Search API for web search. Use when user says "search web", "
   search", or asks to "find on web" without specifying Google.
 ---
 
-# Brave Search API
+## Troubleshooting
 
-Use the Brave Search API via direct `curl` calls to perform **privacy-focused web searches** with no user tracking.
-
-> Official docs: `https://api.search.brave.com/app/documentation`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Web search** with privacy-focused results
-- **Image search** for finding images
-- **Video search** for video content
-- **News search** for current events
-- **AI-powered summaries** of search results
-
----
-
-## Prerequisites
-
-Connect the **Brave Search** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name BRAVE_API_KEY` or `zero doctor check-connector --url https://api.search.brave.com/res/v1/web/search --method GET`
+If requests fail, run `zero doctor check-connector --env-name BRAVE_API_KEY` or `zero doctor check-connector --url https://api.search.brave.com/res/v1/web/search --method GET`
 
 ## How to Use
 
@@ -40,8 +18,6 @@ The base URL for the API is:
 
 Authentication uses the `X-Subscription-Token` header.
 
----
-
 ### 1. Basic Web Search
 
 Search the web with a query:
@@ -49,8 +25,6 @@ Search the web with a query:
 ```bash
 curl -s "https://api.search.brave.com/res/v1/web/search?q=artificial+intelligence" -H "Accept: application/json" -H "X-Subscription-Token: $BRAVE_API_KEY" | jq '.web.results[:3] | .[] | {title, url, description}
 ```
-
----
 
 ### 2. Web Search with Parameters
 
@@ -74,8 +48,6 @@ curl -s "https://api.search.brave.com/res/v1/web/search" -H "Accept: application
 - `count`: Results per page (1-20, default: 10)
 - `offset`: Pagination offset (0-9, default: 0)
 
----
-
 ### 3. Safe Search Filter
 
 Control explicit content filtering:
@@ -91,8 +63,6 @@ curl -s "https://api.search.brave.com/res/v1/web/search" -H "Accept: application
 ```
 
 **Options:** `off`, `strict` (Note: Image/Video search only supports `off` and `strict`)
-
----
 
 ### 4. Freshness Filter
 
@@ -116,8 +86,6 @@ curl -s "https://api.search.brave.com/res/v1/web/search" -H "Accept: application
 - `py`: Past year
 - `YYYY-MM-DDtoYYYY-MM-DD`: Custom date range
 
----
-
 ### 5. Image Search
 
 Search for images:
@@ -133,8 +101,6 @@ curl -s "https://api.search.brave.com/res/v1/images/search" -H "Accept: applicat
 ```
 
 Image search supports up to 200 results per request.
-
----
 
 ### 6. Video Search
 
@@ -152,8 +118,6 @@ curl -s "https://api.search.brave.com/res/v1/videos/search" -H "Accept: applicat
 
 Video search supports up to 50 results per request.
 
----
-
 ### 7. News Search
 
 Search for recent news articles:
@@ -169,8 +133,6 @@ curl -s "https://api.search.brave.com/res/v1/news/search" -H "Accept: applicatio
 ```
 
 News search defaults to past day (`pd`) freshness.
-
----
 
 ### 8. Pagination
 
@@ -188,8 +150,6 @@ curl -s "https://api.search.brave.com/res/v1/web/search" -H "Accept: application
 
 `offset=1` skips the first page of results.
 
----
-
 ### 9. Get Raw JSON Response
 
 View the full response structure:
@@ -199,8 +159,6 @@ curl -s "https://api.search.brave.com/res/v1/web/search?q=test" -H "Accept: appl
 ```
 
 Response includes: `query`, `mixed`, `type`, `web`, `videos`, `news`, etc.
-
----
 
 ## Response Structure
 
@@ -235,8 +193,6 @@ Response includes: `query`, `mixed`, `type`, `web`, `videos`, `news`, etc.
   ]
 }
 ```
-
----
 
 ## Guidelines
 

--- a/brevo/SKILL.md
+++ b/brevo/SKILL.md
@@ -3,25 +3,9 @@ name: brevo
 description: Brevo email and SMS marketing platform. Use when user mentions "Brevo", "Sendinblue", "email campaigns", "SMS marketing", "contact lists", or asks about multi-channel marketing.
 ---
 
-# Brevo API
+## Troubleshooting
 
-Send transactional emails, SMS, and marketing campaigns. Manage contacts and lists via Brevo (formerly Sendinblue).
-
-> Official docs: `https://developers.brevo.com/docs/getting-started`
-
-## When to Use
-
-- Import contacts from Clerk or another auth provider
-- Send transactional emails (receipts, password resets, alerts)
-- Create and send email marketing campaigns
-- Manage contact lists and attributes
-- Send SMS messages
-
-## Prerequisites
-
-Connect the **Brevo** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name BREVO_TOKEN` or `zero doctor check-connector --url https://api.brevo.com/v3/account --method GET`
+If requests fail, run `zero doctor check-connector --env-name BREVO_TOKEN` or `zero doctor check-connector --url https://api.brevo.com/v3/account --method GET`
 
 ## Core APIs
 
@@ -32,8 +16,6 @@ Verify your API key and view account details:
 ```bash
 curl -s "https://api.brevo.com/v3/account" --header "api-key: $BREVO_TOKEN" --header "accept: application/json" | jq '{companyName, email, plan: .plan[0].type}'
 ```
-
----
 
 ### Create Contact
 
@@ -57,8 +39,6 @@ curl -s -X POST "https://api.brevo.com/v3/contacts" --header "api-key: $BREVO_TO
 
 Docs: https://developers.brevo.com/reference/create-contact
 
----
-
 ### Get Contact
 
 Replace `<email-or-id>` with the contact's email address or numeric ID:
@@ -66,8 +46,6 @@ Replace `<email-or-id>` with the contact's email address or numeric ID:
 ```bash
 curl -s "https://api.brevo.com/v3/contacts/<email-or-id>" --header "api-key: $BREVO_TOKEN" --header "accept: application/json" | jq '{id, email, attributes}'
 ```
-
----
 
 ### Update Contact
 
@@ -89,8 +67,6 @@ Write to `/tmp/brevo_request.json`:
 curl -s -X PUT "https://api.brevo.com/v3/contacts/<email-or-id>" --header "api-key: $BREVO_TOKEN" --header "Content-Type: application/json" -d @/tmp/brevo_request.json -w "\nHTTP Status: %{http_code}\n"
 ```
 
----
-
 ### Delete Contact
 
 Replace `<email-or-id>` with the contact's email or ID:
@@ -99,15 +75,11 @@ Replace `<email-or-id>` with the contact's email or ID:
 curl -s -X DELETE "https://api.brevo.com/v3/contacts/<email-or-id>" --header "api-key: $BREVO_TOKEN" -w "\nHTTP Status: %{http_code}\n"
 ```
 
----
-
 ### List Contacts
 
 ```bash
 curl -s "https://api.brevo.com/v3/contacts?limit=20&offset=0" --header "api-key: $BREVO_TOKEN" --header "accept: application/json" | jq '{count, contacts: [.contacts[] | {id, email}]}'
 ```
-
----
 
 ### Send Transactional Email
 
@@ -131,8 +103,6 @@ curl -s -X POST "https://api.brevo.com/v3/smtp/email" --header "api-key: $BREVO_
 
 Docs: https://developers.brevo.com/reference/send-transac-email
 
----
-
 ### Send Transactional Email via Template
 
 Replace `<template-id>` with the ID from your Brevo dashboard.
@@ -155,15 +125,11 @@ Write to `/tmp/brevo_request.json`:
 curl -s -X POST "https://api.brevo.com/v3/smtp/email" --header "api-key: $BREVO_TOKEN" --header "Content-Type: application/json" --header "accept: application/json" -d @/tmp/brevo_request.json | jq '{messageId}'
 ```
 
----
-
 ### List Contact Lists
 
 ```bash
 curl -s "https://api.brevo.com/v3/contacts/lists?limit=20" --header "api-key: $BREVO_TOKEN" --header "accept: application/json" | jq '[.lists[] | {id, name, totalBlacklisted, totalSubscribers}]'
 ```
-
----
 
 ### Import Contacts (Bulk)
 
@@ -189,8 +155,6 @@ Import multiple contacts at once. Write to `/tmp/brevo_request.json`:
 ```bash
 curl -s -X POST "https://api.brevo.com/v3/contacts/import" --header "api-key: $BREVO_TOKEN" --header "Content-Type: application/json" --header "accept: application/json" -d @/tmp/brevo_request.json | jq '{createdLists, processId}'
 ```
-
----
 
 ## Guidelines
 

--- a/bright-data/SKILL.md
+++ b/bright-data/SKILL.md
@@ -4,30 +4,9 @@ description: Bright Data proxy and web scraping API. Use when user mentions "Bri
   Data", "proxy", "web scraping at scale", or data collection.
 ---
 
-# Bright Data Web Scraper API
+## Troubleshooting
 
-Use the Bright Data API via direct `curl` calls for **social media scraping**, **web data extraction**, and **account management**.
-
-> Official docs: `https://docs.brightdata.com/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Scrape social media** - Twitter/X, Reddit, YouTube, Instagram, TikTok, LinkedIn
-- **Extract web data** - Posts, profiles, comments, engagement metrics
-- **Monitor usage** - Track bandwidth and request usage
-- **Manage account** - Check status and zones
-
----
-
-## Prerequisites
-
-Connect the **Bright Data** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name BRIGHTDATA_TOKEN` or `zero doctor check-connector --url https://api.brightdata.com/datasets/v3/trigger --method POST`
+If requests fail, run `zero doctor check-connector --env-name BRIGHTDATA_TOKEN` or `zero doctor check-connector --url https://api.brightdata.com/datasets/v3/trigger --method POST`
 
 ## Social Media Scraping
 
@@ -41,8 +20,6 @@ Bright Data supports scraping these social media platforms:
 | Instagram | ✅ | ✅ | ✅ | ✅ |
 | TikTok | ✅ | ✅ | ✅ | - |
 | LinkedIn | ✅ | ✅ | - | - |
-
----
 
 ## How to Use
 
@@ -75,8 +52,6 @@ curl -s -X POST "https://api.brightdata.com/datasets/v3/trigger?dataset_id=<data
 }
 ```
 
----
-
 ### 2. Trigger Scraping (Synchronous)
 
 Get results immediately in the response (for small requests).
@@ -98,8 +73,6 @@ curl -s -X POST "https://api.brightdata.com/datasets/v3/scrape?dataset_id=<datas
   -d @/tmp/brightdata_request.json
 ```
 
----
-
 ### 3. Monitor Progress
 
 Check the status of a scraping job (replace `<snapshot-id>` with your actual snapshot ID):
@@ -120,8 +93,6 @@ curl -s "https://api.brightdata.com/datasets/v3/progress/<snapshot-id>" \
 
 Status values: `running`, `ready`, `failed`
 
----
-
 ### 4. Download Results
 
 Once status is `ready`, download the collected data (replace `<snapshot-id>` with your actual snapshot ID):
@@ -130,8 +101,6 @@ Once status is `ready`, download the collected data (replace `<snapshot-id>` wit
 curl -s "https://api.brightdata.com/datasets/v3/snapshot/<snapshot-id>?format=json" \
   -H "Authorization: Bearer $BRIGHTDATA_TOKEN"
 ```
-
----
 
 ### 5. List Snapshots
 
@@ -142,8 +111,6 @@ curl -s "https://api.brightdata.com/datasets/v3/snapshots" \
   -H "Authorization: Bearer $BRIGHTDATA_TOKEN" | jq '.[] | {snapshot_id, dataset_id, status}'
 ```
 
----
-
 ### 6. Cancel Snapshot
 
 Cancel a running job (replace `<snapshot-id>` with your actual snapshot ID):
@@ -152,8 +119,6 @@ Cancel a running job (replace `<snapshot-id>` with your actual snapshot ID):
 curl -s -X POST "https://api.brightdata.com/datasets/v3/cancel?snapshot_id=<snapshot-id>" \
   -H "Authorization: Bearer $BRIGHTDATA_TOKEN"
 ```
-
----
 
 ## Platform-Specific Examples
 
@@ -199,8 +164,6 @@ curl -s -X POST "https://api.brightdata.com/datasets/v3/scrape?dataset_id=<datas
 
 **Returns:** `post_id`, `text`, `replies`, `likes`, `retweets`, `views`, `hashtags`, `media`
 
----
-
 ### Reddit - Scrape Subreddit Posts
 
 Write to `/tmp/brightdata_request.json`:
@@ -244,8 +207,6 @@ curl -s -X POST "https://api.brightdata.com/datasets/v3/scrape?dataset_id=<datas
 ```
 
 **Returns:** `comment_id`, `user_posted`, `comment_text`, `upvotes`, `replies`
-
----
 
 ### YouTube - Scrape Video Info
 
@@ -308,8 +269,6 @@ curl -s -X POST "https://api.brightdata.com/datasets/v3/scrape?dataset_id=<datas
 
 **Returns:** `comment_text`, `likes`, `replies`, `username`, `date`
 
----
-
 ### Instagram - Scrape Profile
 
 Write to `/tmp/brightdata_request.json`:
@@ -355,8 +314,6 @@ curl -s -X POST "https://api.brightdata.com/datasets/v3/trigger?dataset_id=<data
   -d @/tmp/brightdata_request.json
 ```
 
----
-
 ## Account Management
 
 ### Check Account Status
@@ -390,8 +347,6 @@ curl -s "https://api.brightdata.com/customer/bw" \
   -H "Authorization: Bearer $BRIGHTDATA_TOKEN"
 ```
 
----
-
 ## Getting Dataset IDs
 
 To use the scraping features, you need a `dataset_id`:
@@ -402,8 +357,6 @@ To use the scraping features, you need a `dataset_id`:
 4. Copy the `dataset_id` from the dataset settings
 
 Dataset IDs can also be found in the bandwidth usage API response under the `data` field keys (e.g., `v__ds_api_gd_xxxxx` where `gd_xxxxx` is your dataset ID).
-
----
 
 ## Common Parameters
 
@@ -417,15 +370,11 @@ Dataset IDs can also be found in the bandwidth usage API response under the `dat
 | `sort_by` | Sort order (Reddit) | `new`, `top`, `hot` |
 | `format` | Response format | `json`, `csv` |
 
----
-
 ## Rate Limits
 
 - Batch mode: up to 100 concurrent requests
 - Maximum input size: 1GB per batch
 - Exceeding limits returns `429` error
-
----
 
 ## Guidelines
 

--- a/browserbase/SKILL.md
+++ b/browserbase/SKILL.md
@@ -4,32 +4,9 @@ description: Browserbase API for headless browser automation. Use when user ment
   "headless browser", "browser automation", or "Browserbase".
 ---
 
-# Browserbase
+## Troubleshooting
 
-Cloud browser infrastructure for AI agents and automation. Create browser sessions, persist authentication with contexts, debug live sessions, and retrieve session recordings.
-
-> Official docs: https://docs.browserbase.com/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Create cloud browser sessions for Playwright/Puppeteer automation
-- Persist login state and cookies across sessions using Contexts
-- Debug browser sessions in real-time with live URLs
-- Retrieve session recordings and logs for debugging
-- Manage browser sessions programmatically (list, get, update)
-- Run browser automation with proxy and stealth support
-
----
-
-## Prerequisites
-
-Connect the **Browserbase** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name BROWSERBASE_TOKEN` or `zero doctor check-connector --url https://api.browserbase.com/v1/sessions --method POST`
+If requests fail, run `zero doctor check-connector --env-name BROWSERBASE_TOKEN` or `zero doctor check-connector --url https://api.browserbase.com/v1/sessions --method POST`
 
 ## How to Use
 
@@ -217,8 +194,6 @@ Upload files to use in a browser session. Replace `<your-session-id>` with the a
 curl -s -X POST "https://api.browserbase.com/v1/sessions/<your-session-id>/uploads" --header "X-BB-API-Key: $BROWSERBASE_TOKEN" -F "file=@/path/to/file.pdf"
 ```
 
----
-
 ## Contexts API
 
 Contexts allow you to persist cookies, cache, and session storage across multiple browser sessions.
@@ -285,8 +260,6 @@ curl -s -X DELETE "https://api.browserbase.com/v1/contexts/<your-context-id>" --
 
 Successful deletion returns HTTP 204 (No Content).
 
----
-
 ## Projects API
 
 ### Get Project Usage
@@ -296,8 +269,6 @@ Retrieve project-wide usage statistics (browser minutes and proxy bytes). Replac
 ```bash
 curl -s -X GET "https://api.browserbase.com/v1/projects/<your-project-id>/usage" --header "X-BB-API-Key: $BROWSERBASE_TOKEN"
 ```
-
----
 
 ## API Endpoints Reference
 
@@ -317,8 +288,6 @@ curl -s -X GET "https://api.browserbase.com/v1/projects/<your-project-id>/usage"
 | `/v1/contexts/{id}` | DELETE | Delete a context |
 | `/v1/projects/{id}/usage` | GET | Get project usage stats |
 
----
-
 ## Session Status Values
 
 | Status | Description |
@@ -328,8 +297,6 @@ curl -s -X GET "https://api.browserbase.com/v1/projects/<your-project-id>/usage"
 | `ERROR` | Session ended with an error |
 | `TIMED_OUT` | Session exceeded timeout |
 | `REQUEST_RELEASE` | Request to end session |
-
----
 
 ## Guidelines
 

--- a/browserless/SKILL.md
+++ b/browserless/SKILL.md
@@ -4,32 +4,9 @@ description: Browserless API for headless Chrome. Use when user mentions "headle
   Chrome", "browserless", or needs browser automation.
 ---
 
-# Browserless
+## Troubleshooting
 
-Headless Chrome browser as a service. Take screenshots, generate PDFs, scrape JS-rendered pages, and run Puppeteer/Playwright scripts without managing browser infrastructure.
-
-> Official docs: https://docs.browserless.io/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Scrape JavaScript-heavy pages (React, Vue, Angular)
-- Take full-page or element screenshots
-- Generate PDFs from web pages
-- Execute custom JavaScript in a browser context
-- Bypass bot detection with stealth mode
-- Run Puppeteer/Playwright scripts in the cloud
-
----
-
-## Prerequisites
-
-Connect the **Browserless** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name BROWSERLESS_TOKEN` or `zero doctor check-connector --url https://production-sfo.browserless.io/scrape --method POST`
+If requests fail, run `zero doctor check-connector --env-name BROWSERLESS_TOKEN` or `zero doctor check-connector --url https://production-sfo.browserless.io/scrape --method POST`
 
 ## How to Use
 
@@ -469,8 +446,6 @@ curl -s -X DELETE "https://production-sfo.browserless.io/e/<encoded-path>/sessio
 }
 ```
 
----
-
 ## API Endpoints
 
 | Endpoint | Method | Description |
@@ -485,8 +460,6 @@ curl -s -X DELETE "https://production-sfo.browserless.io/e/<encoded-path>/sessio
 | `/performance` | POST | Lighthouse audits (a11y, perf, SEO) |
 | `/session` | POST | Create persistent browser session |
 | `/session/{id}` | DELETE | Stop persistent session |
-
----
 
 ## Common Options
 
@@ -531,8 +504,6 @@ Control page navigation:
 }
 ```
 
----
-
 ## Query Parameters
 
 | Parameter | Description |
@@ -541,8 +512,6 @@ Control page navigation:
 | `stealth` | Enable stealth mode (`true`/`false`) |
 | `blockAds` | Block advertisements |
 | `proxy` | Use proxy server |
-
----
 
 ## Response Format
 
@@ -568,8 +537,6 @@ Control page navigation:
   ]
 }
 ```
-
----
 
 ## Guidelines
 

--- a/cal-com/SKILL.md
+++ b/cal-com/SKILL.md
@@ -3,24 +3,9 @@ name: cal-com
 description: Cal.com open-source scheduling API. Use when user mentions "Cal.com", "cal.com", "open source scheduling", "booking", "event types", or asks about interview or meeting scheduling.
 ---
 
-# Cal.com API
+## Troubleshooting
 
-Manage bookings, event types, and availability via the Cal.com REST API v2.
-
-> Official docs: `https://cal.com/docs/api-reference/v2/introduction`
-
-## When to Use
-
-- List event types (meeting formats available for booking)
-- Create, retrieve, or cancel bookings programmatically
-- Check a user's availability for scheduling
-- Integrate booking flows into your own application
-
-## Prerequisites
-
-Connect the **Cal.com** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CALCOM_TOKEN` or `zero doctor check-connector --url https://api.cal.com/v2/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name CALCOM_TOKEN` or `zero doctor check-connector --url https://api.cal.com/v2/me --method GET`
 
 ## Core APIs
 
@@ -30,15 +15,11 @@ Connect the **Cal.com** connector at [app.vm0.ai/connectors](https://app.vm0.ai/
 curl -s "https://api.cal.com/v2/me" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '{id, email, name, username, timeZone}'
 ```
 
----
-
 ### List Event Types
 
 ```bash
 curl -s "https://api.cal.com/v2/event-types" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '[.data[] | {id, title, slug, length, hidden}]'
 ```
-
----
 
 ### Get Event Type
 
@@ -48,8 +29,6 @@ Replace `<event-type-id>` with the numeric ID from the list above:
 curl -s "https://api.cal.com/v2/event-types/<event-type-id>" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '.data | {id, title, length, description, locations}'
 ```
 
----
-
 ### Get Availability
 
 Check available slots for an event type. Replace `<username>` and `<event-type-slug>` with actual values. Dates in `YYYY-MM-DD` format:
@@ -57,8 +36,6 @@ Check available slots for an event type. Replace `<username>` and `<event-type-s
 ```bash
 curl -s "https://api.cal.com/v2/slots/available?username=<username>&eventTypeSlug=<event-type-slug>&startTime=2025-01-15&endTime=2025-01-22&timeZone=America/New_York" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '{slots: [.data.slots | to_entries[] | {date: .key, times: [.value[] | .time]}] | .[0:3]}'
 ```
-
----
 
 ### Create Booking
 
@@ -86,15 +63,11 @@ curl -s -X POST "https://api.cal.com/v2/bookings" --header "Authorization: Beare
 
 Docs: https://cal.com/docs/api-reference/v2/bookings/create-a-booking
 
----
-
 ### List Bookings
 
 ```bash
 curl -s "https://api.cal.com/v2/bookings?take=20" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '[.data[] | {uid, status, title, start, end, attendeeName: .attendees[0].name}]'
 ```
-
----
 
 ### Get Booking
 
@@ -103,8 +76,6 @@ Replace `<booking-uid>` with the booking UID from the list above:
 ```bash
 curl -s "https://api.cal.com/v2/bookings/<booking-uid>" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '{uid, status, title, start, end, attendees}'
 ```
-
----
 
 ### Cancel Booking
 
@@ -122,8 +93,6 @@ Write to `/tmp/calcom_request.json`:
 curl -s -X DELETE "https://api.cal.com/v2/bookings/<booking-uid>/cancel" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" --header "Content-Type: application/json" -d @/tmp/calcom_request.json | jq '{status}'
 ```
 
----
-
 ### Reschedule Booking
 
 Replace `<booking-uid>` with the booking UID.
@@ -140,8 +109,6 @@ Write to `/tmp/calcom_request.json`:
 ```bash
 curl -s -X POST "https://api.cal.com/v2/bookings/<booking-uid>/reschedule" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" --header "Content-Type: application/json" -d @/tmp/calcom_request.json | jq '{uid, status, start, end}'
 ```
-
----
 
 ## Guidelines
 

--- a/calendly/SKILL.md
+++ b/calendly/SKILL.md
@@ -3,25 +3,9 @@ name: calendly
 description: Calendly scheduling API. Use when user mentions "Calendly", "calendly.com", "schedule a meeting", "booking link", "event types", or asks about interview scheduling.
 ---
 
-# Calendly API
+## Troubleshooting
 
-Read scheduling data, list event types, retrieve scheduled meetings, and access invitee information via the Calendly API v2.
-
-> Official docs: `https://developer.calendly.com/api-docs/`
-
-## When to Use
-
-- List available event types (e.g., 30-min intro call, 60-min interview)
-- Retrieve scheduled meetings for a user or organization
-- Get invitee details for a specific event
-- Set up webhook subscriptions to receive real-time booking notifications
-- Look up user and organization details
-
-## Prerequisites
-
-Connect the **Calendly** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CALENDLY_TOKEN` or `zero doctor check-connector --url https://api.calendly.com/users/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name CALENDLY_TOKEN` or `zero doctor check-connector --url https://api.calendly.com/users/me --method GET`
 
 ## Core APIs
 
@@ -33,8 +17,6 @@ Returns the authenticated user's URI and organization URI — needed for subsequ
 curl -s "https://api.calendly.com/users/me" --header "Authorization: Bearer $CALENDLY_TOKEN" | jq '{uri, name, email, organization: .current_organization}'
 ```
 
----
-
 ### List Event Types
 
 List all event types for the current user. First get your user URI from the step above.
@@ -45,8 +27,6 @@ Replace `<user-uri>` with the full URI from `GET /users/me` (e.g., `https://api.
 curl -s "https://api.calendly.com/event_types?user=<user-uri>" --header "Authorization: Bearer $CALENDLY_TOKEN" | jq '[.collection[] | {uri, name, duration, active, scheduling_url}]'
 ```
 
----
-
 ### List Scheduled Events
 
 List upcoming scheduled events for a user. Replace `<user-uri>` with your user URI:
@@ -54,8 +34,6 @@ List upcoming scheduled events for a user. Replace `<user-uri>` with your user U
 ```bash
 curl -s "https://api.calendly.com/scheduled_events?user=<user-uri>&status=active&count=20" --header "Authorization: Bearer $CALENDLY_TOKEN" | jq '[.collection[] | {uri, name, status, start_time, end_time, location: .location.type}]'
 ```
-
----
 
 ### List Past Scheduled Events
 
@@ -65,8 +43,6 @@ Replace `<user-uri>` with your user URI:
 curl -s "https://api.calendly.com/scheduled_events?user=<user-uri>&status=canceled&count=20" --header "Authorization: Bearer $CALENDLY_TOKEN" | jq '[.collection[] | {uri, name, status, start_time}]'
 ```
 
----
-
 ### Get a Scheduled Event
 
 Replace `<event-uuid>` with the UUID portion from a scheduled event URI:
@@ -75,8 +51,6 @@ Replace `<event-uuid>` with the UUID portion from a scheduled event URI:
 curl -s "https://api.calendly.com/scheduled_events/<event-uuid>" --header "Authorization: Bearer $CALENDLY_TOKEN" | jq '{uri, name, status, start_time, end_time, invitees_counter}'
 ```
 
----
-
 ### List Invitees for an Event
 
 Get all invitees (attendees) for a specific scheduled event. Replace `<event-uuid>`:
@@ -84,8 +58,6 @@ Get all invitees (attendees) for a specific scheduled event. Replace `<event-uui
 ```bash
 curl -s "https://api.calendly.com/scheduled_events/<event-uuid>/invitees" --header "Authorization: Bearer $CALENDLY_TOKEN" | jq '[.collection[] | {uri, name, email, status, created_at}]'
 ```
-
----
 
 ### Create Webhook Subscription
 
@@ -106,15 +78,11 @@ Write to `/tmp/calendly_request.json`:
 curl -s -X POST "https://api.calendly.com/webhook_subscriptions" --header "Authorization: Bearer $CALENDLY_TOKEN" --header "Content-Type: application/json" -d @/tmp/calendly_request.json | jq '{uri, callback_url: .resource.callback_url, events: .resource.events}'
 ```
 
----
-
 ### List Webhook Subscriptions
 
 ```bash
 curl -s "https://api.calendly.com/webhook_subscriptions?organization=<organization-uri>&scope=organization" --header "Authorization: Bearer $CALENDLY_TOKEN" | jq '[.collection[] | {uri, callback_url, events, state}]'
 ```
-
----
 
 ### Delete Webhook Subscription
 
@@ -123,8 +91,6 @@ Replace `<webhook-uuid>` with the UUID from the webhook URI:
 ```bash
 curl -s -X DELETE "https://api.calendly.com/webhook_subscriptions/<webhook-uuid>" --header "Authorization: Bearer $CALENDLY_TOKEN" -w "\nHTTP Status: %{http_code}\n"
 ```
-
----
 
 ## Guidelines
 

--- a/campaign-strategy/SKILL.md
+++ b/campaign-strategy/SKILL.md
@@ -3,14 +3,6 @@ name: campaign-strategy
 description: Plan and structure marketing campaigns — set objectives, segment audiences, choose channels, build content calendars, allocate budgets, and define KPIs. Trigger on requests for campaign planning, product launch strategy, go-to-market plans, content scheduling, media mix decisions, campaign briefs, or marketing budget allocation.
 ---
 
-# Campaign Strategy
-
-Structured approaches for designing, organizing, and executing marketing campaigns from initial goals through measurement.
-
-## Prerequisites
-
-Connect the **Campaign Strategy** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Five-Part Campaign Architecture
 
 Every campaign rests on five pillars: Goal, Audience, Narrative, Distribution, and Measurement.

--- a/canva/SKILL.md
+++ b/canva/SKILL.md
@@ -4,41 +4,15 @@ description: Canva API for design creation. Use when user mentions "Canva", "cre
   design", "Canva template", or asks about design graphics.
 ---
 
-# Canva API
+## Troubleshooting
 
-Use the Canva Connect API via direct `curl` calls to manage **designs, folders, assets, and comments**.
-
-> Official docs: `https://www.canva.dev/docs/connect/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **List and search designs** in a Canva account
-- **Create new designs** (documents, presentations, whiteboards, or custom sizes)
-- **Export designs** as PDF, PNG, JPG, or other formats
-- **Upload assets** (images, videos) to Canva
-- **Manage folders** and organize designs
-- **Add comments** to designs for collaboration
-- **Get user profile** information
-
----
-
-## Prerequisites
-
-Connect the **Canva** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CANVA_TOKEN` or `zero doctor check-connector --url https://api.canva.com/rest/v1/users/me/profile --method GET`
+If requests fail, run `zero doctor check-connector --env-name CANVA_TOKEN` or `zero doctor check-connector --url https://api.canva.com/rest/v1/users/me/profile --method GET`
 
 ## How to Use
 
 All examples below assume you have `CANVA_TOKEN` set.
 
 Base URL: `https://api.canva.com/rest/v1`
-
----
 
 ### 1. Get Current User Profile
 
@@ -47,8 +21,6 @@ Get your user profile information:
 ```bash
 curl -s "https://api.canva.com/rest/v1/users/me/profile" --header "Authorization: Bearer $CANVA_TOKEN" | jq '.profile'
 ```
-
----
 
 ### 2. List Designs
 
@@ -66,8 +38,6 @@ curl -s "https://api.canva.com/rest/v1/designs?query=marketing&limit=10" --heade
 
 Save a design ID from the results for use in subsequent commands.
 
----
-
 ### 3. Get Design Details
 
 Get metadata for a specific design. Replace `<design-id>` with an actual design ID:
@@ -75,8 +45,6 @@ Get metadata for a specific design. Replace `<design-id>` with an actual design 
 ```bash
 curl -s "https://api.canva.com/rest/v1/designs/<design-id>" --header "Authorization: Bearer $CANVA_TOKEN" | jq '.design | {id, title, owner, urls, created_at, updated_at, page_count}'
 ```
-
----
 
 ### 4. Create a New Design
 
@@ -123,8 +91,6 @@ Then run:
 curl -s -X POST "https://api.canva.com/rest/v1/designs" --header "Authorization: Bearer $CANVA_TOKEN" --header "Content-Type: application/json" -d @/tmp/canva_request.json | jq '.design | {id, title, urls}'
 ```
 
----
-
 ### 5. Export Design as PDF
 
 Export a design as PDF. Replace `<design-id>` with an actual design ID:
@@ -155,8 +121,6 @@ curl -s "https://api.canva.com/rest/v1/exports/<export-id>" --header "Authorizat
 
 When status is `success`, download URLs are valid for 24 hours.
 
----
-
 ### 6. Export Design as PNG
 
 Export a design as PNG. Replace `<design-id>` with an actual design ID:
@@ -182,8 +146,6 @@ curl -s -X POST "https://api.canva.com/rest/v1/exports" --header "Authorization:
 
 Poll with the same export status endpoint as above.
 
----
-
 ### 7. List Design Pages
 
 Get all pages of a design. Replace `<design-id>` with an actual design ID:
@@ -191,8 +153,6 @@ Get all pages of a design. Replace `<design-id>` with an actual design ID:
 ```bash
 curl -s "https://api.canva.com/rest/v1/designs/<design-id>/pages" --header "Authorization: Bearer $CANVA_TOKEN" | jq '.items[] | {index: .index, title: .title, width: .width, height: .height}'
 ```
-
----
 
 ### 8. Create a Folder
 
@@ -213,8 +173,6 @@ Then run:
 curl -s -X POST "https://api.canva.com/rest/v1/folders" --header "Authorization: Bearer $CANVA_TOKEN" --header "Content-Type: application/json" -d @/tmp/canva_request.json | jq '.folder | {id, name}'
 ```
 
----
-
 ### 9. List Folder Items
 
 List items in a folder. Replace `<folder-id>` with an actual folder ID:
@@ -222,8 +180,6 @@ List items in a folder. Replace `<folder-id>` with an actual folder ID:
 ```bash
 curl -s "https://api.canva.com/rest/v1/folders/<folder-id>/items?limit=20" --header "Authorization: Bearer $CANVA_TOKEN" | jq '.items[] | {type, id: .design.id // .folder.id, name: .design.title // .folder.name}'
 ```
-
----
 
 ### 10. Move Item to Folder
 
@@ -246,8 +202,6 @@ Then run:
 curl -s -X POST "https://api.canva.com/rest/v1/folders/move" --header "Authorization: Bearer $CANVA_TOKEN" --header "Content-Type: application/json" -d @/tmp/canva_request.json
 ```
 
----
-
 ### 11. Get Asset Details
 
 Get metadata for an uploaded asset. Replace `<asset-id>` with an actual asset ID:
@@ -255,8 +209,6 @@ Get metadata for an uploaded asset. Replace `<asset-id>` with an actual asset ID
 ```bash
 curl -s "https://api.canva.com/rest/v1/assets/<asset-id>" --header "Authorization: Bearer $CANVA_TOKEN" | jq '.asset | {id, name, tags, created_at, updated_at, thumbnail}'
 ```
-
----
 
 ### 12. Update Asset
 
@@ -277,8 +229,6 @@ Then run:
 curl -s -X PATCH "https://api.canva.com/rest/v1/assets/<asset-id>" --header "Authorization: Bearer $CANVA_TOKEN" --header "Content-Type: application/json" -d @/tmp/canva_request.json | jq '.asset | {id, name, tags}'
 ```
 
----
-
 ### 13. Delete Asset
 
 Delete an asset (moves to trash). Replace `<asset-id>` with an actual asset ID:
@@ -286,8 +236,6 @@ Delete an asset (moves to trash). Replace `<asset-id>` with an actual asset ID:
 ```bash
 curl -s -X DELETE "https://api.canva.com/rest/v1/assets/<asset-id>" --header "Authorization: Bearer $CANVA_TOKEN"
 ```
-
----
 
 ### 14. Create Comment Thread
 
@@ -310,8 +258,6 @@ Then run:
 curl -s -X POST "https://api.canva.com/rest/v1/designs/<design-id>/comments" --header "Authorization: Bearer $CANVA_TOKEN" --header "Content-Type: application/json" -d @/tmp/canva_request.json | jq '.thread | {id, message}'
 ```
 
----
-
 ### 15. Reply to Comment Thread
 
 Reply to an existing comment thread. Replace `<design-id>` and `<thread-id>`:
@@ -330,8 +276,6 @@ Then run:
 curl -s -X POST "https://api.canva.com/rest/v1/designs/<design-id>/comments/<thread-id>/replies" --header "Authorization: Bearer $CANVA_TOKEN" --header "Content-Type: application/json" -d @/tmp/canva_request.json | jq '.reply | {id, message}'
 ```
 
----
-
 ### 16. List Brand Templates
 
 List available brand templates (requires Canva Enterprise):
@@ -339,8 +283,6 @@ List available brand templates (requires Canva Enterprise):
 ```bash
 curl -s "https://api.canva.com/rest/v1/brand-templates?limit=20" --header "Authorization: Bearer $CANVA_TOKEN" | jq '.items[] | {id, title, created_at}'
 ```
-
----
 
 ## Guidelines
 

--- a/chatwoot/SKILL.md
+++ b/chatwoot/SKILL.md
@@ -4,37 +4,13 @@ description: Chatwoot API for customer support. Use when user mentions "Chatwoot
   "conversations", "support chat", or customer messaging.
 ---
 
-# Chatwoot
+## Troubleshooting
 
-Use Chatwoot via direct `curl` calls to **manage customer support** across multiple channels (website, email, WhatsApp, etc.).
-
-> Official docs: `https://developers.chatwoot.com/api-reference/introduction`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage contacts** - create, search, and update customer profiles
-- **Handle conversations** - create, assign, and track support conversations
-- **Send messages** - reply to customers or add internal notes
-- **List agents** - get support team information
-- **Automate workflows** - integrate with CRM, ticketing, or notification systems
-
----
-
-## Prerequisites
-
-Connect the **Chatwoot** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CHATWOOT_TOKEN` or `zero doctor check-connector --url https://app.chatwoot.com/api/v1/profile --method GET`
+If requests fail, run `zero doctor check-connector --env-name CHATWOOT_TOKEN` or `zero doctor check-connector --url https://app.chatwoot.com/api/v1/profile --method GET`
 
 ## How to Use
 
 All examples use the **Application API** with user access token.
-
----
 
 ### 1. Create a Contact
 
@@ -62,8 +38,6 @@ Then run:
 curl -s -X POST "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/contacts" -H "api_access_token: $CHATWOOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/chatwoot_request.json
 ```
 
----
-
 ### 2. Search Contacts
 
 Search contacts by email, phone, or name:
@@ -72,8 +46,6 @@ Search contacts by email, phone, or name:
 curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/contacts/search?q=john@example.com" -H "api_access_token: $CHATWOOT_TOKEN" | jq '.payload[] | {id, name, email}'
 ```
 
----
-
 ### 3. Get Contact Details
 
 Get a specific contact by ID. Replace `<contact-id>` with the actual contact ID from the "Search Contacts" or "Create a Contact" response:
@@ -81,8 +53,6 @@ Get a specific contact by ID. Replace `<contact-id>` with the actual contact ID 
 ```bash
 curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/contacts/<contact-id>" -H "api_access_token: $CHATWOOT_TOKEN"
 ```
-
----
 
 ### 4. Create a Conversation
 
@@ -108,8 +78,6 @@ Then run:
 curl -s -X POST "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations" -H "api_access_token: $CHATWOOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/chatwoot_request.json
 ```
 
----
-
 ### 5. List Conversations
 
 Get all conversations with optional filters:
@@ -119,8 +87,6 @@ Get all conversations with optional filters:
 curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations?status=open" -H "api_access_token: $CHATWOOT_TOKEN" | jq '.data.payload[] | {id, status, contact: .meta.sender.name}'
 ```
 
----
-
 ### 6. Get Conversation Details
 
 Get details of a specific conversation. Replace `<conversation-id>` with the actual conversation ID from the "List Conversations" or "Create a Conversation" response:
@@ -128,8 +94,6 @@ Get details of a specific conversation. Replace `<conversation-id>` with the act
 ```bash
 curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations/<conversation-id>" -H "api_access_token: $CHATWOOT_TOKEN"
 ```
-
----
 
 ### 7. Send a Message
 
@@ -151,8 +115,6 @@ Then run:
 curl -s -X POST "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations/<conversation-id>/messages" -H "api_access_token: $CHATWOOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/chatwoot_request.json
 ```
 
----
-
 ### 8. Add Private Note
 
 Add an internal note (not visible to customer). Replace `<conversation-id>` with the actual conversation ID from the "List Conversations" response:
@@ -173,8 +135,6 @@ Then run:
 curl -s -X POST "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations/<conversation-id>/messages" -H "api_access_token: $CHATWOOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/chatwoot_request.json
 ```
 
----
-
 ### 9. Assign Conversation
 
 Assign a conversation to an agent. Replace `<conversation-id>` with the actual conversation ID and `<agent-id>` with the agent ID from the "List Agents" response:
@@ -192,8 +152,6 @@ Then run:
 ```bash
 curl -s -X POST "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations/<conversation-id>/assignments" -H "api_access_token: $CHATWOOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/chatwoot_request.json
 ```
-
----
 
 ### 10. Update Conversation Status
 
@@ -213,8 +171,6 @@ Then run:
 curl -s -X POST "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations/<conversation-id>/toggle_status" -H "api_access_token: $CHATWOOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/chatwoot_request.json
 ```
 
----
-
 ### 11. List Agents
 
 Get all agents in the account:
@@ -222,8 +178,6 @@ Get all agents in the account:
 ```bash
 curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/agents" -H "api_access_token: $CHATWOOT_TOKEN" | jq '.[] | {id, name, email, role, availability_status}'
 ```
-
----
 
 ### 12. List Inboxes
 
@@ -233,8 +187,6 @@ Get all inboxes (channels) in the account:
 curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/inboxes" -H "api_access_token: $CHATWOOT_TOKEN" | jq '.payload[] | {id, name, channel_type}'
 ```
 
----
-
 ### 13. Get Conversation Counts
 
 Get counts by status for dashboard:
@@ -242,8 +194,6 @@ Get counts by status for dashboard:
 ```bash
 curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/conversations/meta" -H "api_access_token: $CHATWOOT_TOKEN" | jq '.meta.all_count, .meta.mine_count'
 ```
-
----
 
 ## Conversation Status
 
@@ -254,8 +204,6 @@ curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/co
 | `pending` | Waiting for response |
 | `snoozed` | Temporarily paused |
 
----
-
 ## Message Types
 
 | Type | Value | Description |
@@ -263,8 +211,6 @@ curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/co
 | Outgoing | `outgoing` | Agent to customer |
 | Incoming | `incoming` | Customer to agent |
 | Private | `private: true` | Internal note (not visible to customer) |
-
----
 
 ## Response Fields
 
@@ -295,8 +241,6 @@ curl -s -X GET "https://app.chatwoot.com/api/v1/accounts/$CHATWOOT_ACCOUNT_ID/co
 | `message_type` | incoming/outgoing |
 | `private` | Is internal note |
 | `status` | sent/delivered/read/failed |
-
----
 
 ## Guidelines
 

--- a/clickup/SKILL.md
+++ b/clickup/SKILL.md
@@ -4,33 +4,9 @@ description: ClickUp API for tasks and spaces. Use when user mentions "ClickUp",
   shares a ClickUp link, "ClickUp task", or asks about ClickUp workspace.
 ---
 
-# ClickUp API
+## Troubleshooting
 
-Manage tasks, lists, folders, spaces, and workspaces in ClickUp via the REST API.
-
-> Official docs: `https://developer.clickup.com/reference`
-
----
-
-## Prerequisites
-
-Connect the **ClickUp** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CLICKUP_TOKEN` or `zero doctor check-connector --url https://api.clickup.com/api/v2/user --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- List workspaces, spaces, folders, and lists
-- Create, update, delete, and search tasks
-- Manage comments on tasks
-- Track time entries for tasks
-- Organize work with tags and custom fields
-
----
-
----
+If requests fail, run `zero doctor check-connector --env-name CLICKUP_TOKEN` or `zero doctor check-connector --url https://api.clickup.com/api/v2/user --method GET`
 
 ## How to Use
 
@@ -39,8 +15,6 @@ All examples below assume you have `CLICKUP_TOKEN` set.
 Base URL: `https://api.clickup.com/api/v2`
 
 ClickUp uses numeric IDs for all resources. The hierarchy is: Workspace (team) > Space > Folder > List > Task.
-
----
 
 ## User & Workspaces
 
@@ -55,8 +29,6 @@ curl -s "https://api.clickup.com/api/v2/user" --header "Authorization: Bearer $C
 ```bash
 curl -s "https://api.clickup.com/api/v2/team" --header "Authorization: Bearer $CLICKUP_TOKEN" | jq '.teams[] | {id, name}'
 ```
-
----
 
 ## Spaces
 
@@ -96,8 +68,6 @@ curl -s -X POST "https://api.clickup.com/api/v2/team/<team_id>/space" --header "
 ```bash
 curl -s -X DELETE "https://api.clickup.com/api/v2/space/<space_id>" --header "Authorization: Bearer $CLICKUP_TOKEN"
 ```
-
----
 
 ## Folders
 
@@ -140,8 +110,6 @@ curl -s -X PUT "https://api.clickup.com/api/v2/folder/<folder_id>" --header "Aut
 ```bash
 curl -s -X DELETE "https://api.clickup.com/api/v2/folder/<folder_id>" --header "Authorization: Bearer $CLICKUP_TOKEN"
 ```
-
----
 
 ## Lists
 
@@ -192,8 +160,6 @@ curl -s -X PUT "https://api.clickup.com/api/v2/list/<list_id>" --header "Authori
 ```bash
 curl -s -X DELETE "https://api.clickup.com/api/v2/list/<list_id>" --header "Authorization: Bearer $CLICKUP_TOKEN"
 ```
-
----
 
 ## Tasks
 
@@ -275,8 +241,6 @@ curl -s -X DELETE "https://api.clickup.com/api/v2/task/<task_id>" --header "Auth
 curl -s "https://api.clickup.com/api/v2/team/<team_id>/task?statuses[]=to%20do&statuses[]=in%20progress&assignees[]=<user_id>&page=0" --header "Authorization: Bearer $CLICKUP_TOKEN" | jq '.tasks[] | {id, name, status: .status.status}'
 ```
 
----
-
 ## Comments
 
 ### List Task Comments
@@ -319,8 +283,6 @@ curl -s -X PUT "https://api.clickup.com/api/v2/comment/<comment_id>" --header "A
 curl -s -X DELETE "https://api.clickup.com/api/v2/comment/<comment_id>" --header "Authorization: Bearer $CLICKUP_TOKEN"
 ```
 
----
-
 ## Time Tracking
 
 ### List Time Entries
@@ -352,8 +314,6 @@ curl -s -X POST "https://api.clickup.com/api/v2/team/<team_id>/time_entries" --h
 curl -s -X DELETE "https://api.clickup.com/api/v2/team/<team_id>/time_entries/<timer_id>" --header "Authorization: Bearer $CLICKUP_TOKEN"
 ```
 
----
-
 ## Tags
 
 ### List Space Tags
@@ -373,8 +333,6 @@ curl -s -X POST "https://api.clickup.com/api/v2/task/<task_id>/tag/<tag_name>" -
 ```bash
 curl -s -X DELETE "https://api.clickup.com/api/v2/task/<task_id>/tag/<tag_name>" --header "Authorization: Bearer $CLICKUP_TOKEN"
 ```
-
----
 
 ## Guidelines
 

--- a/close/SKILL.md
+++ b/close/SKILL.md
@@ -4,26 +4,9 @@ description: Close CRM API for sales management. Use when user mentions "Close C
   "Close.io", "sales leads", or asks about sales pipeline.
 ---
 
-# Close CRM API
+## Troubleshooting
 
-Manage leads, contacts, opportunities, tasks, and activities in Close CRM.
-
-> Official docs: `https://developer.close.com/`
-
-## Prerequisites
-
-Connect the **Close** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CLOSE_TOKEN` or `zero doctor check-connector --url https://api.close.com/api/v1/me/ --method GET`
-
-## When to Use
-
-- List, search, create, update, and delete leads
-- Manage contacts within leads
-- Track opportunities (deals) and their statuses
-- Create and manage tasks
-- View activities (calls, emails, notes, meetings)
-- Get current user and organization info
+If requests fail, run `zero doctor check-connector --env-name CLOSE_TOKEN` or `zero doctor check-connector --url https://api.close.com/api/v1/me/ --method GET`
 
 ## Core APIs
 

--- a/cloudflare-tunnel/SKILL.md
+++ b/cloudflare-tunnel/SKILL.md
@@ -4,21 +4,6 @@ description: Cloudflare Tunnel API for secure tunnels. Use when user mentions "C
   tunnel", "argo tunnel", or secure connectivity.
 ---
 
-# Cloudflare Tunnel / Access Authentication
-
-Authenticate HTTP requests to services protected by Cloudflare Access using Service Token headers.
-
-## When to Use
-
-- Access internal services exposed via Cloudflare Tunnel
-- Authenticate to Cloudflare Zero Trust protected applications
-- Make API calls to services behind Cloudflare Access
-- Bypass Cloudflare Access login page for automated requests
-
-## Prerequisites
-
-Connect the **Cloudflare Tunnel / Access Authentication** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Usage
 
 ### Basic curl Request
@@ -94,8 +79,6 @@ curl -k -s \
   -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
   "https://your-protected-service.example.com/api/endpoint"
 ```
-
----
 
 ## Required Headers
 

--- a/cloudflare/SKILL.md
+++ b/cloudflare/SKILL.md
@@ -4,32 +4,9 @@ description: Cloudflare API for DNS and zone management. Use when user mentions 
   "DNS record", "zone", or "CDN settings".
 ---
 
-# Cloudflare
+## Troubleshooting
 
-Cloudflare provides a comprehensive platform for DNS management, CDN, security, serverless computing (Workers), object storage (R2), and more. Use the REST API to manage zones, DNS records, Workers scripts, KV namespaces, R2 buckets, and firewall rules programmatically.
-
-> Official docs: `https://developers.cloudflare.com/api/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Manage DNS records (create, update, delete A, AAAA, CNAME, MX, TXT records)
-- List and configure zones and zone settings
-- Deploy and manage Workers scripts
-- Manage R2 object storage buckets
-- Configure firewall rules and security settings
-- Query analytics and logs
-
----
-
-## Prerequisites
-
-Connect the **Cloudflare** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CLOUDFLARE_TOKEN` or `zero doctor check-connector --url https://api.cloudflare.com/client/v4/user/tokens/verify --method GET`
+If requests fail, run `zero doctor check-connector --env-name CLOUDFLARE_TOKEN` or `zero doctor check-connector --url https://api.cloudflare.com/client/v4/user/tokens/verify --method GET`
 
 ## How to Use
 
@@ -153,8 +130,6 @@ curl -s "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/firewall
 curl -s "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/analytics/dashboard?since=-1440&continuous=true" --header "Authorization: Bearer $CLOUDFLARE_TOKEN" | jq .
 ```
 
----
-
 ## Common DNS Record Types
 
 | Type | Purpose | Example Content |
@@ -166,8 +141,6 @@ curl -s "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/analytic
 | **TXT** | Text record (SPF, DKIM, etc.) | `v=spf1 include:_spf.google.com ~all` |
 | **NS** | Name server | `ns1.example.com` |
 | **SRV** | Service locator | Service-specific format |
-
----
 
 ## Guidelines
 

--- a/cloudinary/SKILL.md
+++ b/cloudinary/SKILL.md
@@ -4,24 +4,9 @@ description: Cloudinary API for image/video management. Use when user mentions "
   "upload image", "transform image", or media assets.
 ---
 
-# Cloudinary Media Hosting
+## Troubleshooting
 
-Cloudinary provides image and video hosting with CDN delivery, automatic optimization, and on-the-fly transformations.
-
-## When to Use
-
-- Upload images with automatic optimization
-- Upload videos with CDN delivery
-- Get CDN-delivered media URLs
-- Apply transformations (resize, crop, format conversion)
-- Concatenate/splice multiple videos
-- Host media for production applications
-
-## Prerequisites
-
-Connect the **Cloudinary Media Hosting** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CLOUDINARY_TOKEN` or `zero doctor check-connector --url https://api.cloudinary.com/v1_1/your-cloud-name/image/upload --method POST`
+If requests fail, run `zero doctor check-connector --env-name CLOUDINARY_TOKEN` or `zero doctor check-connector --url https://api.cloudinary.com/v1_1/your-cloud-name/image/upload --method POST`
 
 ## How to Use
 

--- a/competitor-matrix/SKILL.md
+++ b/competitor-matrix/SKILL.md
@@ -3,14 +3,6 @@ name: competitor-matrix
 description: Conduct competitive analysis with feature comparison matrices, positioning teardowns, win/loss evaluation, and market trend assessment. Activate when researching competitors, building a feature comparison table, evaluating competitive positioning, preparing a competitive brief, analyzing win/loss patterns, mapping the competitive landscape, or assessing market threats and opportunities.
 ---
 
-# Competitor Matrix Skill
-
-You are a competitive intelligence specialist for product teams. You help product managers map competitive landscapes, construct rigorous feature comparisons, decode rival positioning strategies, extract patterns from deal outcomes, and translate market trends into product strategy decisions.
-
-## Prerequisites
-
-Connect the **Competitor Matrix** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Mapping the Competitive Landscape
 
 ### Defining the Competitor Set

--- a/computer/SKILL.md
+++ b/computer/SKILL.md
@@ -5,20 +5,6 @@ description: Computer connector for exposing local services to remote sandboxes 
   "ngrok", "expose local", or needs to bridge local services to a sandbox.
 ---
 
-# Computer Connector
-
-Expose local services to remote sandboxes via authenticated ngrok tunnels.
-
-## When to Use
-
-- Bridge a local development server to a remote sandbox
-- Expose local ports through a secure tunnel
-- Connect sandbox environments to on-premise services
-
-
-## Prerequisites
-
-Connect the **Computer Connector** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
 ## Environment Variables
 
 - `COMPUTER_CONNECTOR_BRIDGE_TOKEN` — Authentication token for the ngrok bridge

--- a/contract-redline/SKILL.md
+++ b/contract-redline/SKILL.md
@@ -3,14 +3,6 @@ name: contract-redline
 description: Analyze commercial agreements clause-by-clause against organizational playbooks, flag deviations by severity, and produce ready-to-send redline markup with fallback positions. Use for vendor contracts, SaaS agreements, procurement terms, customer agreements, license deals, partnership contracts, or any negotiation where you need clause analysis, deviation scoring, and suggested contract language.
 ---
 
-# Contract Redline Skill
-
-You function as the redlining arm of an in-house legal department. Your job is to dissect commercial agreements against the organization's established negotiation standards, surface departures from those standards, rate each departure, and deliver precise replacement language that counsel can paste directly into a markup.
-
-## Prerequisites
-
-Connect the **Contract Redline** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Pre-Review Setup
 
 ### Organizational Playbook

--- a/copywriting/SKILL.md
+++ b/copywriting/SKILL.md
@@ -3,14 +3,6 @@ name: copywriting
 description: Write and edit marketing copy for any channel — blogs, emails, social posts, landing pages, press releases, case studies, ads, and web pages. Trigger on requests for drafting content, writing headlines, crafting CTAs, SEO copywriting, email subject lines, social captions, or any persuasive marketing text.
 ---
 
-# Copywriting
-
-Principles, structures, and techniques for producing high-performing marketing copy across every major channel.
-
-## Prerequisites
-
-Connect the **Copywriting** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Channel Formats and Anatomy
 
 ### Blog Articles

--- a/cronlytic/SKILL.md
+++ b/cronlytic/SKILL.md
@@ -4,35 +4,11 @@ description: Cronlytic API for cron job monitoring. Use when user mentions "cron
   "scheduled task monitoring", or "Cronlytic".
 ---
 
-# Cronlytic
+## Troubleshooting
 
-Use Cronlytic via direct `curl` calls to **schedule and manage cron jobs** that trigger HTTP requests/webhooks.
-
-> Official docs: `https://www.cronlytic.com/api-documentation`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Schedule recurring HTTP requests** (webhooks, API calls)
-- **Automate background tasks** without managing servers
-- **Create cron jobs** with standard 5-field expressions
-- **Pause/resume jobs** dynamically
-- **Monitor job execution** via logs
-
----
-
-## Prerequisites
-
-Connect the **Cronlytic** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CRONLYTIC_API_KEY` or `zero doctor check-connector --url https://api.cronlytic.com/prog/ping --method GET`
+If requests fail, run `zero doctor check-connector --env-name CRONLYTIC_API_KEY` or `zero doctor check-connector --url https://api.cronlytic.com/prog/ping --method GET`
 
 ## How to Use
-
----
 
 ### 1. Health Check (Ping)
 
@@ -43,8 +19,6 @@ curl -s -X GET "https://api.cronlytic.com/prog/ping"
 ```
 
 Response: `{"message": "pong"}`
-
----
 
 ### 2. Create a Cron Job
 
@@ -69,8 +43,6 @@ Then run:
 curl -s -X POST "https://api.cronlytic.com/prog/jobs" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID" -H "Content-Type: application/json" -d @/tmp/cronlytic_request.json | jq '{job_id, name, status, next_run_at}'
 ```
 
----
-
 ### 3. Create GET Request Job
 
 Simple health check every 5 minutes.
@@ -94,8 +66,6 @@ Then run:
 curl -s -X POST "https://api.cronlytic.com/prog/jobs" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID" -H "Content-Type: application/json" -d @/tmp/cronlytic_request.json | jq '{name, status}'
 ```
 
----
-
 ### 4. List All Jobs
 
 Get all your scheduled jobs:
@@ -103,8 +73,6 @@ Get all your scheduled jobs:
 ```bash
 curl -s -X GET "https://api.cronlytic.com/prog/jobs" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID" | jq '.[] | {job_id, name, status, cron_expression, next_run_at}'
 ```
-
----
 
 ### 5. Update a Job
 
@@ -129,8 +97,6 @@ Then run:
 curl -s -X PUT "https://api.cronlytic.com/prog/jobs/<your-job-id>" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID" -H "Content-Type: application/json" -d @/tmp/cronlytic_request.json | jq '{job_id, name, status, next_run_at}'
 ```
 
----
-
 ### 6. Pause a Job
 
 Stop a job from executing. Replace `<your-job-id>` with the actual job ID:
@@ -138,8 +104,6 @@ Stop a job from executing. Replace `<your-job-id>` with the actual job ID:
 ```bash
 curl -s -X POST "https://api.cronlytic.com/prog/jobs/<your-job-id>/pause" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID"
 ```
-
----
 
 ### 7. Resume a Job
 
@@ -149,8 +113,6 @@ Resume a paused job. Replace `<your-job-id>` with the actual job ID:
 curl -s -X POST "https://api.cronlytic.com/prog/jobs/<your-job-id>/resume" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID"
 ```
 
----
-
 ### 8. Get Job Logs
 
 View execution history (last 50 entries). Replace `<your-job-id>` with the actual job ID:
@@ -159,8 +121,6 @@ View execution history (last 50 entries). Replace `<your-job-id>` with the actua
 curl -s -X GET "https://api.cronlytic.com/prog/jobs/<your-job-id>/logs" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID" | jq '.logs[] | {timestamp, status, response_code, response_time}'
 ```
 
----
-
 ### 9. Delete a Job
 
 Permanently delete a job and its logs. Replace `<your-job-id>` with the actual job ID:
@@ -168,8 +128,6 @@ Permanently delete a job and its logs. Replace `<your-job-id>` with the actual j
 ```bash
 curl -s -X DELETE "https://api.cronlytic.com/prog/jobs/<your-job-id>" -H "X-API-Key: $CRONLYTIC_API_KEY" -H "X-User-ID: $CRONLYTIC_USER_ID"
 ```
-
----
 
 ## Cron Expression Format
 
@@ -197,8 +155,6 @@ Standard 5-field cron: `minute hour day month day-of-week`
 | `30 14 * * 0` | Sunday at 2:30 PM |
 | `0 */6 * * *` | Every 6 hours |
 
----
-
 ## Job Status Values
 
 | Status | Description |
@@ -208,8 +164,6 @@ Standard 5-field cron: `minute hour day month day-of-week`
 | `success` | Last execution succeeded |
 | `failed` | Last execution failed |
 | `quota_reached` | Skipped due to plan quota |
-
----
 
 ## Create Job Parameters
 
@@ -231,8 +185,6 @@ Standard 5-field cron: `minute hour day month day-of-week`
 **Valid:** `my-job`, `test_job_1`, `API-Health-Check`
 **Invalid:** `my job` (space), `test@job` (@), `api.health` (.)
 
----
-
 ## Response Fields
 
 | Field | Description |
@@ -245,8 +197,6 @@ Standard 5-field cron: `minute hour day month day-of-week`
 | `cron_expression` | Schedule expression |
 | `next_run_at` | Next scheduled execution (ISO timestamp) |
 | `created_at` | Creation timestamp |
-
----
 
 ## Guidelines
 

--- a/customer-intel/SKILL.md
+++ b/customer-intel/SKILL.md
@@ -3,14 +3,6 @@ name: customer-intel
 description: Investigate and answer customer questions by gathering information from docs, CRMs, wikis, tickets, emails, and web sources, then deliver a confidence-rated response with citations. Activate for customer inquiry research, account background investigation, support question lookup, customer context gathering, or knowledge base queries.
 ---
 
-# Customer Intelligence Gathering
-
-You specialize in assembling accurate, well-sourced answers to questions that arise in customer-facing work. You pull from every available channel, weigh source reliability, and deliver responses that make confidence and attribution transparent.
-
-## Prerequisites
-
-Connect the **Customer Intelligence Gathering** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Investigation Framework
 
 ### Phase 1 — Define the Inquiry
@@ -151,6 +143,7 @@ When different sources tell different stories:
 
 ### Reusable Entry Format
 ```
+
 ## [Topic or Question]
 
 **Verified On:** [date]

--- a/customer-io/SKILL.md
+++ b/customer-io/SKILL.md
@@ -3,24 +3,9 @@ name: customer-io
 description: Customer.io behavioral email and messaging platform. Use when user mentions "Customer.io", "behavioral emails", "lifecycle emails", "triggered messages", or asks about event-based email automation.
 ---
 
-# Customer.io API
+## Troubleshooting
 
-Send behavioral emails, SMS, and push notifications triggered by user events. Two separate APIs — the **Pipelines API** for identifying people and tracking events, and the **App API** for sending transactional messages.
-
-> Official docs: `https://docs.customer.io/integrations/api/customerio-apis/`
-
-## When to Use
-
-- Sync users from Clerk or another auth provider as Customer.io people
-- Track behavioral events (signed up, upgraded, churned) to trigger automated campaigns
-- Send transactional emails (password reset, receipt, notification)
-- Query or manage people profiles and segments
-
-## Prerequisites
-
-Connect the **Customer.io** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name CUSTOMERIO_TRACK_TOKEN` or `zero doctor check-connector --url https://cdp.customer.io/v1/identify --method POST`
+If requests fail, run `zero doctor check-connector --env-name CUSTOMERIO_TRACK_TOKEN` or `zero doctor check-connector --url https://cdp.customer.io/v1/identify --method POST`
 
 ## Core APIs
 
@@ -49,8 +34,6 @@ curl -s -X POST "https://cdp.customer.io/v1/identify" --header "Authorization: B
 
 Docs: https://docs.customer.io/integrations/data-in/connections/http-api/
 
----
-
 ### Track an Event (Pipelines API)
 
 Send a behavioral event to trigger automated campaigns or journeys.
@@ -72,8 +55,6 @@ Write to `/tmp/cio_request.json`:
 ```bash
 curl -s -X POST "https://cdp.customer.io/v1/track" --header "Authorization: Basic $(printf "%s:%s" "$CUSTOMERIO_SITE_ID" "$CUSTOMERIO_TRACK_TOKEN" | base64 -w 0)" --header "Content-Type: application/json" -d @/tmp/cio_request.json
 ```
-
----
 
 ### Send Transactional Email (App API)
 
@@ -101,8 +82,6 @@ curl -s -X POST "https://api.customer.io/v1/send/email" --header "Authorization:
 
 Docs: https://docs.customer.io/journeys/transactional-api-examples/
 
----
-
 ### Delete a Person (App API)
 
 Delete a person by their Customer.io ID. Replace `<person-id>` with the actual ID:
@@ -110,8 +89,6 @@ Delete a person by their Customer.io ID. Replace `<person-id>` with the actual I
 ```bash
 curl -s -X DELETE "https://api.customer.io/v1/customers/<person-id>" --header "Authorization: Bearer $CUSTOMERIO_APP_TOKEN"
 ```
-
----
 
 ### Search People (App API)
 
@@ -137,15 +114,11 @@ Write to `/tmp/cio_request.json`:
 curl -s -X POST "https://api.customer.io/v1/customers" --header "Authorization: Bearer $CUSTOMERIO_APP_TOKEN" --header "Content-Type: application/json" -d @/tmp/cio_request.json | jq '{results: [.results[] | {id, email: .attributes.email}]}'
 ```
 
----
-
 ### List Segments (App API)
 
 ```bash
 curl -s "https://api.customer.io/v1/segments" --header "Authorization: Bearer $CUSTOMERIO_APP_TOKEN" | jq '[.segments[] | {id, name, type}]'
 ```
-
----
 
 ## Guidelines
 

--- a/customer-reply/SKILL.md
+++ b/customer-reply/SKILL.md
@@ -3,14 +3,6 @@ name: customer-reply
 description: Compose professional, empathetic customer-facing messages tailored to context, channel, and urgency. Activate when writing support ticket replies, outage notifications, bug acknowledgments, feature request responses, billing communications, follow-up emails, escalation updates, or any external customer correspondence that needs the right tone and structure.
 ---
 
-# Customer Reply
-
-You craft clear, human, and effective messages to customers across every support scenario. You calibrate language, depth, and format based on the nature of the situation, the communication medium, the customer's history, and the emotional temperature of the conversation.
-
-## Prerequisites
-
-Connect the **Customer Reply** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Foundational Communication Principles
 
 1. **Acknowledge before solving.** Validate what the customer is experiencing before presenting answers or next steps.

--- a/data-profiling/SKILL.md
+++ b/data-profiling/SKILL.md
@@ -3,14 +3,6 @@ name: data-profiling
 description: Profile and explore unfamiliar datasets — assess schema structure, column distributions, data quality, null rates, cardinality, outliers, relationships between tables, and temporal coverage. Use when onboarding to a new data source, auditing data freshness, discovering foreign keys, or deciding what to analyze.
 ---
 
-# Data Profiling
-
-Systematic approach to understanding a dataset's structure, quality, and analytical potential before diving into analysis.
-
-## Prerequisites
-
-Connect the **Data Profiling** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Structural Reconnaissance
 
 ### Table-Level Inventory
@@ -170,6 +162,7 @@ Across numeric columns:
 ### Dataset Summary Template
 
 ```markdown
+
 ## Table: [schema.table_name]
 
 **Purpose**: [What this table captures]

--- a/deel/SKILL.md
+++ b/deel/SKILL.md
@@ -4,35 +4,9 @@ description: Deel API for global payroll and contractors. Use when user mentions
   "contractors", "global payroll", or "EOR".
 ---
 
-# Deel API
+## Troubleshooting
 
-Manage contracts, people, time off, invoices, payments, teams, and organization data with the Deel REST API v2.
-
-> Official docs: https://developer.deel.com/docs
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- List and manage contracts (contractor, EOR, global payroll)
-- View employee and contractor profiles
-- Manage time off requests and entitlements
-- View and create invoice adjustments
-- Access invoices, payments, and payslips
-- Manage teams, departments, and organization structure
-- Track onboarding and offboarding
-- View milestones and timesheets
-- Manage webhooks
-
----
-
-## Prerequisites
-
-Connect the **Deel** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DEEL_TOKEN` or `zero doctor check-connector --url https://api.letsdeel.com/rest/v2/contracts --method GET`
+If requests fail, run `zero doctor check-connector --env-name DEEL_TOKEN` or `zero doctor check-connector --url https://api.letsdeel.com/rest/v2/contracts --method GET`
 
 ## Contracts
 
@@ -111,8 +85,6 @@ curl -s "https://api.letsdeel.com/rest/v2/contracts/<contract-id>/preview" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
 
----
-
 ## EOR Contracts
 
 ### Create EOR Contract
@@ -144,8 +116,6 @@ curl -s "https://api.letsdeel.com/rest/v2/eor/start-date" \
 curl -s "https://api.letsdeel.com/rest/v2/eor/validations/<country-code>" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
-
----
 
 ## People
 
@@ -194,8 +164,6 @@ curl -s -X PATCH "https://api.letsdeel.com/rest/v2/people/<worker-id>/personal" 
   --header "Content-Type: application/json" \
   -d "{\"first_name\": \"Jane\", \"last_name\": \"Doe\"}"
 ```
-
----
 
 ## Time Off
 
@@ -263,8 +231,6 @@ curl -s -X DELETE "https://api.letsdeel.com/rest/v2/time_offs/<time-off-id>" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
 
----
-
 ## Invoice Adjustments
 
 ### List Invoice Adjustments
@@ -313,8 +279,6 @@ curl -s -X DELETE "https://api.letsdeel.com/rest/v2/invoice-adjustments/<id>" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
 
----
-
 ## Adjustments (Generic)
 
 ### List Adjustment Categories
@@ -332,8 +296,6 @@ curl -s -X POST "https://api.letsdeel.com/rest/v2/adjustments" \
   --header "Content-Type: application/json" \
   -d "{\"contract_id\": \"<contract-id>\", \"category_id\": \"<category-id>\", \"amount\": 200, \"description\": \"Expense reimbursement\"}"
 ```
-
----
 
 ## Accounting
 
@@ -380,8 +342,6 @@ curl -s "https://api.letsdeel.com/rest/v2/payments/<payment-id>/breakdown" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
 
----
-
 ## Payslips
 
 ### List EOR Payslips
@@ -405,8 +365,6 @@ curl -s "https://api.letsdeel.com/rest/v2/eor/workers/<worker-id>/payslips/<pays
 curl -s "https://api.letsdeel.com/rest/v2/gp/workers/<worker-id>/payslips" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
-
----
 
 ## Milestones
 
@@ -432,8 +390,6 @@ curl -s -X POST "https://api.letsdeel.com/rest/v2/contracts/<contract-id>/milest
 curl -s -X DELETE "https://api.letsdeel.com/rest/v2/contracts/<contract-id>/milestones/<milestone-id>" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
-
----
 
 ## Timesheets
 
@@ -484,8 +440,6 @@ curl -s -X POST "https://api.letsdeel.com/rest/v2/timesheets/<id>/reviews" \
 curl -s -X DELETE "https://api.letsdeel.com/rest/v2/timesheets/<id>" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
-
----
 
 ## Organization
 
@@ -538,8 +492,6 @@ curl -s "https://api.letsdeel.com/rest/v2/working-locations" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
 
----
-
 ## Onboarding & Offboarding Tracker
 
 ### List Onboarding Tracker
@@ -562,8 +514,6 @@ curl -s "https://api.letsdeel.com/rest/v2/onboarding/tracker/hris_profile/<hris-
 curl -s "https://api.letsdeel.com/rest/v2/offboarding/tracker" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
-
----
 
 ## Lookups
 
@@ -601,8 +551,6 @@ curl -s "https://api.letsdeel.com/rest/v2/lookups/seniorities" \
 curl -s "https://api.letsdeel.com/rest/v2/lookups/time-off-types" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
-
----
 
 ## Webhooks
 
@@ -645,8 +593,6 @@ curl -s -X DELETE "https://api.letsdeel.com/rest/v2/webhooks/<id>" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
 
----
-
 ## Groups
 
 ### List Groups
@@ -681,8 +627,6 @@ curl -s -X DELETE "https://api.letsdeel.com/rest/v2/groups/<id>" \
   --header "Authorization: Bearer $DEEL_TOKEN"
 ```
 
----
-
 ## Guidelines
 
 1. **API versioning**: All endpoints use `/rest/v2/`.
@@ -694,8 +638,6 @@ curl -s -X DELETE "https://api.letsdeel.com/rest/v2/groups/<id>" \
 7. **Invoice adjustments**: Available for contractor contracts. Use the generic `adjustments` endpoints for broader adjustment types.
 8. **EOR vs Contractor**: EOR contracts have separate endpoints under `/eor/` for country-specific compliance, amendments, and offboarding.
 9. **HRIS Profile ID**: Many people/time-off endpoints use the HRIS profile ID, not the contract ID. Get it from the people endpoint.
-
----
 
 ## How to Look Up More API Details
 

--- a/deep-dive/SKILL.md
+++ b/deep-dive/SKILL.md
@@ -6,18 +6,6 @@ description: Structured research and solution design workflow. Use when user men
   research", "方案选型", "调研", or asks to explore options before implementing.
 ---
 
-# Deep Dive
-
-A two-phase workflow for technical research and solution design. Phase 1 gathers facts without suggesting solutions. Phase 2 explores multiple approaches based on those facts.
-
-All artifacts are written to `deep-dive/{task-name}/`.
-
----
-
-## Prerequisites
-
-Connect the **Deep Dive** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Operation: deep research
 
 **Usage:** `deep research [task description]`
@@ -52,6 +40,7 @@ Information gathering phase. Analyze the codebase without suggesting solutions.
 # Research: {task-name}
 
 ## Scope
+
 What was investigated and why.
 
 ## Findings
@@ -69,10 +58,9 @@ What was investigated and why.
 - How data moves through the relevant components
 
 ## Open Questions
+
 - Unresolved items that need clarification
 ```
-
----
 
 ## Operation: deep innovate
 
@@ -115,6 +103,7 @@ For each approach, document:
 # Innovation: {task-name}
 
 ## Research Summary
+
 Key findings from the research phase.
 
 ## Approach A: {name}
@@ -135,9 +124,11 @@ How it fits with existing architecture.
 Long-term considerations.
 
 ## Approach B: {name}
+
 (same structure)
 
 ## Approach C: {name}
+
 (same structure)
 
 ## Comparison Matrix
@@ -150,5 +141,6 @@ Long-term considerations.
 | Maintainability  |            |            |            |
 
 ## Next Steps
+
 Awaiting user decision before proceeding.
 ```

--- a/deepseek/SKILL.md
+++ b/deepseek/SKILL.md
@@ -4,30 +4,9 @@ description: DeepSeek API for AI model inference. Use when user mentions "DeepSe
   "DeepSeek API", or asks about DeepSeek models.
 ---
 
-# DeepSeek API
+## Troubleshooting
 
-Use the DeepSeek API via direct `curl` calls to access **powerful AI language models** for chat, reasoning, and code generation.
-
-> Official docs: `https://api-docs.deepseek.com/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Chat completions** with DeepSeek-V3.2 model
-- **Deep reasoning** tasks using the reasoning model
-- **Code generation and completion** (FIM - Fill-in-the-Middle)
-- **OpenAI-compatible API** as a cost-effective alternative
-
----
-
-## Prerequisites
-
-Connect the **DeepSeek** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DEEPSEEK_TOKEN` or `zero doctor check-connector --url https://api.deepseek.com/chat/completions --method POST`
+If requests fail, run `zero doctor check-connector --env-name DEEPSEEK_TOKEN` or `zero doctor check-connector --url https://api.deepseek.com/chat/completions --method POST`
 
 ## How to Use
 
@@ -37,8 +16,6 @@ The base URL for the DeepSeek API is:
 
 - `https://api.deepseek.com` (recommended)
 - `https://api.deepseek.com/v1` (OpenAI-compatible)
-
----
 
 ### 1. Basic Chat Completion
 
@@ -73,8 +50,6 @@ curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: ap
 - `deepseek-chat`: DeepSeek-V3.2 non-thinking mode (128K context, 8K max output)
 - `deepseek-reasoner`: DeepSeek-V3.2 thinking mode (128K context, 64K max output)
 
----
-
 ### 2. Chat with Temperature Control
 
 Adjust creativity/randomness with temperature:
@@ -107,8 +82,6 @@ curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: ap
 - `top_p` (0-1, default 1): Nucleus sampling threshold
 - `max_tokens`: Maximum tokens to generate
 
----
-
 ### 3. Streaming Response
 
 Get real-time token-by-token output:
@@ -136,8 +109,6 @@ curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: ap
 
 Streaming returns Server-Sent Events (SSE) with delta chunks, ending with `data: [DONE]`.
 
----
-
 ### 4. Deep Reasoning (Thinking Mode)
 
 Use the reasoner model for complex reasoning tasks:
@@ -163,8 +134,6 @@ curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: ap
 ```
 
 The reasoner model excels at math, logic, and multi-step problems.
-
----
 
 ### 5. JSON Output Mode
 
@@ -196,8 +165,6 @@ Then run:
 ```bash
 curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $DEEPSEEK_TOKEN" -d @/tmp/deepseek_request.json | jq -r '.choices[0].message.content'
 ```
-
----
 
 ### 6. Multi-turn Conversation
 
@@ -231,8 +198,6 @@ Then run:
 curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $DEEPSEEK_TOKEN" -d @/tmp/deepseek_request.json | jq -r '.choices[0].message.content'
 ```
 
----
-
 ### 7. Code Completion (FIM)
 
 Use Fill-in-the-Middle for code completion (beta endpoint):
@@ -257,8 +222,6 @@ FIM is useful for:
 - Code completion in editors
 - Filling gaps in documents
 - Context-aware text generation
-
----
 
 ### 8. Function Calling (Tools)
 
@@ -305,8 +268,6 @@ curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: ap
 
 The model will return a `tool_calls` array when it wants to use a function.
 
----
-
 ### 9. Check Token Usage
 
 Extract usage information from response:
@@ -336,8 +297,6 @@ Response includes:
 - `completion_tokens`: Output token count
 - `total_tokens`: Sum of both
 
----
-
 ## OpenAI SDK Compatibility
 
 DeepSeek is fully compatible with OpenAI SDKs. Just change the base URL:
@@ -353,8 +312,6 @@ client = OpenAI(api_key="your-deepseek-key", base_url="https://api.deepseek.com"
 import OpenAI from 'openai';
 const client = new OpenAI({ apiKey: 'your-deepseek-key', baseURL: 'https://api.deepseek.com' });
 ```
-
----
 
 ## Tips: Complex JSON Payloads
 
@@ -386,8 +343,6 @@ Then run:
 ```bash
 curl -s "https://api.deepseek.com/chat/completions" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $DEEPSEEK_TOKEN" -d @/tmp/deepseek_request.json
 ```
-
----
 
 ## Guidelines
 

--- a/devto/SKILL.md
+++ b/devto/SKILL.md
@@ -4,30 +4,9 @@ description: Dev.to API for articles and posts. Use when user mentions "Dev.to",
   article", "dev community", or asks about blog posts.
 ---
 
-# Dev.to Publisher
+## Troubleshooting
 
-Use the Dev.to API via direct `curl` calls to **publish and manage articles**.
-
-> Official docs: `https://developers.forem.com/api/v1`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Publish articles** to Dev.to
-- **Update existing articles**
-- **Manage drafts**
-- **Fetch your published articles**
-
----
-
-## Prerequisites
-
-Connect the **Dev.to Publisher** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DEVTO_TOKEN` or `zero doctor check-connector --url https://dev.to/api/articles --method GET`
+If requests fail, run `zero doctor check-connector --env-name DEVTO_TOKEN` or `zero doctor check-connector --url https://dev.to/api/articles --method GET`
 
 ## How to Use
 
@@ -136,8 +115,6 @@ Then run:
 curl -s -X POST "https://dev.to/api/articles" -H "api-key: $DEVTO_TOKEN" -H "Content-Type: application/json" -d @/tmp/devto_request.json | jq '{id, url, published}'
 ```
 
----
-
 ## Managing Articles
 
 ### 5. Get Your Articles
@@ -207,8 +184,6 @@ Then run:
 curl -s -X PUT "https://dev.to/api/articles/<your-article-id>" -H "api-key: $DEVTO_TOKEN" -H "Content-Type: application/json" -d @/tmp/devto_request.json | jq '{id, url, published}'
 ```
 
----
-
 ## Article Parameters
 
 | Parameter | Type | Description |
@@ -220,8 +195,6 @@ curl -s -X PUT "https://dev.to/api/articles/<your-article-id>" -H "api-key: $DEV
 | `main_image` | string | Cover image URL |
 | `canonical_url` | string | Original article URL (for cross-posts) |
 | `series` | string | Series name to group articles |
-
----
 
 ## Examples
 
@@ -289,8 +262,6 @@ Then run:
 ```bash
 curl -s -X POST "https://dev.to/api/articles" -H "api-key: $DEVTO_TOKEN" -H "Content-Type: application/json" -d @/tmp/devto_request.json | jq '{url}'
 ```
-
----
 
 ## Guidelines
 

--- a/dify/SKILL.md
+++ b/dify/SKILL.md
@@ -4,31 +4,9 @@ description: Dify API for LLM app building. Use when user mentions "Dify", "LLM 
   "AI workflow", or asks about Dify platform.
 ---
 
-# Dify API
+## Troubleshooting
 
-Build and interact with AI-powered workflows, chatbots, and text generation apps via Dify's REST API.
-
-> Official docs: `https://docs.dify.ai/en/use-dify/publish/developing-with-apis`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Run AI workflows** with custom inputs and retrieve results
-- **Chat with AI apps** in multi-turn conversations
-- **Generate text completions** from configured prompts
-- **Manage knowledge bases** (create, list, add documents, query)
-- **Upload files** for use in AI app conversations or workflows
-
----
-
-## Prerequisites
-
-Connect the **Dify** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DIFY_TOKEN` or `zero doctor check-connector --url https://api.dify.ai/v1/chat-messages --method POST`
+If requests fail, run `zero doctor check-connector --env-name DIFY_TOKEN` or `zero doctor check-connector --url https://api.dify.ai/v1/chat-messages --method POST`
 
 ## Chat Messages
 
@@ -100,8 +78,6 @@ curl -s -X POST "https://api.dify.ai/v1/chat-messages" --header "Authorization: 
 curl -s -X POST "https://api.dify.ai/v1/chat-messages/{task_id}/stop" --header "Authorization: Bearer $DIFY_TOKEN" --header "Content-Type: application/json" -d '{"user": "user-123"}' | jq .
 ```
 
----
-
 ## Text Completion
 
 ### Create Completion Message
@@ -125,8 +101,6 @@ curl -s -X POST "https://api.dify.ai/v1/completion-messages" --header "Authoriza
 ```
 
 The `inputs` object keys depend on the variables configured in your Dify app's prompt template.
-
----
 
 ## Workflow Execution
 
@@ -178,8 +152,6 @@ curl -s -X POST "https://api.dify.ai/v1/workflows/run" --header "Authorization: 
 curl -s -X GET "https://api.dify.ai/v1/workflows/run/{workflow_run_id}" --header "Authorization: Bearer $DIFY_TOKEN" | jq .
 ```
 
----
-
 ## Conversations
 
 ### List Conversations
@@ -206,8 +178,6 @@ curl -s -X DELETE "https://api.dify.ai/v1/conversations/{conversation_id}" --hea
 curl -s -X POST "https://api.dify.ai/v1/conversations/{conversation_id}/name" --header "Authorization: Bearer $DIFY_TOKEN" --header "Content-Type: application/json" -d '{"name": "My Chat Session", "user": "user-123"}' | jq .
 ```
 
----
-
 ## Message Feedback
 
 ```bash
@@ -216,8 +186,6 @@ curl -s -X POST "https://api.dify.ai/v1/messages/{message_id}/feedbacks" --heade
 
 Rating values: `like`, `dislike`, or `null` (to remove feedback).
 
----
-
 ## Suggested Questions
 
 Get follow-up question suggestions after a message:
@@ -225,8 +193,6 @@ Get follow-up question suggestions after a message:
 ```bash
 curl -s -X GET "https://api.dify.ai/v1/messages/{message_id}/suggested?user=user-123" --header "Authorization: Bearer $DIFY_TOKEN" | jq .
 ```
-
----
 
 ## File Upload
 
@@ -237,8 +203,6 @@ curl -s -X POST "https://api.dify.ai/v1/files/upload" --header "Authorization: B
 ```
 
 Use the returned `id` in chat messages by adding it to the `files` array in the request body.
-
----
 
 ## Application Info
 
@@ -253,8 +217,6 @@ curl -s -X GET "https://api.dify.ai/v1/parameters?user=user-123" --header "Autho
 ```bash
 curl -s -X GET "https://api.dify.ai/v1/meta?user=user-123" --header "Authorization: Bearer $DIFY_TOKEN" | jq .
 ```
-
----
 
 ## Knowledge Base Management
 
@@ -331,8 +293,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.dify.ai/v1/datasets/{dataset_id}/retrieve" --header "Authorization: Bearer $DIFY_TOKEN" --header "Content-Type: application/json" -d @/tmp/dify_request.json | jq .
 ```
-
----
 
 ## Guidelines
 

--- a/discord-webhook/SKILL.md
+++ b/discord-webhook/SKILL.md
@@ -4,35 +4,9 @@ description: Discord Webhook API for sending messages. Use when user says "send 
   message", "Discord webhook", or "post to Discord".
 ---
 
-# Discord Webhook
-
-Use Discord Webhooks via direct `curl` calls to **send messages to Discord channels** without setting up a bot.
-
-> Official docs: `https://discord.com/developers/docs/resources/webhook`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Send notifications** to Discord channels
-- **Post alerts** from CI/CD pipelines
-- **Share updates** with rich embeds
-- **Upload files** to channels
-- **Simple integrations** without bot complexity
-
----
-
-## Prerequisites
-
-Connect the **Discord Webhook** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 All examples below assume you have `DISCORD_WEBHOOK_URL` set.
-
----
 
 ### 1. Send Simple Message
 
@@ -49,8 +23,6 @@ Then run:
 ```bash
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/discord_webhook_request.json
 ```
-
----
 
 ### 2. Send with Custom Username and Avatar
 
@@ -69,8 +41,6 @@ Then run:
 ```bash
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/discord_webhook_request.json
 ```
-
----
 
 ### 3. Send Rich Embed
 
@@ -114,8 +84,6 @@ curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/
 - Yellow: `16776960`
 - Orange: `16744192`
 
----
-
 ### 4. Send Error Alert
 
 Write to `/tmp/discord_webhook_request.json`:
@@ -151,8 +119,6 @@ Then run:
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/discord_webhook_request.json
 ```
 
----
-
 ### 5. Send File Attachment
 
 Write to `/tmp/discord_webhook_payload.json`:
@@ -169,8 +135,6 @@ Then run:
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -F "file1=@screenshot.png" -F 'payload_json=@/tmp/discord_webhook_payload.json'
 ```
 
----
-
 ### 6. Send Multiple Files
 
 Write to `/tmp/discord_webhook_payload.json`:
@@ -186,8 +150,6 @@ Then run:
 ```bash
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -F "file1=@error.log" -F "file2=@debug.log" -F 'payload_json=@/tmp/discord_webhook_payload.json'
 ```
-
----
 
 ### 7. Send Multiple Embeds
 
@@ -218,8 +180,6 @@ Then run:
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/discord_webhook_request.json
 ```
 
----
-
 ### 8. Send with Mention
 
 Write to `/tmp/discord_webhook_request.json`:
@@ -241,8 +201,6 @@ curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/
 
 Replace `<your-user-id>` with the actual Discord user ID.
 
----
-
 ### 9. Send Silent Message (No Notification)
 
 Write to `/tmp/discord_webhook_request.json`:
@@ -259,8 +217,6 @@ Then run:
 ```bash
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/discord_webhook_request.json
 ```
-
----
 
 ### 10. CI/CD Pipeline Notification
 
@@ -306,8 +262,6 @@ Then run:
 curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/tmp/discord_webhook_request.json
 ```
 
----
-
 ## Embed Structure
 
 ```json
@@ -326,8 +280,6 @@ curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d @/
   "timestamp": "2025-01-01T12:00:00.000Z"
 }
 ```
-
----
 
 ## Guidelines
 

--- a/discord/SKILL.md
+++ b/discord/SKILL.md
@@ -5,34 +5,9 @@ description: Discord API for servers and messages. Use when user mentions "Disco
   Discord bots.
 ---
 
-# Discord Bot API
+## Troubleshooting
 
-Use the Discord Bot API via direct `curl` calls to **manage channels, guilds, messages, and users**.
-
-> Official docs: `https://discord.com/developers/docs`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Send messages** to specific channels
-- **Read messages** from channels
-- **Manage channels** (create, edit, delete)
-- **Get server info** (guilds, members, roles)
-- **React to messages** and moderate content
-- **Create webhooks** programmatically
-
-For simple message posting, use `discord-webhook` skill instead.
-
----
-
-## Prerequisites
-
-Connect the **Discord** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DISCORD_BOT_TOKEN` or `zero doctor check-connector --url https://discord.com/api/v10/users/@me --method GET`
+If requests fail, run `zero doctor check-connector --env-name DISCORD_BOT_TOKEN` or `zero doctor check-connector --url https://discord.com/api/v10/users/@me --method GET`
 
 ## How to Use
 
@@ -40,15 +15,11 @@ Base URL: `https://discord.com/api/v10`
 
 Authorization header: `Authorization: Bot YOUR_TOKEN`
 
----
-
 ### 1. Get Current Bot User
 
 ```bash
 curl -s "https://discord.com/api/v10/users/@me" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '{id, username, discriminator}'
 ```
-
----
 
 ### 2. Send Message to Channel
 
@@ -65,8 +36,6 @@ Then run (replace `<your-channel-id>` with the actual channel ID):
 ```bash
 curl -s -X POST "https://discord.com/api/v10/channels/<your-channel-id>/messages" -H "Authorization: Bot $DISCORD_BOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/discord_request.json
 ```
-
----
 
 ### 3. Send Embed Message
 
@@ -90,8 +59,6 @@ Then run (replace `<your-channel-id>` with the actual channel ID):
 curl -s -X POST "https://discord.com/api/v10/channels/<your-channel-id>/messages" -H "Authorization: Bot $DISCORD_BOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/discord_request.json
 ```
 
----
-
 ### 4. Get Channel Info
 
 Replace `<your-channel-id>` with the actual channel ID:
@@ -99,8 +66,6 @@ Replace `<your-channel-id>` with the actual channel ID:
 ```bash
 curl -s "https://discord.com/api/v10/channels/<your-channel-id>" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '{id, name, type, guild_id}'
 ```
-
----
 
 ### 5. Get Channel Messages
 
@@ -110,8 +75,6 @@ Replace `<your-channel-id>` with the actual channel ID:
 curl -s "https://discord.com/api/v10/channels/<your-channel-id>/messages?limit=10" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '.[] | {id, author: .author.username, content}'
 ```
 
----
-
 ### 6. Get Specific Message
 
 Replace `<your-channel-id>` and `<your-message-id>` with the actual IDs:
@@ -120,8 +83,6 @@ Replace `<your-channel-id>` and `<your-message-id>` with the actual IDs:
 curl -s "https://discord.com/api/v10/channels/<your-channel-id>/messages/<your-message-id>" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '{id, content, author: .author.username}'
 ```
 
----
-
 ### 7. Delete Message
 
 Replace `<your-channel-id>` and `<your-message-id>` with the actual IDs:
@@ -129,8 +90,6 @@ Replace `<your-channel-id>` and `<your-message-id>` with the actual IDs:
 ```bash
 curl -s -X DELETE "https://discord.com/api/v10/channels/<your-channel-id>/messages/<your-message-id>" -H "Authorization: Bot $DISCORD_BOT_TOKEN"
 ```
-
----
 
 ### 8. Add Reaction
 
@@ -142,8 +101,6 @@ curl -s -X PUT "https://discord.com/api/v10/channels/<your-channel-id>/messages/
 
 Note: Emoji must be URL encoded (👍 = `%F0%9F%91%8D`)
 
----
-
 ### 9. Get Guild (Server) Info
 
 Replace `<your-guild-id>` with the actual guild ID:
@@ -151,8 +108,6 @@ Replace `<your-guild-id>` with the actual guild ID:
 ```bash
 curl -s "https://discord.com/api/v10/guilds/<your-guild-id>" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '{id, name, member_count, owner_id}'
 ```
-
----
 
 ### 10. List Guild Channels
 
@@ -162,8 +117,6 @@ Replace `<your-guild-id>` with the actual guild ID:
 curl -s "https://discord.com/api/v10/guilds/<your-guild-id>/channels" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '.[] | {id, name, type}'
 ```
 
----
-
 ### 11. Get Guild Members
 
 Replace `<your-guild-id>` with the actual guild ID:
@@ -172,8 +125,6 @@ Replace `<your-guild-id>` with the actual guild ID:
 curl -s "https://discord.com/api/v10/guilds/<your-guild-id>/members?limit=10" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '.[] | {user: .user.username, nick, joined_at}'
 ```
 
----
-
 ### 12. Get Guild Roles
 
 Replace `<your-guild-id>` with the actual guild ID:
@@ -181,8 +132,6 @@ Replace `<your-guild-id>` with the actual guild ID:
 ```bash
 curl -s "https://discord.com/api/v10/guilds/<your-guild-id>/roles" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '.[] | {id, name, color, position}'
 ```
-
----
 
 ### 13. Create Webhook
 
@@ -200,8 +149,6 @@ Then run (replace `<your-channel-id>` with the actual channel ID):
 curl -s -X POST "https://discord.com/api/v10/channels/<your-channel-id>/webhooks" -H "Authorization: Bot $DISCORD_BOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/discord_request.json | jq '{id, token, url: "https://discord.com/api/webhooks/\(.id)/\(.token)"}'
 ```
 
----
-
 ### 14. List Channel Webhooks
 
 Replace `<your-channel-id>` with the actual channel ID:
@@ -209,8 +156,6 @@ Replace `<your-channel-id>` with the actual channel ID:
 ```bash
 curl -s "https://discord.com/api/v10/channels/<your-channel-id>/webhooks" -H "Authorization: Bot $DISCORD_BOT_TOKEN" | jq '.[] | {id, name, token}'
 ```
-
----
 
 ### 15. Create Text Channel
 
@@ -229,8 +174,6 @@ Then run (replace `<your-guild-id>` with the actual guild ID):
 curl -s -X POST "https://discord.com/api/v10/guilds/<your-guild-id>/channels" -H "Authorization: Bot $DISCORD_BOT_TOKEN" -H "Content-Type: application/json" -d @/tmp/discord_request.json | jq '{id, name}'
 ```
 
----
-
 ## Channel Types
 
 | Type | Description |
@@ -241,8 +184,6 @@ curl -s -X POST "https://discord.com/api/v10/guilds/<your-guild-id>/channels" -H
 | 5 | Announcement |
 | 13 | Stage |
 | 15 | Forum |
-
----
 
 ## Guidelines
 

--- a/docusign/SKILL.md
+++ b/docusign/SKILL.md
@@ -4,36 +4,9 @@ description: DocuSign API for electronic signatures. Use when user mentions "Doc
   "e-signature", "sign document", or "send for signature".
 ---
 
-# DocuSign eSignature API
+## Troubleshooting
 
-Create, send, and manage electronic signature envelopes via the DocuSign eSignature REST API v2.1.
-
-> Official docs: `https://developers.docusign.com/docs/esign-rest-api/reference/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Send documents for electronic signature
-- Create and manage envelopes
-- List and use templates
-- Check envelope and recipient status
-- Download signed documents
-
----
-
-## Prerequisites
-
-
-> **Important:** DocuSign API requires a `base_uri` and `account_id` obtained from the userinfo endpoint. Always call "Get User Info" first to determine the correct base URI and account ID before making API calls.
-
-> **Placeholders:** Values in `<angle-brackets>` like `<envelope-id>` are placeholders. Replace them with actual values when executing.
-
----
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DOCUSIGN_TOKEN` or `zero doctor check-connector --url https://account.docusign.com/oauth/userinfo --method GET`
+If requests fail, run `zero doctor check-connector --env-name DOCUSIGN_TOKEN` or `zero doctor check-connector --url https://account.docusign.com/oauth/userinfo --method GET`
 
 ## User Info
 
@@ -46,8 +19,6 @@ curl -s "https://account.docusign.com/oauth/userinfo" --header "Authorization: B
 ```
 
 Use the `base_uri` and `account_id` from the default account (where `is_default` is `true`) for all subsequent API calls. The API base path is `{base_uri}/restapi/v2.1/accounts/{account_id}`.
-
----
 
 ## Envelopes
 
@@ -128,8 +99,6 @@ Write to `/tmp/docusign_void.json`:
 curl -s -X PUT "<base-uri>/restapi/v2.1/accounts/<account-id>/envelopes/<envelope-id>" --header "Authorization: Bearer $DOCUSIGN_TOKEN" --header "Content-Type: application/json" -d @/tmp/docusign_void.json | jq '{envelopeId, status}'
 ```
 
----
-
 ## Recipients
 
 ### List Envelope Recipients
@@ -137,8 +106,6 @@ curl -s -X PUT "<base-uri>/restapi/v2.1/accounts/<account-id>/envelopes/<envelop
 ```bash
 curl -s "<base-uri>/restapi/v2.1/accounts/<account-id>/envelopes/<envelope-id>/recipients" --header "Authorization: Bearer $DOCUSIGN_TOKEN" | jq '.signers[] | {recipientId, name, email, status, signedDateTime}'
 ```
-
----
 
 ## Documents
 
@@ -163,8 +130,6 @@ Download all documents in the envelope as a single PDF:
 ```bash
 curl -s "<base-uri>/restapi/v2.1/accounts/<account-id>/envelopes/<envelope-id>/documents/combined" --header "Authorization: Bearer $DOCUSIGN_TOKEN" --header "Accept: application/pdf" --output /tmp/combined_documents.pdf
 ```
-
----
 
 ## Templates
 
@@ -201,8 +166,6 @@ Write to `/tmp/docusign_template_envelope.json`:
 ```bash
 curl -s -X POST "<base-uri>/restapi/v2.1/accounts/<account-id>/envelopes" --header "Authorization: Bearer $DOCUSIGN_TOKEN" --header "Content-Type: application/json" -d @/tmp/docusign_template_envelope.json | jq '{envelopeId, status, statusDateTime, uri}'
 ```
-
----
 
 ## Guidelines
 

--- a/doppler/SKILL.md
+++ b/doppler/SKILL.md
@@ -3,23 +3,9 @@ name: doppler
 description: Doppler Secrets Manager API for retrieving and listing secrets. Use when user mentions "Doppler", "doppler secrets", "dp.st token", or asks about secrets management with Doppler.
 ---
 
-# Doppler Secrets Manager API
+## Troubleshooting
 
-Doppler is a secrets manager that lets you fetch, list, and manage secrets across projects and environments. This skill enables retrieving individual secrets or listing all secrets from a Doppler project config using a service token.
-
-> Official docs: `https://docs.doppler.com/reference/api`
-
-## When to Use
-
-- Fetch the value of a specific secret from a Doppler config
-- List all secrets in a Doppler project/config
-- Inspect raw vs. computed secret values (with variable interpolation)
-
-## Prerequisites
-
-Connect the **Doppler** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DOPPLER_TOKEN` or `zero doctor check-connector --url https://api.doppler.com/v3/configs/config/secret --method GET`
+If requests fail, run `zero doctor check-connector --env-name DOPPLER_TOKEN` or `zero doctor check-connector --url https://api.doppler.com/v3/configs/config/secret --method GET`
 
 ## Core APIs
 
@@ -36,8 +22,6 @@ curl -s "https://api.doppler.com/v3/configs/config/secret" \
 
 Replace `<project-slug>` with your Doppler project slug, `<config-name>` with the config (e.g., `dev`, `prd`), and `<SECRET_NAME>` with the exact secret key.
 
----
-
 ### List All Secrets in a Config
 
 ```bash
@@ -47,8 +31,6 @@ curl -s "https://api.doppler.com/v3/configs/config/secrets" \
   --data-urlencode "project=<project-slug>" \
   --data-urlencode "config=<config-name>" | jq '.secrets | to_entries[] | {name: .key, raw: .value.raw, computed: .value.computed}'
 ```
-
----
 
 ### Download All Secrets as JSON
 
@@ -63,16 +45,12 @@ curl -s "https://api.doppler.com/v3/configs/config/secrets/download" \
 
 Returns a flat key/value JSON object of all secrets.
 
----
-
 ### List Projects
 
 ```bash
 curl -s "https://api.doppler.com/v3/projects" \
   -H "Authorization: Bearer $DOPPLER_TOKEN" | jq '.projects[] | {id, name, slug}'
 ```
-
----
 
 ### List Configs in a Project
 
@@ -82,8 +60,6 @@ curl -s "https://api.doppler.com/v3/configs" \
   -G \
   --data-urlencode "project=<project-slug>" | jq '.configs[] | {name, environment, locked}'
 ```
-
----
 
 ## Guidelines
 

--- a/dropbox/SKILL.md
+++ b/dropbox/SKILL.md
@@ -4,31 +4,9 @@ description: Dropbox API for file storage. Use when user mentions "Dropbox", "dr
   shares a Dropbox link, "upload to Dropbox", or asks about cloud storage.
 ---
 
-# Dropbox API
+## Troubleshooting
 
-Manage files, folders, sharing, and file requests in Dropbox using the HTTP API v2.
-
-> Official docs: https://www.dropbox.com/developers/documentation/http/documentation
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- List, search, upload, download, move, copy, or delete files and folders
-- Get file metadata, revisions, and previews
-- Create and manage shared links and folder sharing
-- Manage file requests
-- Check storage usage
-
----
-
-## Prerequisites
-
-Connect the **Dropbox** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name DROPBOX_TOKEN` or `zero doctor check-connector --url https://api.dropboxapi.com/2/users/get_current_account --method POST`
+If requests fail, run `zero doctor check-connector --env-name DROPBOX_TOKEN` or `zero doctor check-connector --url https://api.dropboxapi.com/2/users/get_current_account --method POST`
 
 ## User
 
@@ -45,8 +23,6 @@ curl -s -X POST "https://api.dropboxapi.com/2/users/get_current_account" \
 curl -s -X POST "https://api.dropboxapi.com/2/users/get_space_usage" \
   --header "Authorization: Bearer $DROPBOX_TOKEN"
 ```
-
----
 
 ## Files & Folders
 
@@ -213,8 +189,6 @@ curl -s -X POST "https://api.dropboxapi.com/2/files/tags/remove" \
   -d "{\"path\": \"/Documents/report.pdf\", \"tag_text\": \"important\"}"
 ```
 
----
-
 ## Upload & Download
 
 ### Upload File (up to 150 MB)
@@ -257,8 +231,6 @@ curl -s -X POST "https://content.dropboxapi.com/2/files/get_thumbnail:2" \
   --header "Dropbox-API-Arg: {\"resource\": {\".tag\": \"path\", \"path\": \"/Photos/image.jpg\"}, \"format\": \"jpeg\", \"size\": \"w256h256\"}" \
   -o thumbnail.jpg
 ```
-
----
 
 ## Sharing
 
@@ -345,8 +317,6 @@ curl -s -X POST "https://api.dropboxapi.com/2/sharing/list_folders" \
   -d "{\"limit\": 100}"
 ```
 
----
-
 ## File Requests
 
 ### List File Requests
@@ -399,8 +369,6 @@ curl -s -X POST "https://api.dropboxapi.com/2/file_requests/count" \
   --header "Authorization: Bearer $DROPBOX_TOKEN"
 ```
 
----
-
 ## Guidelines
 
 1. **All POST**: Dropbox API uses POST for nearly everything, including reads. Don't use GET.
@@ -411,8 +379,6 @@ curl -s -X POST "https://api.dropboxapi.com/2/file_requests/count" \
 6. **Rate limits**: Back off on 429 responses. Use `Retry-After` header.
 7. **Shared links**: Use `create_shared_link_with_settings` (not deprecated `create_shared_link`).
 8. **Batch operations**: `copy_batch`, `move_batch`, `delete_batch` are available for bulk operations.
-
----
 
 ## How to Look Up More API Details
 

--- a/elevenlabs/SKILL.md
+++ b/elevenlabs/SKILL.md
@@ -4,30 +4,9 @@ description: ElevenLabs API for text-to-speech and voice. Use when user mentions
   "text to speech", "voice cloning", or "AI voice".
 ---
 
-# ElevenLabs API
+## Troubleshooting
 
-Use the ElevenLabs API via direct `curl` calls to generate **realistic AI speech** from text.
-
-> Official docs: `https://elevenlabs.io/docs/api-reference`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Convert text to speech** with high-quality AI voices
-- **List available voices** to find the right voice for your use case
-- **Stream audio output** for real-time playback
-- **Generate voiceovers** for videos, podcasts, or accessibility
-
----
-
-## Prerequisites
-
-Connect the **ElevenLabs** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ELEVENLABS_TOKEN` or `zero doctor check-connector --url https://api.elevenlabs.io/v1/voices --method GET`
+If requests fail, run `zero doctor check-connector --env-name ELEVENLABS_TOKEN` or `zero doctor check-connector --url https://api.elevenlabs.io/v1/voices --method GET`
 
 ## How to Use
 
@@ -36,8 +15,6 @@ All examples below assume you have `ELEVENLABS_TOKEN` set.
 The base URL for the ElevenLabs API is:
 
 - `https://api.elevenlabs.io/v1`
-
----
 
 ### 1. List Available Voices
 
@@ -52,8 +29,6 @@ This returns voice IDs needed for text-to-speech. Common voice categories:
 - `cloned`: Your cloned voices
 - `generated`: AI-designed voices
 
----
-
 ### 2. Get Voice Details
 
 Get detailed information about a specific voice. Replace `<your-voice-id>` with an actual voice ID:
@@ -61,8 +36,6 @@ Get detailed information about a specific voice. Replace `<your-voice-id>` with 
 ```bash
 curl -s -X GET "https://api.elevenlabs.io/v1/voices/<your-voice-id>" --header "xi-api-key: $ELEVENLABS_TOKEN"
 ```
-
----
 
 ### 3. List Available Models
 
@@ -76,8 +49,6 @@ Common models:
 - `eleven_multilingual_v2`: Best quality, supports 29 languages
 - `eleven_flash_v2_5`: Low latency, good for real-time
 - `eleven_v3`: Latest model (alpha)
-
----
 
 ### 4. Text to Speech (Save to File)
 
@@ -107,8 +78,6 @@ curl -s -X POST "https://api.elevenlabs.io/v1/text-to-speech/<your-voice-id>" --
 - `stability` (0.0-1.0): Higher = more consistent, lower = more expressive
 - `similarity_boost` (0.0-1.0): Higher = closer to original voice
 
----
-
 ### 5. Text to Speech with Streaming
 
 Stream audio for real-time playback. Replace `<your-voice-id>` with an actual voice ID:
@@ -128,8 +97,6 @@ Then run:
 curl -s -X POST "https://api.elevenlabs.io/v1/text-to-speech/<your-voice-id>/stream" --header "xi-api-key: $ELEVENLABS_TOKEN" --header "Content-Type: application/json" --header "Accept: audio/mpeg" -d @/tmp/elevenlabs_request.json --output streamed.mp3
 ```
 
----
-
 ### 6. Get User Subscription Info
 
 Check your usage and character limits:
@@ -137,8 +104,6 @@ Check your usage and character limits:
 ```bash
 curl -s -X GET "https://api.elevenlabs.io/v1/user/subscription" --header "xi-api-key: $ELEVENLABS_TOKEN" | jq '{character_count, character_limit, tier}'
 ```
-
----
 
 ## Output Formats
 
@@ -165,8 +130,6 @@ Available formats:
 - `pcm_16000`: PCM at 16kHz
 - `pcm_22050`: PCM at 22.05kHz
 - `pcm_24000`: PCM at 24kHz
-
----
 
 ## Guidelines
 

--- a/escalation-brief/SKILL.md
+++ b/escalation-brief/SKILL.md
@@ -3,14 +3,6 @@ name: escalation-brief
 description: Prepare structured escalation packages for engineering, product, security, or leadership with reproduction steps, business impact, and full context. Activate when a support issue needs to go beyond the support team, when writing an escalation document, when evaluating whether a problem warrants escalation, or when tracking follow-through after handing off an issue.
 ---
 
-# Escalation Brief
-
-You are skilled at judging when a support issue must be elevated and at assembling escalation packages that give receiving teams everything they need to act without delay. You maintain ownership of the customer relationship even after the technical problem moves to another team.
-
-## Prerequisites
-
-Connect the **Escalation Brief** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Deciding: Escalate or Resolve In-House?
 
 ### Keep It in Support When:

--- a/explorium/SKILL.md
+++ b/explorium/SKILL.md
@@ -4,31 +4,9 @@ description: Explorium API for external data enrichment. Use when user mentions 
   "data enrichment", "business data", or external datasets.
 ---
 
-# Explorium API
+## Troubleshooting
 
-Use the Explorium API via direct `curl` calls to **enrich business and prospect data**, discover leads, and track real-time business events.
-
-> Official docs: `https://developers.explorium.ai/reference/introduction`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Enrich business data** with firmographic, technographic, and financial information
-- **Discover and enrich prospects** with contact details, social profiles, and professional history
-- **Search and match businesses** by name, domain, or other identifiers
-- **Track business events** such as funding rounds, job changes, and company updates
-- **Bulk process** up to 50 business or prospect records in a single request
-
----
-
-## Prerequisites
-
-Connect the **Explorium** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name EXPLORIUM_TOKEN` or `zero doctor check-connector --url https://api.explorium.ai/v1/businesses/stats --method POST`
+If requests fail, run `zero doctor check-connector --env-name EXPLORIUM_TOKEN` or `zero doctor check-connector --url https://api.explorium.ai/v1/businesses/stats --method POST`
 
 ## How to Use
 
@@ -39,8 +17,6 @@ The base URL for the Explorium API is:
 - `https://api.explorium.ai`
 
 The API key is passed via the `api_key` header in all requests.
-
----
 
 ### 1. Get Business Statistics
 
@@ -67,8 +43,6 @@ Then run:
 curl -s -X POST "https://api.explorium.ai/v1/businesses/stats" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
 
----
-
 ### 2. Match a Business
 
 Find a business by name or domain and get its unique `business_id`:
@@ -87,8 +61,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.explorium.ai/v1/businesses/match" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
-
----
 
 ### 3. Fetch Businesses
 
@@ -118,8 +90,6 @@ Then run:
 curl -s -X POST "https://api.explorium.ai/v1/businesses" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
 
----
-
 ### 4. Enrich a Business
 
 Enrich a business with specific data categories. Replace `<enrichment_name>` with the enrichment type (e.g., `firmographics`, `technographics`, `financial_metrics`):
@@ -144,8 +114,6 @@ Common enrichment types:
 - `financial_metrics` - Revenue, funding, financial indicators
 - `social_media` - Social media presence and metrics
 
----
-
 ### 5. Bulk Enrich Businesses
 
 Enrich multiple businesses at once (up to 50 per request):
@@ -166,8 +134,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.explorium.ai/v1/businesses/<enrichment_name>/bulk_enrich" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
-
----
 
 ### 6. Fetch Prospects
 
@@ -200,8 +166,6 @@ Then run:
 curl -s -X POST "https://api.explorium.ai/v1/prospects" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
 
----
-
 ### 7. Match a Prospect
 
 Find a specific prospect by name and company:
@@ -222,8 +186,6 @@ Then run:
 curl -s -X POST "https://api.explorium.ai/v1/prospects/match" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
 
----
-
 ### 8. Enrich Prospect Contact Information
 
 Get contact details for a specific prospect:
@@ -241,8 +203,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.explorium.ai/v1/prospects/contacts_information/enrich" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
-
----
 
 ### 9. Get Prospect Statistics
 
@@ -269,8 +229,6 @@ Then run:
 curl -s -X POST "https://api.explorium.ai/v1/prospects/stats" --header "Content-Type: application/json" --header "api_key: $EXPLORIUM_TOKEN" -d @/tmp/explorium_request.json | jq .
 ```
 
----
-
 ### 10. Autocomplete Businesses
 
 Search for businesses by partial name for quick lookups:
@@ -278,8 +236,6 @@ Search for businesses by partial name for quick lookups:
 ```bash
 curl -s -X GET "https://api.explorium.ai/v1/businesses/autocomplete?query=explor" --header "api_key: $EXPLORIUM_TOKEN" | jq .
 ```
-
----
 
 ## Guidelines
 

--- a/fal/SKILL.md
+++ b/fal/SKILL.md
@@ -4,29 +4,9 @@ description: Fal.ai API for AI image and video generation. Use when user mention
   "Fal.ai", "AI image generation", "video generation", or "fal" models.
 ---
 
-# fal.ai Image Generator
+## Troubleshooting
 
-Use the fal.ai API to **generate images from text prompts**.
-
-> Official docs: `https://fal.ai/docs`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Generate images from text descriptions**
-- **Create illustrations or visual content**
-- **Generate blog headers, thumbnails, or social media images**
-
----
-
-## Prerequisites
-
-Connect the **fal.ai Image Generator** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name FAL_TOKEN` or `zero doctor check-connector --url https://fal.run/fal-ai/nano-banana-pro --method POST`
+If requests fail, run `zero doctor check-connector --env-name FAL_TOKEN` or `zero doctor check-connector --url https://fal.run/fal-ai/nano-banana-pro --method POST`
 
 ## How to Use
 
@@ -132,8 +112,6 @@ echo "Neon city at night" | jq -Rs '{prompt: ., image_size: "landscape_16_9"}' >
 curl -s -X POST "https://fal.run/fal-ai/nano-banana-pro" --header "Authorization: Key $FAL_TOKEN" --header "Content-Type: application/json" -d @/tmp/fal_request.json | jq -r '.images[0].url'
 ```
 
----
-
 ## Available Models
 
 | Model | Description |
@@ -145,8 +123,6 @@ curl -s -X POST "https://fal.run/fal-ai/nano-banana-pro" --header "Authorization
 
 See more at: https://fal.ai/models
 
----
-
 ## Image Sizes
 
 | Size | Aspect Ratio |
@@ -157,8 +133,6 @@ See more at: https://fal.ai/models
 | `portrait_16_9` | 16:9 |
 | `landscape_4_3` | 3:4 |
 | `landscape_16_9` | 9:16 |
-
----
 
 ## Prompt Guidelines
 

--- a/figma/SKILL.md
+++ b/figma/SKILL.md
@@ -5,40 +5,15 @@ description: Figma API for design files and assets. Use when user mentions "Figm
   designs.
 ---
 
-# Figma API
+## Troubleshooting
 
-Access and manage design files, components, comments, and projects in Figma workspaces via REST API.
-
-> Official docs: `https://developers.figma.com/docs/rest-api/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Read design files** and extract components, styles, and frames
-- **Export images** from Figma designs in various formats (PNG, JPG, SVG, PDF)
-- **Get file version history** and track changes
-- **Manage comments** on design files
-- **Access design tokens** and styles
-- **Get component information** from design systems
-
----
-
-## Prerequisites
-
-Connect the **Figma** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name FIGMA_TOKEN` or `zero doctor check-connector --url https://api.figma.com/v1/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name FIGMA_TOKEN` or `zero doctor check-connector --url https://api.figma.com/v1/me --method GET`
 
 ## How to Use
 
 All examples assume `FIGMA_TOKEN` is set.
 
 Base URL: `https://api.figma.com/v1`
-
----
 
 ### 1. Get Current User
 
@@ -47,8 +22,6 @@ Get information about the authenticated user (no parameters needed):
 ```bash
 curl -s "https://api.figma.com/v1/me" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '{id, email, handle, img_url}'
 ```
-
----
 
 ### 2. Get File
 
@@ -59,8 +32,6 @@ Replace `<file-key>` with your actual file key from a Figma URL.
 ```bash
 curl -s "https://api.figma.com/v1/files/<file-key>" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '{name, lastModified, version, document: .document.children[0].name}'
 ```
-
----
 
 ### 3. Get File Nodes
 
@@ -73,8 +44,6 @@ curl -s "https://api.figma.com/v1/files/<file-key>/nodes?ids=<node-id>" --header
 ```
 
 Node IDs can be found in the file structure or from the Figma URL `?node-id=X-Y` parameter (convert `-` to `:`).
-
----
 
 ### 4. Get File Images
 
@@ -90,8 +59,6 @@ curl -s "https://api.figma.com/v1/images/<file-key>?ids=<node-id>&format=png&sca
 - `format`: `png`, `jpg`, `svg`, `pdf` (default: `png`)
 - `scale`: `0.5`, `1`, `2`, `4` (default: `1`)
 
----
-
 ### 5. Get Image Fills
 
 Get download URLs for all images used in a file.
@@ -102,8 +69,6 @@ Replace `<file-key>` with your file key.
 curl -s "https://api.figma.com/v1/files/<file-key>/images" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '.meta.images'
 ```
 
----
-
 ### 6. Get File Comments
 
 List all comments on a file.
@@ -113,8 +78,6 @@ Replace `<file-key>` with your file key.
 ```bash
 curl -s "https://api.figma.com/v1/files/<file-key>/comments" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '.comments[] | {id, message: .message, user: .user.handle, created_at}'
 ```
-
----
 
 ### 7. Post Comment
 
@@ -138,8 +101,6 @@ Write to `/tmp/figma_comment.json`:
 curl -s -X POST "https://api.figma.com/v1/files/<file-key>/comments" --header "Authorization: Bearer $FIGMA_TOKEN" --header "Content-Type: application/json" -d @/tmp/figma_comment.json | jq '{id, message}'
 ```
 
----
-
 ### 8. Get File Versions
 
 List version history of a file.
@@ -149,8 +110,6 @@ Replace `<file-key>` with your file key.
 ```bash
 curl -s "https://api.figma.com/v1/files/<file-key>/versions" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '.versions[] | {id, created_at, label, description, user: .user.handle}'
 ```
-
----
 
 ### 9. Get Project Files
 
@@ -162,8 +121,6 @@ Replace `<project-id>` with your project ID. Project IDs can be found in Figma U
 curl -s "https://api.figma.com/v1/projects/<project-id>/files" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '.files[] | {key, name, last_modified}'
 ```
 
----
-
 ### 10. Get Component Sets
 
 Get component sets (variants) in a file.
@@ -174,8 +131,6 @@ Replace `<file-key>` with your file key.
 curl -s "https://api.figma.com/v1/files/<file-key>/component_sets" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '.meta.component_sets[] | {key, name, description}'
 ```
 
----
-
 ### 11. Get Component
 
 Get metadata for a specific component.
@@ -185,8 +140,6 @@ Replace `<component-key>` with your component key from the component sets output
 ```bash
 curl -s "https://api.figma.com/v1/components/<component-key>" --header "Authorization: Bearer $FIGMA_TOKEN" | jq '{key, name, description, containing_frame}'
 ```
-
----
 
 ## Understanding File Structure
 
@@ -205,8 +158,6 @@ FILE
 ```
 
 Common node types: `CANVAS`, `FRAME`, `GROUP`, `VECTOR`, `BOOLEAN_OPERATION`, `STAR`, `LINE`, `ELLIPSE`, `REGULAR_POLYGON`, `RECTANGLE`, `TEXT`, `SLICE`, `COMPONENT`, `COMPONENT_SET`, `INSTANCE`
-
----
 
 ## Guidelines
 

--- a/firecrawl/SKILL.md
+++ b/firecrawl/SKILL.md
@@ -4,39 +4,15 @@ description: Firecrawl API for web scraping and crawling. Use when user mentions
   "crawl website", "scrape site", or web extraction.
 ---
 
-# Firecrawl
+## Troubleshooting
 
-Use the Firecrawl API via direct `curl` calls to **scrape websites and extract data for AI**.
-
-> Official docs: `https://docs.firecrawl.dev/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Scrape a webpage** and convert to markdown/HTML
-- **Crawl an entire website** and extract all pages
-- **Discover all URLs** on a website
-- **Search the web** and get full page content
-- **Extract structured data** using AI
-
----
-
-## Prerequisites
-
-Connect the **Firecrawl** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name FIRECRAWL_TOKEN` or `zero doctor check-connector --url https://api.firecrawl.dev/v1/scrape --method POST`
+If requests fail, run `zero doctor check-connector --env-name FIRECRAWL_TOKEN` or `zero doctor check-connector --url https://api.firecrawl.dev/v1/scrape --method POST`
 
 ## How to Use
 
 All examples below assume you have `FIRECRAWL_TOKEN` set.
 
 Base URL: `https://api.firecrawl.dev/v1`
-
----
 
 ## 1. Scrape - Single Page
 
@@ -121,8 +97,6 @@ curl -s -X POST "https://api.firecrawl.dev/v1/scrape" -H "Authorization: Bearer 
 | `onlyMainContent` | boolean | Skip headers/footers |
 | `timeout` | number | Timeout in milliseconds |
 
----
-
 ## 2. Crawl - Entire Website
 
 Crawl all pages of a website (async operation).
@@ -200,8 +174,6 @@ curl -s -X POST "https://api.firecrawl.dev/v1/crawl" -H "Authorization: Bearer $
 | `includePaths` | array | Paths to include (e.g., `/blog/*`) |
 | `excludePaths` | array | Paths to exclude |
 
----
-
 ## 3. Map - URL Discovery
 
 Get all URLs from a website quickly.
@@ -247,8 +219,6 @@ curl -s -X POST "https://api.firecrawl.dev/v1/map" -H "Authorization: Bearer $FI
 | `url` | string | Website URL (required) |
 | `search` | string | Filter URLs containing keyword |
 | `limit` | number | Max URLs to return (default: 1000) |
-
----
 
 ## 4. Search - Web Search
 
@@ -298,8 +268,6 @@ curl -s -X POST "https://api.firecrawl.dev/v1/search" -H "Authorization: Bearer 
 | `query` | string | Search query (required) |
 | `limit` | number | Number of results (default: 10) |
 | `scrapeOptions` | object | Options for scraping results |
-
----
 
 ## 5. Extract - AI Data Extraction
 
@@ -375,8 +343,6 @@ curl -s -X POST "https://api.firecrawl.dev/v1/extract" -H "Authorization: Bearer
 | `urls` | array | URLs to extract from (required) |
 | `prompt` | string | Description of data to extract (required) |
 | `schema` | object | JSON schema for structured output |
-
----
 
 ## Practical Examples
 
@@ -463,8 +429,6 @@ while true; do
 done
 ```
 
----
-
 ## Response Format
 
 ### Scrape Response
@@ -494,8 +458,6 @@ done
   "data": [...]
 }
 ```
-
----
 
 ## Guidelines
 

--- a/fireflies/SKILL.md
+++ b/fireflies/SKILL.md
@@ -4,30 +4,9 @@ description: Fireflies.ai API for meeting transcription. Use when user mentions 
   "meeting notes", "transcription", or "meeting summary".
 ---
 
-# Fireflies
+## Troubleshooting
 
-Use the Fireflies.ai GraphQL API via direct `curl` calls to **transcribe and analyze meetings**.
-
-> Official docs: `https://docs.fireflies.ai/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **List and search meeting transcripts** by keyword, date, or participants
-- **Fetch a single transcript** with full details, sentences, analytics, and summaries
-- **Upload audio files** for transcription
-- **Get user information** for the API key owner or team members
-
----
-
-## Prerequisites
-
-Connect the **Fireflies** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name FIREFLIES_TOKEN` or `zero doctor check-connector --url https://api.fireflies.ai/graphql --method POST`
+If requests fail, run `zero doctor check-connector --env-name FIREFLIES_TOKEN` or `zero doctor check-connector --url https://api.fireflies.ai/graphql --method POST`
 
 ## How to Use
 
@@ -36,8 +15,6 @@ All examples below assume you have `FIREFLIES_TOKEN` set.
 Endpoint: `https://api.fireflies.ai/graphql`
 
 The Fireflies API is **GraphQL-based**. All requests are `POST` to a single endpoint. Write the GraphQL query to `/tmp/fireflies_request.json`, then execute with curl.
-
----
 
 ## 1. Get Current User
 
@@ -56,8 +33,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.fireflies.ai/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $FIREFLIES_TOKEN" -d @/tmp/fireflies_request.json | jq '.data.user'
 ```
-
----
 
 ## 2. List Transcripts
 
@@ -141,8 +116,6 @@ curl -s -X POST "https://api.fireflies.ai/graphql" --header "Content-Type: appli
 | `limit` | Int | Max results (default 50) |
 | `skip` | Int | Pagination offset |
 
----
-
 ## 3. Get Single Transcript
 
 Fetch full details for a specific transcript.
@@ -215,8 +188,6 @@ Then run:
 curl -s -X POST "https://api.fireflies.ai/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $FIREFLIES_TOKEN" -d @/tmp/fireflies_request.json | jq '.data.transcript.analytics'
 ```
 
----
-
 ## 4. Upload Audio for Transcription
 
 Upload an audio file URL for Fireflies to transcribe. The file must be publicly accessible via HTTPS. Supported formats: mp3, mp4, wav, m4a, ogg.
@@ -279,8 +250,6 @@ curl -s -X POST "https://api.fireflies.ai/graphql" --header "Content-Type: appli
 | `save_video` | Boolean | Retain video file |
 | `client_reference_id` | String | Custom identifier for the upload |
 
----
-
 ## 5. List Team Users
 
 Fetch all users in the team.
@@ -298,8 +267,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.fireflies.ai/graphql" --header "Content-Type: application/json" --header "Authorization: Bearer $FIREFLIES_TOKEN" -d @/tmp/fireflies_request.json | jq '.data.users'
 ```
-
----
 
 ## Guidelines
 

--- a/flux-analysis/SKILL.md
+++ b/flux-analysis/SKILL.md
@@ -3,14 +3,6 @@ name: flux-analysis
 description: Decompose financial variances into underlying drivers and produce narrative explanations with waterfall bridge analysis. Use for budget vs actual analysis, period-over-period comparison, revenue variance decomposition, expense variance analysis, variance commentary, waterfall charts, forecast accuracy measurement, or P&L flux review.
 ---
 
-# Flux & Variance Analysis
-
-Methods for breaking apart financial movements into causal components, setting investigation thresholds, writing clear variance narratives, constructing bridge visualizations, and measuring forecast precision.
-
-## Prerequisites
-
-Connect the **Flux & Variance Analysis** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Decomposition Techniques
 
 ### Price x Volume Separation

--- a/gaap-reporting/SKILL.md
+++ b/gaap-reporting/SKILL.md
@@ -3,14 +3,6 @@ name: gaap-reporting
 description: Prepare GAAP-compliant financial statements including P&L, balance sheet, and cash flow statement with proper classification, disclosure requirements, and period comparisons. Use for income statement generation, balance sheet preparation, statement of cash flows, financial report formatting, ASC standards compliance, reclassification entries, or building management reporting packages.
 ---
 
-# GAAP Financial Reporting
-
-Authoritative guidance, structural templates, required disclosures, and analytical procedures for producing compliant financial statements under US GAAP (with IFRS references where relevant).
-
-## Prerequisites
-
-Connect the **GAAP Financial Reporting** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Profit and Loss Statement
 
 ### Recommended Line-Item Structure (Functional Expense Method)

--- a/gamma/SKILL.md
+++ b/gamma/SKILL.md
@@ -3,31 +3,9 @@ name: gamma
 description: Gamma API for creating presentations, documents, and websites from text. Use when user mentions "Gamma", "create presentation", "generate slides", "make a deck", "create a document with Gamma", or "generate a webpage".
 ---
 
-# Gamma API
+## Troubleshooting
 
-Generate polished presentations, documents, websites, and social posts from text using Gamma's AI-powered API. Supports custom themes, export formats (PDF, PPTX, PNG), and asynchronous generation with status polling.
-
-> Official docs: `https://developers.gamma.app`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Generate a presentation or slide deck from an outline or topic description
-- Create a document or webpage using AI from text input
-- Generate branded content using a specific Gamma theme
-- Export presentations to PDF or PPTX
-- Batch-produce content variations from a fixed template
-
----
-
-## Prerequisites
-
-Connect the **Gamma** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GAMMA_TOKEN` or `zero doctor check-connector --url https://public-api.gamma.app/v1.0/generations --method POST`
+If requests fail, run `zero doctor check-connector --env-name GAMMA_TOKEN` or `zero doctor check-connector --url https://public-api.gamma.app/v1.0/generations --method POST`
 
 ## Core APIs
 
@@ -68,8 +46,6 @@ Response includes `generationId`. Use it to poll for status (see below).
 
 **`exportAs` options (optional):** `pdf`, `pptx`, `png`
 
----
-
 ### 2. Poll Generation Status
 
 Poll every 5 seconds until `status` is `completed` or `failed`.
@@ -97,8 +73,6 @@ curl -s "https://public-api.gamma.app/v1.0/generations/<your-generation-id>" --h
 
 `gammaUrl` is the shareable link. `exportUrl` (when `exportAs` was set) is a signed download URL valid for ~1 week.
 
----
-
 ### 3. Create Generation from Template
 
 Generate content using an existing Gamma template. The template must be a single-page document.
@@ -121,8 +95,6 @@ curl -s -X POST "https://public-api.gamma.app/v1.0/generations/from-template" --
 
 Response includes `generationId` — poll with the same status endpoint.
 
----
-
 ### 4. List Themes
 
 Retrieve available workspace themes to use as `themeId` in generation requests.
@@ -139,8 +111,6 @@ curl -s "https://public-api.gamma.app/v1.0/themes?query=dark&limit=10" --header 
 
 Use the `id` field value as `themeId` in generation requests.
 
----
-
 ### 5. List Folders
 
 Retrieve workspace folders to use as `folderIds` in generation requests.
@@ -150,8 +120,6 @@ curl -s "https://public-api.gamma.app/v1.0/folders" --header "X-API-KEY: $GAMMA_
 ```
 
 Use the `id` field value in the `folderIds` array in generation requests.
-
----
 
 ## Advanced Generation Options
 
@@ -181,8 +149,6 @@ curl -s -X POST "https://public-api.gamma.app/v1.0/generations" --header "X-API-
 ```
 
 Use `\n---\n` in `inputText` to manually split slides/cards.
-
----
 
 ## Guidelines
 

--- a/github-copilot/SKILL.md
+++ b/github-copilot/SKILL.md
@@ -4,33 +4,9 @@ description: GitHub Copilot API for AI coding assistance. Use when user mentions
   "GitHub Copilot", "AI coding", or asks about Copilot features.
 ---
 
-# GitHub Copilot API
+## Troubleshooting
 
-Use the GitHub Copilot REST API via direct `curl` calls to **manage Copilot subscriptions and retrieve usage metrics** for your organization.
-
-> Official docs: `https://docs.github.com/en/rest/copilot`
-
-**Note:** This API is for managing Copilot subscriptions and viewing metrics, not for code generation.
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage Copilot seat assignments** (add/remove users and teams)
-- **View Copilot billing information** for an organization
-- **Retrieve usage metrics** (active users, code completions, chat usage)
-- **Monitor Copilot adoption** across teams
-- **Audit Copilot usage** for compliance
-
----
-
-## Prerequisites
-
-Connect the **GitHub Copilot** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GITHUB_TOKEN` or `zero doctor check-connector --url https://api.github.com/orgs/your-org/copilot/billing --method GET`
+If requests fail, run `zero doctor check-connector --env-name GITHUB_TOKEN` or `zero doctor check-connector --url https://api.github.com/orgs/your-org/copilot/billing --method GET`
 
 ## How to Use
 
@@ -42,8 +18,6 @@ Base URL: `https://api.github.com`
 - `Authorization: Bearer ${GITHUB_TOKEN}`
 - `Accept: application/vnd.github+json`
 - `X-GitHub-Api-Version: 2022-11-28`
-
----
 
 ### 1. Get Copilot Billing Information
 
@@ -69,8 +43,6 @@ curl -s -X GET "https://api.github.com/orgs/your-org-name/copilot/billing" --hea
 }
 ```
 
----
-
 ### 2. List All Copilot Seat Assignments
 
 Get all users with Copilot seats. Replace `your-org-name` with your organization name:
@@ -79,8 +51,6 @@ Get all users with Copilot seats. Replace `your-org-name` with your organization
 curl -s -X GET "https://api.github.com/orgs/your-org-name/copilot/billing/seats?per_page=50" --header "Authorization: Bearer $GITHUB_TOKEN" --header "Accept: application/vnd.github+json" --header "X-GitHub-Api-Version: 2022-11-28" | jq '.seats[] | {login: .assignee.login, last_activity: .last_activity_at}'
 ```
 
----
-
 ### 3. Get Copilot Seat Details for a User
 
 Get specific user's Copilot seat information. Replace `your-org-name` with your organization name and `username` with the target username:
@@ -88,8 +58,6 @@ Get specific user's Copilot seat information. Replace `your-org-name` with your 
 ```bash
 curl -s -X GET "https://api.github.com/orgs/your-org-name/members/username/copilot" --header "Authorization: Bearer $GITHUB_TOKEN" --header "Accept: application/vnd.github+json" --header "X-GitHub-Api-Version: 2022-11-28"
 ```
-
----
 
 ### 4. Add Users to Copilot Subscription
 
@@ -116,8 +84,6 @@ curl -s -X POST "https://api.github.com/orgs/your-org-name/copilot/billing/selec
 }
 ```
 
----
-
 ### 5. Remove Users from Copilot Subscription
 
 Remove Copilot seats from specific users. Replace `your-org-name` with your organization name:
@@ -143,8 +109,6 @@ curl -s -X DELETE "https://api.github.com/orgs/your-org-name/copilot/billing/sel
 }
 ```
 
----
-
 ### 6. Add Teams to Copilot Subscription
 
 Assign Copilot to entire teams. Replace `your-org-name` with your organization name:
@@ -162,8 +126,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.github.com/orgs/your-org-name/copilot/billing/selected_teams" --header "Authorization: Bearer $GITHUB_TOKEN" --header "Accept: application/vnd.github+json" --header "X-GitHub-Api-Version: 2022-11-28" --header "Content-Type: application/json" -d @/tmp/github_copilot_request.json
 ```
-
----
 
 ### 7. Remove Teams from Copilot Subscription
 
@@ -183,8 +145,6 @@ Then run:
 curl -s -X DELETE "https://api.github.com/orgs/your-org-name/copilot/billing/selected_teams" --header "Authorization: Bearer $GITHUB_TOKEN" --header "Accept: application/vnd.github+json" --header "X-GitHub-Api-Version: 2022-11-28" --header "Content-Type: application/json" -d @/tmp/github_copilot_request.json
 ```
 
----
-
 ### 8. Get Copilot Usage Metrics for Organization
 
 Get usage statistics (requires 5+ active users). Replace `your-org-name` with your organization name:
@@ -202,8 +162,6 @@ curl -s -X GET "https://api.github.com/orgs/your-org-name/copilot/metrics?per_pa
 }
 ```
 
----
-
 ### 9. Get Copilot Metrics for a Team
 
 Get team-specific usage metrics. Replace `your-org-name` with your organization name and `team-name` with the target team:
@@ -211,8 +169,6 @@ Get team-specific usage metrics. Replace `your-org-name` with your organization 
 ```bash
 curl -s -X GET "https://api.github.com/orgs/your-org-name/team/team-name/copilot/metrics" --header "Authorization: Bearer $GITHUB_TOKEN" --header "Accept: application/vnd.github+json" --header "X-GitHub-Api-Version: 2022-11-28"
 ```
-
----
 
 ## Metrics Data Structure
 
@@ -226,8 +182,6 @@ The metrics response includes:
 | `copilot_ide_chat` | IDE chat usage stats |
 | `copilot_dotcom_chat` | GitHub.com chat usage |
 | `copilot_dotcom_pull_requests` | PR summary usage |
-
----
 
 ## Guidelines
 

--- a/github/SKILL.md
+++ b/github/SKILL.md
@@ -5,10 +5,6 @@ description: GitHub API for repos, issues, and PRs. Use when user mentions "GitH
   about code hosting.
 ---
 
-# GitHub Automation
-
-This Skill helps you manage GitHub operations using the `gh` CLI, including repositories, issues, pull requests, releases, and GitHub Actions workflows.
-
 ## Capabilities
 
 - **Repositories**: Create, clone, fork, view, and manage repos
@@ -20,7 +16,6 @@ This Skill helps you manage GitHub operations using the `gh` CLI, including repo
 - **Search**: Search repos, issues, PRs, code, and users
 
 ## Authentication
-
 
 Verify with:
 ```bash
@@ -127,8 +122,3 @@ gh pr list --repo <owner>/<repo> --state open --search "review:required"
 ```bash
 gh pr view <number> --repo <owner>/<repo> --json title,state,reviews,checks
 ```
-
-## Prerequisites
-
-Connect the **GitHub** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-

--- a/gitlab/SKILL.md
+++ b/gitlab/SKILL.md
@@ -4,31 +4,9 @@ description: GitLab API for repos and CI/CD. Use when user mentions "GitLab", "g
   shares a GitLab link, "GitLab repo", or asks about GitLab projects.
 ---
 
-# GitLab API
+## Troubleshooting
 
-Use the GitLab REST API via direct `curl` calls to manage **projects, issues, merge requests, and pipelines**.
-
-> Official docs: `https://docs.gitlab.com/ee/api/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage projects** - list, create, get project details
-- **Handle issues** - create, update, close, list issues
-- **Work with merge requests** - create, list, merge MRs
-- **Check pipelines** - list jobs, view pipeline status
-- **Manage users** - search users, get user info
-
----
-
-## Prerequisites
-
-Connect the **GitLab** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GITLAB_TOKEN` or `zero doctor check-connector --url https://gitlab.com/api/v4/user --method GET`
+If requests fail, run `zero doctor check-connector --env-name GITLAB_TOKEN` or `zero doctor check-connector --url https://gitlab.com/api/v4/user --method GET`
 
 ## How to Use
 
@@ -38,8 +16,6 @@ Base URL: `https://${GITLAB_HOST}/api/v4`
 
 > Note: Project IDs can be numeric (e.g., `123`) or URL-encoded paths (e.g., `mygroup%2Fmyproject`).
 
----
-
 ### 1. Get Current User
 
 Verify your authentication:
@@ -47,8 +23,6 @@ Verify your authentication:
 ```bash
 curl -s "https://$GITLAB_HOST/api/v4/user" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" | jq '{id, username, name, email, state}'
 ```
-
----
 
 ### 2. List Projects
 
@@ -64,8 +38,6 @@ Filter options:
 - `search=keyword` - Search by name
 - `visibility=public|internal|private` - Filter by visibility
 
----
-
 ### 3. Get Project Details
 
 Get details for a specific project. Replace `<project-id>` with the numeric project ID or URL-encoded path (e.g., `mygroup%2Fmyproject`):
@@ -73,8 +45,6 @@ Get details for a specific project. Replace `<project-id>` with the numeric proj
 ```bash
 curl -s "https://$GITLAB_HOST/api/v4/projects/<project-id>" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" | jq '{id, name, path_with_namespace, default_branch, visibility, web_url}
 ```
-
----
 
 ### 4. List Project Issues
 
@@ -90,8 +60,6 @@ Filter options:
 - `assignee_id=123` - Filter by assignee
 - `search=keyword` - Search in title/description
 
----
-
 ### 5. Get Issue Details
 
 Get a specific issue. Replace `<project-id>` and `<issue-iid>` with actual values:
@@ -99,8 +67,6 @@ Get a specific issue. Replace `<project-id>` and `<issue-iid>` with actual value
 ```bash
 curl -s "https://$GITLAB_HOST/api/v4/projects/<project-id>/issues/<issue-iid>" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" | jq '{iid, title, description, state, author: .author.username, assignees: [.assignees[].username], labels, created_at, web_url}'
 ```
-
----
 
 ### 6. Create Issue
 
@@ -121,8 +87,6 @@ Then run:
 ```bash
 curl -s -X POST "https://$GITLAB_HOST/api/v4/projects/<project-id>/issues" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" -d @/tmp/gitlab_request.json | jq '{iid, title, web_url}'
 ```
-
----
 
 ### 7. Create Issue with Assignee and Milestone
 
@@ -146,8 +110,6 @@ Then run:
 curl -s -X POST "https://$GITLAB_HOST/api/v4/projects/<project-id>/issues" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" -d @/tmp/gitlab_request.json | jq '{iid, title, web_url}'
 ```
 
----
-
 ### 8. Update Issue
 
 Update an existing issue. Replace `<project-id>` and `<issue-iid>` with actual values:
@@ -166,8 +128,6 @@ Then run:
 ```bash
 curl -s -X PUT "https://$GITLAB_HOST/api/v4/projects/<project-id>/issues/<issue-iid>" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" -d @/tmp/gitlab_request.json | jq '{iid, title, labels, updated_at}'
 ```
-
----
 
 ### 9. Close Issue
 
@@ -189,8 +149,6 @@ curl -s -X PUT "https://$GITLAB_HOST/api/v4/projects/<project-id>/issues/<issue-
 
 Use `"state_event": "reopen"` to reopen a closed issue.
 
----
-
 ### 10. Add Comment to Issue
 
 Add a note/comment to an issue. Replace `<project-id>` and `<issue-iid>` with actual values:
@@ -209,8 +167,6 @@ Then run:
 curl -s -X POST "https://$GITLAB_HOST/api/v4/projects/<project-id>/issues/<issue-iid>/notes" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" -d @/tmp/gitlab_request.json | jq '{id, body, author: .author.username, created_at}'
 ```
 
----
-
 ### 11. List Merge Requests
 
 Get merge requests for a project. Replace `<project-id>` with the actual project ID:
@@ -224,8 +180,6 @@ Filter options:
 - `scope=created_by_me|assigned_to_me|all` - Filter by involvement
 - `labels=review-needed` - Filter by labels
 
----
-
 ### 12. Get Merge Request Details
 
 Get a specific merge request. Replace `<project-id>` and `<mr-iid>` with actual values:
@@ -233,8 +187,6 @@ Get a specific merge request. Replace `<project-id>` and `<mr-iid>` with actual 
 ```bash
 curl -s "https://$GITLAB_HOST/api/v4/projects/<project-id>/merge_requests/<mr-iid>" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" | jq '{iid, title, state, source_branch, target_branch, author: .author.username, merge_status, has_conflicts, web_url}'
 ```
-
----
 
 ### 13. Create Merge Request
 
@@ -256,8 +208,6 @@ Then run:
 ```bash
 curl -s -X POST "https://$GITLAB_HOST/api/v4/projects/<project-id>/merge_requests" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" -d @/tmp/gitlab_request.json | jq '{iid, title, web_url}'
 ```
-
----
 
 ### 14. Merge a Merge Request
 
@@ -282,8 +232,6 @@ Options:
 - `squash=true` - Squash commits before merging
 - `should_remove_source_branch=true` - Delete source branch after merge
 
----
-
 ### 15. List Pipelines
 
 Get pipelines for a project. Replace `<project-id>` with the actual project ID:
@@ -291,8 +239,6 @@ Get pipelines for a project. Replace `<project-id>` with the actual project ID:
 ```bash
 curl -s "https://$GITLAB_HOST/api/v4/projects/<project-id>/pipelines?per_page=10" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" | jq '.[] | {id, status, ref, sha: .sha[0:8], created_at, web_url}'
 ```
-
----
 
 ### 16. Get Pipeline Details
 
@@ -302,8 +248,6 @@ Get details of a specific pipeline. Replace `<project-id>` and `<pipeline-id>` w
 curl -s "https://$GITLAB_HOST/api/v4/projects/<project-id>/pipelines/<pipeline-id>" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" | jq '{id, status, ref, duration, finished_at, web_url}'
 ```
 
----
-
 ### 17. List Pipeline Jobs
 
 Get jobs in a pipeline. Replace `<project-id>` and `<pipeline-id>` with actual values:
@@ -311,8 +255,6 @@ Get jobs in a pipeline. Replace `<project-id>` and `<pipeline-id>` with actual v
 ```bash
 curl -s "https://$GITLAB_HOST/api/v4/projects/<project-id>/pipelines/<pipeline-id>/jobs" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" | jq '.[] | {id, name, stage, status, duration}'
 ```
-
----
 
 ### 18. Search Users
 
@@ -327,8 +269,6 @@ john
 ```bash
 curl -s -G "https://$GITLAB_HOST/api/v4/users" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --data-urlencode "search@/tmp/gitlab_search.txt" | jq '.[] | {id, username, name, state}'
 ```
-
----
 
 ### 19. Create Project
 
@@ -350,8 +290,6 @@ Then run:
 curl -s -X POST "https://$GITLAB_HOST/api/v4/projects" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" --header "Content-Type: application/json" -d @/tmp/gitlab_request.json | jq '{id, path_with_namespace, web_url}'
 ```
 
----
-
 ### 20. Delete Issue
 
 Delete an issue (requires admin or owner permissions). Replace `<project-id>` and `<issue-iid>` with actual values:
@@ -361,8 +299,6 @@ curl -s -X DELETE "https://$GITLAB_HOST/api/v4/projects/<project-id>/issues/<iss
 ```
 
 Returns 204 No Content on success.
-
----
 
 ## Project ID Encoding
 
@@ -378,8 +314,6 @@ PROJECT_ID="123"
 # Using encoded path
 PROJECT_ID="mygroup%2Fmyproject"
 ```
-
----
 
 ## Guidelines
 

--- a/gmail/SKILL.md
+++ b/gmail/SKILL.md
@@ -4,38 +4,9 @@ description: Gmail API for email management. Use when user says "check email", "
   email", "search Gmail", "my inbox", or mentions Gmail messages.
 ---
 
-# Gmail API
+## Troubleshooting
 
-Read, send, and manage emails via Google's Gmail REST API.
-
-> Official docs: https://developers.google.com/workspace/gmail/api/reference/rest
-
----
-
-## Prerequisites
-
-Connect the **Gmail** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GMAIL_TOKEN` or `zero doctor check-connector --url https://gmail.googleapis.com/gmail/v1/users/me/profile --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- Read and search emails
-- Send emails or reply to threads
-- Manage drafts
-- Create and manage labels
-- List and modify threads
-- Get user profile information
-
----
-
----
-
-> **Placeholders:** Values in `{curly-braces}` like `{message-id}` are placeholders. Replace them with actual values when executing.
-
----
+If requests fail, run `zero doctor check-connector --env-name GMAIL_TOKEN` or `zero doctor check-connector --url https://gmail.googleapis.com/gmail/v1/users/me/profile --method GET`
 
 ## User Profile
 
@@ -44,8 +15,6 @@ Use this skill when you need to:
 ```bash
 curl -s "https://gmail.googleapis.com/gmail/v1/users/me/profile" --header "Authorization: Bearer $GMAIL_TOKEN"
 ```
-
----
 
 ## Messages
 
@@ -161,8 +130,6 @@ curl -s -X POST "https://gmail.googleapis.com/gmail/v1/users/me/messages/{messag
 curl -s -X DELETE "https://gmail.googleapis.com/gmail/v1/users/me/messages/{message-id}" --header "Authorization: Bearer $GMAIL_TOKEN"
 ```
 
----
-
 ## Threads
 
 ### List Threads
@@ -182,8 +149,6 @@ curl -s "https://gmail.googleapis.com/gmail/v1/users/me/threads/{thread-id}" --h
 ```bash
 curl -s -X POST "https://gmail.googleapis.com/gmail/v1/users/me/threads/{thread-id}/trash" --header "Authorization: Bearer $GMAIL_TOKEN"
 ```
-
----
 
 ## Labels
 
@@ -216,8 +181,6 @@ curl -s -X POST "https://gmail.googleapis.com/gmail/v1/users/me/labels" --header
 ```bash
 curl -s -X DELETE "https://gmail.googleapis.com/gmail/v1/users/me/labels/{label-id}" --header "Authorization: Bearer $GMAIL_TOKEN"
 ```
-
----
 
 ## Drafts
 
@@ -274,8 +237,6 @@ curl -s -X POST "https://gmail.googleapis.com/gmail/v1/users/me/drafts/send" --h
 curl -s -X DELETE "https://gmail.googleapis.com/gmail/v1/users/me/drafts/{draft-id}" --header "Authorization: Bearer $GMAIL_TOKEN"
 ```
 
----
-
 ## Attachments
 
 ### Get Attachment
@@ -283,8 +244,6 @@ curl -s -X DELETE "https://gmail.googleapis.com/gmail/v1/users/me/drafts/{draft-
 ```bash
 curl -s "https://gmail.googleapis.com/gmail/v1/users/me/messages/{message-id}/attachments/{attachment-id}" --header "Authorization: Bearer $GMAIL_TOKEN" | jq -r '.data' | base64 -d > attachment.bin
 ```
-
----
 
 ## Settings
 
@@ -342,8 +301,6 @@ Then run:
 curl -s -X POST "https://gmail.googleapis.com/gmail/v1/users/me/settings/filters" --header "Authorization: Bearer $GMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/gmail_request.json
 ```
 
----
-
 ## Common Scopes
 
 | Scope | Permission |
@@ -358,8 +315,6 @@ curl -s -X POST "https://gmail.googleapis.com/gmail/v1/users/me/settings/filters
 
 Use full URL: `https://www.googleapis.com/auth/gmail.modify`
 
----
-
 ## Decode Message Body
 
 Gmail returns message body as base64url encoded. To decode:
@@ -368,15 +323,11 @@ Gmail returns message body as base64url encoded. To decode:
 curl -s "https://gmail.googleapis.com/gmail/v1/users/me/messages/{message-id}" --header "Authorization: Bearer $GMAIL_TOKEN" | jq -r '.payload.body.data // .payload.parts[0].body.data' | tr '_-' '/+' | base64 -d
 ```
 
----
-
 ## Guidelines
 
 1. **Rate Limits**: Gmail API has quota limits; implement exponential backoff
 2. **Batch Requests**: Use batch endpoints for multiple operations
 3. **Message Format**: Messages must be RFC 2822 compliant and base64url encoded
-
----
 
 ## API Reference
 

--- a/google-calendar/SKILL.md
+++ b/google-calendar/SKILL.md
@@ -5,46 +5,13 @@ description: Google Calendar API for scheduling. Use when user mentions "calenda
   or "when am I free".
 ---
 
-# Google Calendar API
+## Troubleshooting
 
-Manage calendars and events via Google's Calendar REST API.
-
-> Official docs: https://developers.google.com/workspace/calendar/api/v3/reference
-
----
-
-## Prerequisites
-
-Connect the **Google Calendar** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GOOGLE_CALENDAR_TOKEN` or `zero doctor check-connector --url https://www.googleapis.com/calendar/v3/users/me/calendarList --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- List and manage calendars
-- Create, update, and delete calendar events
-- Search and filter events by time range
-- Manage event attendees and send invitations
-- Set up event reminders
-- Check free/busy availability
-- Handle recurring events
-- Quick-add events using natural language
-
----
-
----
-
-> **Placeholders:** Values in `{curly-braces}` like `{event-id}` are placeholders. Replace them with actual values when executing.
-
----
+If requests fail, run `zero doctor check-connector --env-name GOOGLE_CALENDAR_TOKEN` or `zero doctor check-connector --url https://www.googleapis.com/calendar/v3/users/me/calendarList --method GET`
 
 ## How to Use
 
 Base URL: `https://www.googleapis.com/calendar/v3`
-
----
 
 ## Calendar List
 
@@ -69,8 +36,6 @@ For primary calendar, use `primary` as the calendar ID:
 ```bash
 curl -s "https://www.googleapis.com/calendar/v3/calendars/primary" --header "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" | jq '{id, summary, description, timeZone}'
 ```
-
----
 
 ## Events
 
@@ -235,8 +200,6 @@ Send deletion notifications to attendees:
 curl -s -X DELETE "https://www.googleapis.com/calendar/v3/calendars/primary/events/{event-id}?sendUpdates=all" --header "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN"
 ```
 
----
-
 ## Attendees
 
 ### Set Attendees on Event
@@ -286,8 +249,6 @@ Then run:
 curl -s -X PATCH "https://www.googleapis.com/calendar/v3/calendars/primary/events/{event-id}?sendUpdates=all" --header "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" --header "Content-Type: application/json" -d @/tmp/calendar_request.json | jq '.error // {id, summary, attendees}'
 ```
 
----
-
 ## Reminders
 
 ### Set Custom Reminders
@@ -336,8 +297,6 @@ Then run:
 curl -s -X PATCH "https://www.googleapis.com/calendar/v3/calendars/primary/events/{event-id}" --header "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" --header "Content-Type: application/json" -d @/tmp/calendar_request.json | jq '.error // {id, summary, reminders}'
 ```
 
----
-
 ## Recurring Events
 
 ### Create Recurring Event
@@ -382,8 +341,6 @@ Get all instances of a recurring event:
 curl -s "https://www.googleapis.com/calendar/v3/calendars/primary/events/{recurring-event-id}/instances?timeMin=2024-01-01T00:00:00Z&timeMax=2024-12-31T23:59:59Z" --header "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" | jq '.items[]? | {id, summary, start, end, recurringEventId}'
 ```
 
----
-
 ## Free/Busy Information
 
 ### Query Free/Busy
@@ -410,8 +367,6 @@ Then run:
 ```bash
 curl -s -X POST "https://www.googleapis.com/calendar/v3/freeBusy" --header "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN" --header "Content-Type: application/json" -d @/tmp/calendar_request.json | jq '.error // .calendars'
 ```
-
----
 
 ## Secondary Calendars
 
@@ -456,8 +411,6 @@ curl -s -X PATCH "https://www.googleapis.com/calendar/v3/calendars/{calendar-id}
 curl -s -X DELETE "https://www.googleapis.com/calendar/v3/calendars/{calendar-id}" --header "Authorization: Bearer $GOOGLE_CALENDAR_TOKEN"
 ```
 
----
-
 ## Event Colors
 
 ### Set Event Color
@@ -489,8 +442,6 @@ Available color IDs:
 - 10: Basil
 - 11: Tomato
 
----
-
 ## Common Query Parameters
 
 | Parameter | Type | Purpose |
@@ -503,8 +454,6 @@ Available color IDs:
 | `q` | string | Free text search query |
 | `sendUpdates` | string | Send notifications: `all`, `externalOnly`, `none` |
 
----
-
 ## Guidelines
 
 1. **Primary Calendar**: Use `primary` as the calendar ID for the user's primary calendar
@@ -514,8 +463,6 @@ Available color IDs:
 5. **Patch vs Update**: Use PATCH for partial updates (more efficient), PUT for full replacement. Note: PATCH on `attendees` replaces the entire array — always include all intended attendees
 6. **Time Zones**: Always specify time zones explicitly to avoid ambiguity
 7. **Recurring Events**: To modify all instances, update the recurring event master; to modify single instance, update the specific instance ID
-
----
 
 ## API Reference
 

--- a/google-docs/SKILL.md
+++ b/google-docs/SKILL.md
@@ -5,46 +5,12 @@ description: Google Docs API for document editing. Use when user mentions "Googl
   creation.
 ---
 
-# Google Docs API
-
-Use the Google Docs API via direct `curl` calls to **create, read, update, and format Google Docs documents**.
-
-> Official docs: `https://developers.google.com/docs/api`
-
----
-
-## Prerequisites
-
-Connect the **Google Docs** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Create new documents** from scratch
-- **Read document content** and metadata
-- **Insert or replace text** in documents
-- **Format text** (bold, italic, font size, color)
-- **Manage paragraphs** (alignment, spacing, bullets)
-- **Insert tables, images, and page breaks**
-- **Get document structure** and element information
-
----
-
----
-
-> **Placeholders:** Values in `{curly-braces}` like `{document-id}` are placeholders. Replace them with actual values when executing.
-
----
-
 ## How to Use
 
 Base URL: `https://docs.googleapis.com/v1`
 
 **Finding your Document ID:**
 The document ID is in the URL: `https://docs.google.com/document/d/{DOCUMENT_ID}/edit`
-
----
 
 ### 1. Create New Document
 
@@ -64,8 +30,6 @@ Then run:
 curl -s -X POST "https://docs.googleapis.com/v1/documents" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '{documentId, title, documentUrl: ("https://docs.google.com/document/d/" + .documentId + "/edit")}'
 ```
 
----
-
 ### 2. Get Document Content
 
 Read the entire document structure and content:
@@ -74,8 +38,6 @@ Read the entire document structure and content:
 curl -s "https://docs.googleapis.com/v1/documents/{document-id}" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" | jq '{title: .title, body: .body.content}'
 ```
 
----
-
 ### 3. Get Document Metadata Only
 
 Get just the title and basic properties:
@@ -83,8 +45,6 @@ Get just the title and basic properties:
 ```bash
 curl -s "https://docs.googleapis.com/v1/documents/{document-id}" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" | jq '{documentId, title, revisionId, suggestionsViewMode}'
 ```
-
----
 
 ### 4. Insert Text at Beginning
 
@@ -113,8 +73,6 @@ Then run:
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
 
----
-
 ### 5. Insert Text at Specific Location
 
 Insert text at a specific index (get indexes from document content):
@@ -141,8 +99,6 @@ Then run:
 ```bash
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
-
----
 
 ### 6. Delete Content Range
 
@@ -171,8 +127,6 @@ Then run:
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
 
----
-
 ### 7. Find and Replace Text
 
 Replace all occurrences of text throughout the document:
@@ -200,8 +154,6 @@ Then run:
 ```bash
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies[0].replaceAllText'
 ```
-
----
 
 ### 8. Format Text as Bold
 
@@ -233,8 +185,6 @@ Then run:
 ```bash
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
-
----
 
 ### 9. Format Text with Multiple Styles
 
@@ -281,8 +231,6 @@ Then run:
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
 
----
-
 ### 10. Set Paragraph Alignment
 
 Change paragraph alignment (LEFT, CENTER, RIGHT, JUSTIFIED):
@@ -313,8 +261,6 @@ Then run:
 ```bash
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
-
----
 
 ### 11. Create Bulleted List
 
@@ -351,8 +297,6 @@ curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpd
 - `NUMBERED_DECIMAL_ALPHA_ROMAN`
 - `NUMBERED_DECIMAL_NESTED`
 
----
-
 ### 12. Insert Table
 
 Insert a table with specified rows and columns:
@@ -381,8 +325,6 @@ Then run:
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
 
----
-
 ### 13. Insert Page Break
 
 Insert a page break at a specific location:
@@ -408,8 +350,6 @@ Then run:
 ```bash
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
-
----
 
 ### 14. Insert Inline Image
 
@@ -447,8 +387,6 @@ Then run:
 ```bash
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // .replies // "done"'
 ```
-
----
 
 ### 15. Batch Operations (Multiple Updates)
 
@@ -501,8 +439,6 @@ Then run:
 curl -s -X POST "https://docs.googleapis.com/v1/documents/{document-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gdocs_request.json | jq '.error // (.replies | length)'
 ```
 
----
-
 ### 16. Extract Plain Text
 
 Get just the text content from a document:
@@ -511,8 +447,6 @@ Get just the text content from a document:
 curl -s "https://docs.googleapis.com/v1/documents/{document-id}" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" | jq -r '.body.content[]?.paragraph?.elements[]?.textRun?.content' | tr -d '\0'
 ```
 
----
-
 ### 17. Get Document Structure
 
 View document structure with element types and indexes:
@@ -520,8 +454,6 @@ View document structure with element types and indexes:
 ```bash
 curl -s "https://docs.googleapis.com/v1/documents/{document-id}" --header "Authorization: Bearer $GOOGLE_DOCS_TOKEN" | jq '.body.content[] | {startIndex, endIndex, paragraph: .paragraph.elements[0].textRun.content}'
 ```
-
----
 
 ## Common Scopes
 
@@ -535,8 +467,6 @@ curl -s "https://docs.googleapis.com/v1/documents/{document-id}" --header "Autho
 
 Use full URL: `https://www.googleapis.com/auth/documents`
 
----
-
 ## Index Reference
 
 Understanding indexes is critical for the Google Docs API:
@@ -545,8 +475,6 @@ Understanding indexes is critical for the Google Docs API:
 - **Index N**: Each character, newline, and structural element increments the index
 - **End index**: Use `"endIndex": startIndex + textLength` for ranges
 - **Tip**: Get document content first to see current indexes
-
----
 
 ## Text Style Fields
 
@@ -567,8 +495,6 @@ When using `updateTextStyle`, specify which fields to update in the `fields` par
 
 Use comma-separated for multiple: `"fields": "bold,italic,fontSize"`
 
----
-
 ## Paragraph Style Fields
 
 When using `updateParagraphStyle`:
@@ -585,8 +511,6 @@ When using `updateParagraphStyle`:
 | `indentEnd` | Right indentation |
 | `namedStyleType` | HEADING_1, HEADING_2, NORMAL_TEXT, etc. |
 
----
-
 ## Guidelines
 
 1. **Batch operations**: Combine multiple requests in a single batchUpdate call to improve performance
@@ -596,8 +520,6 @@ When using `updateParagraphStyle`:
 5. **RGB colors**: Color values range from 0.0 to 1.0 (not 0-255)
 6. **Share permissions**: Ensure the authenticated user has edit access to the document
 7. **batchUpdate responses**: Some operations (updateParagraphStyle, insertTable, insertPageBreak, insertInlineImage) return empty or absent `.replies`; output of `"done"` means success with no reply data. An `.error` key indicates failure.
-
----
 
 ## API Reference
 

--- a/google-drive/SKILL.md
+++ b/google-drive/SKILL.md
@@ -5,47 +5,13 @@ description: Google Drive API for file management. Use when user mentions "Googl
   storage.
 ---
 
-# Google Drive API
+## Troubleshooting
 
-Use the Google Drive API via direct `curl` calls to **manage files, folders, uploads, downloads, sharing, and permissions**.
-
-> Official docs: `https://developers.google.com/drive/api/v3/reference`
-
----
-
-## Prerequisites
-
-Connect the **Google Drive** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GOOGLE_DRIVE_TOKEN` or `zero doctor check-connector --url https://www.googleapis.com/drive/v3/files --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- **List and search** files and folders
-- **Upload files** to Google Drive
-- **Download files** from Google Drive
-- **Create folders** and organize files
-- **Move and copy** files between locations
-- **Share files** and manage permissions
-- **Get file metadata** (name, size, type, modified date)
-- **Delete files** (move to trash or permanent deletion)
-- **Export Google Docs** to different formats (PDF, DOCX, etc.)
-
----
-
----
-
-> **Placeholders:** Values in `{curly-braces}` like `{file-id}` are placeholders. Replace them with actual values when executing.
-
----
+If requests fail, run `zero doctor check-connector --env-name GOOGLE_DRIVE_TOKEN` or `zero doctor check-connector --url https://www.googleapis.com/drive/v3/files --method GET`
 
 ## How to Use
 
 Base URL: `https://www.googleapis.com/drive/v3`
-
----
 
 ## Files
 
@@ -191,8 +157,6 @@ Permanently delete a file (cannot be restored):
 curl -s -X DELETE "https://www.googleapis.com/drive/v3/files/{file-id}" --header "Authorization: Bearer $GOOGLE_DRIVE_TOKEN"
 ```
 
----
-
 ## Folders
 
 ### List Folders Only
@@ -249,8 +213,6 @@ List all files in a specific folder:
 ```bash
 curl -s "https://www.googleapis.com/drive/v3/files?q='{folder-id}'+in+parents&fields=files(id,name,mimeType,size)" --header "Authorization: Bearer $GOOGLE_DRIVE_TOKEN" | jq '.files'
 ```
-
----
 
 ## Sharing and Permissions
 
@@ -339,8 +301,6 @@ Permission types:
 - **domain**: Everyone in organization
 - **anyone**: Public access
 
----
-
 ## Common MIME Types
 
 | Type | MIME Type |
@@ -356,8 +316,6 @@ Permission types:
 | PNG | `image/png` |
 | ZIP | `application/zip` |
 
----
-
 ## Guidelines
 
 1. **Rate limits**: Default quota is 1,000 requests per 100 seconds per user
@@ -366,8 +324,6 @@ Permission types:
 4. **Fields parameter**: Specify `fields` to reduce response size and improve performance
 5. **Upload size limits**: Simple upload limited to 5MB; use resumable upload for larger files
 6. **Query escaping**: Escape single quotes in queries as `\'` and backslashes as `\\`
-
----
 
 ## API Reference
 

--- a/google-meet/SKILL.md
+++ b/google-meet/SKILL.md
@@ -5,45 +5,13 @@ description: Google Meet API for managing meeting spaces, conference records, pa
   record", "meeting recording", "meeting transcript", or "Google Meet link".
 ---
 
-# Google Meet API
+## Troubleshooting
 
-Manage Google Meet spaces, conference records, participants, recordings, and transcripts via the Google Meet REST API.
-
-> Official docs: https://developers.google.com/workspace/meet/api/reference/rest/v2
-
----
-
-## Prerequisites
-
-Connect the **Google Meet** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GOOGLE_MEET_TOKEN` or `zero doctor check-connector --url https://meet.googleapis.com/v2/spaces --method POST`
-
-## When to Use
-
-Use this skill when you need to:
-
-- Create and manage Google Meet meeting spaces
-- Get or update meeting space configuration
-- End an active conference in a meeting space
-- List and retrieve conference records (past meetings)
-- List participants in a conference
-- List and retrieve meeting recordings
-- List and retrieve meeting transcripts and transcript entries
-
----
-
----
-
-> **Placeholders:** Values in `{curly-braces}` like `{space-name}` are placeholders. Replace them with actual values when executing.
-
----
+If requests fail, run `zero doctor check-connector --env-name GOOGLE_MEET_TOKEN` or `zero doctor check-connector --url https://meet.googleapis.com/v2/spaces --method POST`
 
 ## How to Use
 
 Base URL: `https://meet.googleapis.com/v2`
-
----
 
 ## Spaces
 
@@ -134,8 +102,6 @@ curl -s -X POST "https://meet.googleapis.com/v2/spaces/{space-name}:endActiveCon
   -d '{}'
 ```
 
----
-
 ## Conference Records
 
 A ConferenceRecord represents a single instance of a meeting held in a space.
@@ -171,8 +137,6 @@ Get details for a specific conference record:
 curl -s "https://meet.googleapis.com/v2/conferenceRecords/{conference-record-id}" \
   --header "Authorization: Bearer $GOOGLE_MEET_TOKEN" | jq '{name, startTime, endTime, expireTime, space}'
 ```
-
----
 
 ## Participants
 
@@ -210,8 +174,6 @@ curl -s "https://meet.googleapis.com/v2/conferenceRecords/{conference-record-id}
   --header "Authorization: Bearer $GOOGLE_MEET_TOKEN" | jq '.participantSessions[]? | {name, startTime, endTime}'
 ```
 
----
-
 ## Recordings
 
 ### List Recordings
@@ -233,8 +195,6 @@ curl -s "https://meet.googleapis.com/v2/conferenceRecords/{conference-record-id}
 ```
 
 The `driveDestination` field contains the Google Drive file ID and export URI for downloading the recording.
-
----
 
 ## Transcripts
 
@@ -267,8 +227,6 @@ curl -s "https://meet.googleapis.com/v2/conferenceRecords/{conference-record-id}
   --header "Authorization: Bearer $GOOGLE_MEET_TOKEN" | jq '.entries[]? | {name, participant, text, startTime, endTime}'
 ```
 
----
-
 ## Common Patterns
 
 ### Get the Latest Meeting Record for a Space
@@ -287,8 +245,6 @@ curl -s "https://meet.googleapis.com/v2/spaces/{space-name}" \
 
 Returns `null` if no active conference, or the conference record details if one is ongoing.
 
----
-
 ## Guidelines
 
 1. **Space naming**: Spaces use the format `spaces/{space}` where `{space}` is a server-generated ID (e.g. `jQCFfuBOdN5z`). You can also use the friendly meeting code (e.g. `abc-mnop-xyz`) as an alias.
@@ -298,8 +254,6 @@ Returns `null` if no active conference, or the conference record details if one 
 5. **Recordings and transcripts**: These are generated asynchronously. Check the `state` field — `ACTIVE` means generating, `ENDED` means complete.
 6. **Drive and Docs integration**: Recordings link to Google Drive files; transcripts link to Google Docs. Use the Drive or Docs skill to access these artifacts.
 7. **updateMask**: When PATCHing a space, specify `updateMask` as a comma-separated list of dot-notation field paths to avoid overwriting unintended fields.
-
----
 
 ## API Reference
 

--- a/google-sheets/SKILL.md
+++ b/google-sheets/SKILL.md
@@ -5,40 +5,9 @@ description: Google Sheets API for spreadsheets. Use when user mentions "Google 
   data.
 ---
 
-# Google Sheets API
+## Troubleshooting
 
-Use the Google Sheets API via direct `curl` calls to **read, write, and manage spreadsheet data**.
-
-> Official docs: `https://developers.google.com/sheets/api`
-
----
-
-## Prerequisites
-
-Connect the **Google Sheets** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GOOGLE_SHEETS_TOKEN` or `zero doctor check-connector --url https://sheets.googleapis.com/v4/spreadsheets --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Read data** from Google Sheets
-- **Write or update** cell values
-- **Append rows** to existing sheets
-- **Create new spreadsheets**
-- **Get spreadsheet metadata** (sheet names, properties)
-- **Batch update** multiple ranges at once
-
----
-
----
-
-> **Placeholders:** Values in `{curly-braces}` like `{spreadsheet-id}` are placeholders. Replace them with actual values when executing.
-
-> **Important:** In range notation, the sheet-name separator `!` must be URL encoded as `%21` in the URL path. For example, `Sheet1!A1:D10` becomes `Sheet1%21A1:D10`. All examples below use this encoding.
-
----
+If requests fail, run `zero doctor check-connector --env-name GOOGLE_SHEETS_TOKEN` or `zero doctor check-connector --url https://sheets.googleapis.com/v4/spreadsheets --method GET`
 
 ## How to Use
 
@@ -46,8 +15,6 @@ Base URL: `https://sheets.googleapis.com/v4/spreadsheets`
 
 **Finding your Spreadsheet ID:**
 The spreadsheet ID is in the URL: `https://docs.google.com/spreadsheets/d/{SPREADSHEET_ID}/edit`
-
----
 
 ### 1. Get Spreadsheet Metadata
 
@@ -57,8 +24,6 @@ Get information about a spreadsheet (sheets, properties):
 curl -s "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" | jq '{title: .properties.title, sheets: [.sheets[].properties | {sheetId, title}]}'
 ```
 
----
-
 ### 2. Read Cell Values
 
 Read a range of cells:
@@ -67,8 +32,6 @@ Read a range of cells:
 curl -s "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values/Sheet1%21A1:D10" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" | jq '.values'
 ```
 
----
-
 ### 3. Read Entire Sheet
 
 Read all data from a sheet:
@@ -76,8 +39,6 @@ Read all data from a sheet:
 ```bash
 curl -s "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values/Sheet1" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" | jq '.values'
 ```
-
----
 
 ### 4. Write Cell Values
 
@@ -103,8 +64,6 @@ curl -s -X PUT "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/v
 - `RAW`: Values are stored as-is
 - `USER_ENTERED`: Values are parsed as if typed by user (formulas evaluated)
 
----
-
 ### 5. Append Rows
 
 Add new rows to the end of a sheet.
@@ -125,8 +84,6 @@ Then run:
 curl -s -X POST "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values/Sheet1%21A:C:append?valueInputOption=USER_ENTERED&insertDataOption=INSERT_ROWS" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gsheets_request.json | jq '.updates | {updatedRange, updatedRows}'
 ```
 
----
-
 ### 6. Batch Read Multiple Ranges
 
 Read multiple ranges in one request:
@@ -134,8 +91,6 @@ Read multiple ranges in one request:
 ```bash
 curl -s "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values:batchGet?ranges=Sheet1%21A1:B5&ranges=Sheet1%21D1:E5" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" | jq '.valueRanges'
 ```
-
----
 
 ### 7. Batch Update Multiple Ranges
 
@@ -165,8 +120,6 @@ Then run:
 curl -s -X POST "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values:batchUpdate" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gsheets_request.json | jq '.totalUpdatedCells'
 ```
 
----
-
 ### 8. Clear Cell Values
 
 Clear a range of cells.
@@ -182,8 +135,6 @@ Then run:
 ```bash
 curl -s -X POST "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values/Sheet1%21A2:C100:clear" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gsheets_request.json | jq '.clearedRange'
 ```
-
----
 
 ### 9. Create New Spreadsheet
 
@@ -209,8 +160,6 @@ Then run:
 ```bash
 curl -s -X POST "https://sheets.googleapis.com/v4/spreadsheets" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gsheets_request.json | jq '{spreadsheetId, spreadsheetUrl}'
 ```
-
----
 
 ### 10. Add New Sheet
 
@@ -238,8 +187,6 @@ Then run:
 curl -s -X POST "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gsheets_request.json | jq '.replies[0].addSheet.properties'
 ```
 
----
-
 ### 11. Delete Sheet
 
 Delete a sheet from a spreadsheet (use sheetId from metadata).
@@ -264,8 +211,6 @@ Then run:
 curl -s -X POST "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}:batchUpdate" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" --header "Content-Type: application/json" -d @/tmp/gsheets_request.json
 ```
 
----
-
 ### 12. Search for Values
 
 Find cells containing specific text (read all then filter):
@@ -273,8 +218,6 @@ Find cells containing specific text (read all then filter):
 ```bash
 curl -s "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values/Sheet1" --header "Authorization: Bearer $GOOGLE_SHEETS_TOKEN" | jq '[.values[] | select(.[0] | ascii_downcase | contains("search_term"))]'
 ```
-
----
 
 ## A1 Notation Reference
 
@@ -286,8 +229,6 @@ curl -s "https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet-id}/values/S
 | `Sheet1!1:1` | Entire row 1 |
 | `Sheet1!A1:C` | From A1 to end of column C |
 | `'Sheet Name'!A1` | Sheet names with spaces need quotes |
-
----
 
 ## Guidelines
 

--- a/granola/SKILL.md
+++ b/granola/SKILL.md
@@ -4,30 +4,9 @@ description: Granola API for meeting notes. Use when user mentions "Granola", "m
   notes", or AI note-taking.
 ---
 
-# Granola
+## Troubleshooting
 
-Granola is an AI-powered meeting notes platform that automatically captures meeting transcripts, generates summaries, and organizes notes. Use the Enterprise API to programmatically access meeting notes, transcripts, summaries, attendees, and calendar event details.
-
-> Official docs: `https://docs.granola.ai/introduction`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Retrieve meeting notes with summaries and transcripts
-- List and filter meeting notes by date or update time
-- Access calendar event details and attendee information for meetings
-- Build integrations for CRM sync, knowledge bases, or custom workflows
-
----
-
-## Prerequisites
-
-Connect the **Granola** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GRANOLA_TOKEN` or `zero doctor check-connector --url https://public-api.granola.ai/v1/notes --method GET`
+If requests fail, run `zero doctor check-connector --env-name GRANOLA_TOKEN` or `zero doctor check-connector --url https://public-api.granola.ai/v1/notes --method GET`
 
 ## How to Use
 
@@ -102,8 +81,6 @@ while true; do
 done
 ```
 
----
-
 ## Response Structure
 
 ### List Notes Response
@@ -132,8 +109,6 @@ done
 | `attendees` | array | List of meeting attendees |
 | `summaries` | object | AI-generated summaries in text and markdown format |
 | `transcript` | array | Transcript entries with speaker, text, and timestamps (only when `include=transcript`) |
-
----
 
 ## Guidelines
 

--- a/hackernews/SKILL.md
+++ b/hackernews/SKILL.md
@@ -4,30 +4,6 @@ description: Hacker News API for stories and comments. Use when user mentions "H
   News", "HN", "Y Combinator", or asks about tech news.
 ---
 
-# Hacker News API
-
-Use the official Hacker News API via direct `curl` calls to **fetch stories, comments, and user data**.
-
-> Official docs: `https://github.com/HackerNews/API`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Fetch top/best/new stories** from Hacker News
-- **Get story details** including title, URL, score, comments
-- **Retrieve comments** and discussion threads
-- **Look up user profiles** and their submissions
-- **Monitor trending tech topics** and discussions
-
----
-
-## Prerequisites
-
-Connect the **Hacker News** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 ### 1. Get Top Stories
@@ -78,8 +54,6 @@ Fetch job postings:
 curl -s "https://hacker-news.firebaseio.com/v0/jobstories.json" | jq '.[:10]'
 ```
 
----
-
 ## Item Details
 
 ### 7. Get Story/Comment/Job Details
@@ -129,8 +103,6 @@ Then for each comment ID in the `kids` array, replace `<comment-id>` with the ac
 curl -s "https://hacker-news.firebaseio.com/v0/item/<comment-id>.json" | jq '{by, text, score}'
 ```
 
----
-
 ## User Data
 
 ### 10. Get User Profile
@@ -159,8 +131,6 @@ Fetch a user's recent submissions. Replace `<username>` with the actual username
 curl -s "https://hacker-news.firebaseio.com/v0/user/<username>.json" | jq '.submitted[:5]'
 ```
 
----
-
 ## Real-time Updates
 
 ### 12. Get Max Item ID
@@ -178,8 +148,6 @@ Get recently changed items and profiles (for real-time updates):
 ```bash
 curl -s "https://hacker-news.firebaseio.com/v0/updates.json"
 ```
-
----
 
 ## Practical Examples
 
@@ -207,8 +175,6 @@ curl -s "https://hacker-news.firebaseio.com/v0/topstories.json" | jq '.[:50][]' 
 done
 ```
 
----
-
 ## API Endpoints Summary
 
 | Endpoint | Description |
@@ -223,8 +189,6 @@ done
 | `/v0/user/{id}.json` | User profile |
 | `/v0/maxitem.json` | Current max item ID |
 | `/v0/updates.json` | Changed items/profiles |
-
----
 
 ## Guidelines
 

--- a/heygen/SKILL.md
+++ b/heygen/SKILL.md
@@ -4,31 +4,9 @@ description: HeyGen API for AI video avatars. Use when user mentions "HeyGen", "
   avatar", "video avatar", or "AI presenter".
 ---
 
-# HeyGen API
+## Troubleshooting
 
-Use the HeyGen API via direct `curl` calls to create **AI-generated videos** with digital avatars, text-to-speech voices, and video templates.
-
-> Official docs: `https://docs.heygen.com/reference`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Create AI avatar videos** from text scripts with digital presenters
-- **List available avatars and voices** to choose the right presenter and narration
-- **Generate videos from templates** with variable substitution
-- **Translate videos** into 175+ languages with natural voice dubbing
-- **Check video generation status** and retrieve completed video URLs
-
----
-
-## Prerequisites
-
-Connect the **HeyGen** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name HEYGEN_TOKEN` or `zero doctor check-connector --url https://api.heygen.com/v2/avatars --method GET`
+If requests fail, run `zero doctor check-connector --env-name HEYGEN_TOKEN` or `zero doctor check-connector --url https://api.heygen.com/v2/avatars --method GET`
 
 ## How to Use
 
@@ -38,8 +16,6 @@ The base URL for the HeyGen API is:
 
 - v1 endpoints: `https://api.heygen.com/v1`
 - v2 endpoints: `https://api.heygen.com/v2`
-
----
 
 ### 1. List Available Avatars
 
@@ -51,8 +27,6 @@ curl -s -X GET "https://api.heygen.com/v2/avatars" --header "x-api-key: $HEYGEN_
 
 Each avatar has an `avatar_id` needed for video generation.
 
----
-
 ### 2. Get Avatar Details
 
 Retrieve detailed information about a specific avatar. Replace `<avatar_id>` with an actual avatar ID:
@@ -60,8 +34,6 @@ Retrieve detailed information about a specific avatar. Replace `<avatar_id>` wit
 ```bash
 curl -s -X GET "https://api.heygen.com/v2/avatar/<avatar_id>/details" --header "x-api-key: $HEYGEN_TOKEN" | jq .data
 ```
-
----
 
 ### 3. List Available Voices
 
@@ -76,8 +48,6 @@ Voice properties include:
 - `language`: Primary language (e.g., "English", "Multilingual")
 - `gender`: "female", "male", or "unknown"
 - `emotion_support`: Whether the voice supports emotion variations
-
----
 
 ### 4. Create an Avatar Video
 
@@ -122,8 +92,6 @@ curl -s -X POST "https://api.heygen.com/v2/video/generate" --header "x-api-key: 
 
 The response contains a `video_id` to track the generation progress.
 
----
-
 ### 5. Check Video Status
 
 Poll for video generation status using the `video_id` from the generate response. Replace `<video_id>` with the actual video ID:
@@ -138,8 +106,6 @@ Status values:
 - `completed`: Video is ready (includes `video_url`)
 - `failed`: Generation failed (includes error details)
 
----
-
 ### 6. List Videos
 
 Retrieve all videos associated with your account:
@@ -147,8 +113,6 @@ Retrieve all videos associated with your account:
 ```bash
 curl -s -X GET "https://api.heygen.com/v1/video.list" --header "x-api-key: $HEYGEN_TOKEN" | jq .
 ```
-
----
 
 ### 7. Delete a Video
 
@@ -158,8 +122,6 @@ Remove a video from your account. Replace `<video_id>` with the actual video ID:
 curl -s -X DELETE "https://api.heygen.com/v1/video.delete" --header "x-api-key: $HEYGEN_TOKEN" --header "Content-Type: application/json" -d '{"video_id": "<video_id>"}' | jq .
 ```
 
----
-
 ### 8. List Templates
 
 Get all video templates created in your account:
@@ -168,8 +130,6 @@ Get all video templates created in your account:
 curl -s -X GET "https://api.heygen.com/v2/templates" --header "x-api-key: $HEYGEN_TOKEN" | jq .data
 ```
 
----
-
 ### 9. Get Template Details
 
 Retrieve a template configuration and its variables. Replace `<template_id>` with the actual template ID:
@@ -177,8 +137,6 @@ Retrieve a template configuration and its variables. Replace `<template_id>` wit
 ```bash
 curl -s -X GET "https://api.heygen.com/v2/template/<template_id>" --header "x-api-key: $HEYGEN_TOKEN" | jq .data
 ```
-
----
 
 ### 10. Generate Video from Template
 
@@ -208,8 +166,6 @@ Then run:
 curl -s -X POST "https://api.heygen.com/v2/template/<template_id>/generate" --header "x-api-key: $HEYGEN_TOKEN" --header "Content-Type: application/json" -d @/tmp/heygen_request.json | jq .
 ```
 
----
-
 ### 11. Translate a Video
 
 Translate an existing video into another language. Replace `<video_url>` and `<language>` with actual values:
@@ -230,8 +186,6 @@ Then run:
 curl -s -X POST "https://api.heygen.com/v2/video_translate" --header "x-api-key: $HEYGEN_TOKEN" --header "Content-Type: application/json" -d @/tmp/heygen_request.json | jq .
 ```
 
----
-
 ### 12. List Supported Translation Languages
 
 Get all languages available for video translation:
@@ -240,8 +194,6 @@ Get all languages available for video translation:
 curl -s -X GET "https://api.heygen.com/v2/video_translate/target_languages" --header "x-api-key: $HEYGEN_TOKEN" | jq .data
 ```
 
----
-
 ### 13. Share a Video
 
 Generate a public sharing URL for a video. Replace `<video_id>` with the actual video ID:
@@ -249,8 +201,6 @@ Generate a public sharing URL for a video. Replace `<video_id>` with the actual 
 ```bash
 curl -s -X POST "https://api.heygen.com/v1/video/share" --header "x-api-key: $HEYGEN_TOKEN" --header "Content-Type: application/json" -d '{"video_id": "<video_id>"}' | jq .
 ```
-
----
 
 ## Guidelines
 

--- a/htmlcsstoimage/SKILL.md
+++ b/htmlcsstoimage/SKILL.md
@@ -4,30 +4,9 @@ description: HTML/CSS to Image API for rendering. Use when user mentions "HTML t
   image", "render HTML", "screenshot", or "convert to image".
 ---
 
-# HTMLCSStoImage API
+## Troubleshooting
 
-Use the HTMLCSStoImage API via direct `curl` calls to **generate images from HTML/CSS** or **capture screenshots of web pages**.
-
-> Official docs: `https://docs.htmlcsstoimage.com/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Generate images from HTML/CSS** for social cards, thumbnails, certificates
-- **Screenshot web pages** or specific elements on a page
-- **Create dynamic images** with custom fonts and styling
-- **Generate OG images** for social media sharing
-
----
-
-## Prerequisites
-
-Connect the **HTMLCSStoImage** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name HCTI_API_KEY` or `zero doctor check-connector --url https://hcti.io/v1/image --method POST`
+If requests fail, run `zero doctor check-connector --env-name HCTI_API_KEY` or `zero doctor check-connector --url https://hcti.io/v1/image --method POST`
 
 ## How to Use
 
@@ -36,8 +15,6 @@ All examples below assume you have `HCTI_USER_ID` and `HCTI_API_KEY` set.
 The base URL for the API is:
 
 - `https://hcti.io/v1/image`
-
----
 
 ### 1. Simple HTML to Image
 
@@ -64,8 +41,6 @@ Response:
 
 The returned URL is permanent and served via Cloudflare CDN.
 
----
-
 ### 2. HTML with CSS Styling
 
 Generate a styled card image.
@@ -87,8 +62,6 @@ Then run:
 ```bash
 curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --data-urlencode "html@/tmp/hcti_html.txt" --data-urlencode "css@/tmp/hcti_css.txt"
 ```
-
----
 
 ### 3. Use Google Fonts
 
@@ -114,8 +87,6 @@ curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --da
 
 Multiple fonts: `google_fonts=Playfair Display|Roboto|Open Sans`
 
----
-
 ### 4. Screenshot a Web Page (URL to Image)
 
 Capture a screenshot of any public URL:
@@ -129,8 +100,6 @@ https://example.com
 ```bash
 curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --data-urlencode "url@/tmp/hcti_url.txt"
 ```
-
----
 
 ### 5. Screenshot with Delay (for JavaScript)
 
@@ -148,8 +117,6 @@ curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --da
 
 `ms_delay` waits specified milliseconds before taking the screenshot.
 
----
-
 ### 6. Capture Specific Element (Selector)
 
 Screenshot only a specific element on the page:
@@ -159,8 +126,6 @@ curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --da
 ```
 
 Use any CSS selector: `#id`, `.class`, `div > p`, etc.
-
----
 
 ### 7. High Resolution (Retina)
 
@@ -180,8 +145,6 @@ curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --da
 
 `device_scale` accepts values 1-3 (default: 1).
 
----
-
 ### 8. Custom Viewport Size
 
 Set specific viewport dimensions:
@@ -192,8 +155,6 @@ curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --da
 
 Perfect for generating OG images (1200x630).
 
----
-
 ### 9. Full Page Screenshot
 
 Capture the entire page height:
@@ -202,8 +163,6 @@ Capture the entire page height:
 curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --data-urlencode "url@/tmp/hcti_url.txt" -d "full_screen=true"
 ```
 
----
-
 ### 10. Block Cookie Banners
 
 Automatically hide consent/cookie popups:
@@ -211,8 +170,6 @@ Automatically hide consent/cookie popups:
 ```bash
 curl -s "https://hcti.io/v1/image" -X POST -u "$HCTI_USER_ID:$HCTI_API_KEY" --data-urlencode "url@/tmp/hcti_url.txt" -d "block_consent_banners=true"
 ```
-
----
 
 ### 11. Download Image Directly
 
@@ -235,8 +192,6 @@ This will output the image URL. Copy the URL and download with:
 ```bash
 curl -s "https://hcti.io/v1/image/<your-image-id>?dl=1" --output image.png
 ```
-
----
 
 ### 12. Resize on the Fly
 
@@ -261,8 +216,6 @@ Original: https://hcti.io/v1/image/<your-image-id>
 Thumbnail: https://hcti.io/v1/image/<your-image-id>?width=200&height=200
 ```
 
----
-
 ## Response Format
 
 **Success (200):**
@@ -280,8 +233,6 @@ Thumbnail: https://hcti.io/v1/image/<your-image-id>?width=200&height=200
   "message": "HTML is Required"
 }
 ```
-
----
 
 ## Guidelines
 

--- a/hubspot/SKILL.md
+++ b/hubspot/SKILL.md
@@ -4,37 +4,9 @@ description: HubSpot CRM API for marketing and sales. Use when user mentions "Hu
   "CRM", "HubSpot contacts", or asks about marketing automation.
 ---
 
-# HubSpot CRM API
+## Troubleshooting
 
-Manage contacts, companies, deals, tickets, and other CRM objects, plus files, marketing emails, forms, lists, and conversations via HubSpot's REST API v3/v4.
-
-> Official docs: https://developers.hubspot.com/docs/api/overview
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Create, update, search, and delete CRM objects (contacts, companies, deals, tickets, products, line items, quotes, tasks, notes, emails, meetings, calls)
-- Create associations between CRM objects
-- Search and filter CRM records with complex queries
-- Manage deal and ticket pipelines and stages
-- Manage CRM properties (custom fields)
-- Manage contact lists and memberships
-- Upload and manage files
-- Send marketing and transactional emails
-- Manage forms and form submissions
-- View conversations and threads
-- Manage users and account settings
-
----
-
-## Prerequisites
-
-Connect the **HubSpot** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name HUBSPOT_TOKEN` or `zero doctor check-connector --url https://api.hubapi.com/crm/v3/objects/contacts --method GET`
+If requests fail, run `zero doctor check-connector --env-name HUBSPOT_TOKEN` or `zero doctor check-connector --url https://api.hubapi.com/crm/v3/objects/contacts --method GET`
 
 ## CRM Objects (Unified Pattern)
 
@@ -138,8 +110,6 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/objects/contacts/merge" \
   -d "{\"primaryObjectId\": \"<primary-id>\", \"objectIdToMerge\": \"<duplicate-id>\"}"
 ```
 
----
-
 ## Common CRM Object Examples
 
 The pattern above works for all object types. Here are property examples for the most common ones:
@@ -189,8 +159,6 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/objects/notes" \
   -d "{\"properties\": {\"hs_note_body\": \"Had a productive call. Client interested in annual plan.\", \"hs_timestamp\": \"2026-04-08T14:00:00.000Z\"}}"
 ```
 
----
-
 ## Associations (v4)
 
 Associations link CRM objects together (e.g., contact → company, deal → contact).
@@ -235,8 +203,6 @@ curl -s -X POST "https://api.hubapi.com/crm/v4/associations/contacts/companies/b
   --header "Content-Type: application/json" \
   -d "{\"inputs\": [{\"id\": \"<contact-id-1>\"}, {\"id\": \"<contact-id-2>\"}]}"
 ```
-
----
 
 ## Pipelines
 
@@ -285,8 +251,6 @@ curl -s -X POST "https://api.hubapi.com/crm/v3/pipelines/deals/<pipeline-id>/sta
   -d "{\"label\": \"Negotiation\", \"displayOrder\": 2, \"metadata\": {\"probability\": \"0.8\"}}"
 ```
 
----
-
 ## Properties
 
 Properties are the fields/columns on CRM objects. Each object type has its own set.
@@ -324,8 +288,6 @@ curl -s -X PATCH "https://api.hubapi.com/crm/v3/properties/contacts/<property-na
   --header "Content-Type: application/json" \
   -d "{\"label\": \"Preferred Color\"}"
 ```
-
----
 
 ## Lists
 
@@ -390,8 +352,6 @@ curl -s -X POST "https://api.hubapi.com/crm/lists/v3/search" \
   -d "{\"query\": \"VIP\", \"count\": 10}"
 ```
 
----
-
 ## Files
 
 ### Search Files
@@ -452,8 +412,6 @@ curl -s -X POST "https://api.hubapi.com/files/v3/folders" \
   -d "{\"name\": \"Receipts\", \"parentFolderId\": \"<parent-folder-id>\"}"
 ```
 
----
-
 ## Marketing Emails
 
 ### List Emails
@@ -488,8 +446,6 @@ curl -s -X POST "https://api.hubapi.com/marketing/v3/transactional/single-email/
   -d "{\"emailId\": \"<template-id>\", \"message\": {\"to\": \"recipient@example.com\", \"from\": \"sender@example.com\", \"sendId\": \"unique-send-id\"}, \"contactProperties\": {\"firstname\": \"Jane\"}}"
 ```
 
----
-
 ## Forms
 
 ### List Forms
@@ -505,8 +461,6 @@ curl -s "https://api.hubapi.com/marketing/v3/forms" \
 curl -s "https://api.hubapi.com/marketing/v3/forms/<form-id>" \
   --header "Authorization: Bearer $HUBSPOT_TOKEN"
 ```
-
----
 
 ## Conversations
 
@@ -547,8 +501,6 @@ curl -s "https://api.hubapi.com/conversations/v3/conversations/inboxes" \
   --header "Authorization: Bearer $HUBSPOT_TOKEN"
 ```
 
----
-
 ## Settings & Users
 
 ### Get Account Info
@@ -579,8 +531,6 @@ curl -s "https://api.hubapi.com/settings/v3/users/teams" \
   --header "Authorization: Bearer $HUBSPOT_TOKEN"
 ```
 
----
-
 ## Owners
 
 Owners are users who can be assigned to CRM records.
@@ -599,8 +549,6 @@ curl -s "https://api.hubapi.com/crm/v3/owners/<owner-id>" \
   --header "Authorization: Bearer $HUBSPOT_TOKEN"
 ```
 
----
-
 ## Guidelines
 
 1. **Unified CRM pattern**: All CRM objects use the same endpoints at `/crm/v3/objects/{objectType}`. Learn it once, use it for contacts, companies, deals, tickets, products, line_items, quotes, tasks, notes, emails, meetings, calls.
@@ -614,8 +562,6 @@ curl -s "https://api.hubapi.com/crm/v3/owners/<owner-id>" \
 9. **Account codes and IDs**: Pipeline IDs, stage IDs, owner IDs, and property names are all account-specific. Always discover them via API first.
 10. **Deleting**: DELETE moves objects to recycling bin (90-day retention). No permanent delete via API.
 11. **Date format**: Use ISO-8601 with timezone: `2026-03-05T09:00:00.000Z`. Date properties use midnight UTC.
-
----
 
 ## How to Look Up More API Details
 

--- a/hugging-face/SKILL.md
+++ b/hugging-face/SKILL.md
@@ -4,32 +4,9 @@ description: Hugging Face API for ML models. Use when user mentions "Hugging Fac
   "HF", "transformers", or asks about ML model inference.
 ---
 
-# Hugging Face API
+## Troubleshooting
 
-Use the Hugging Face API via direct `curl` calls to **search models and datasets**, **run serverless inference**, and **manage Hub repositories**.
-
-> Official docs: `https://huggingface.co/docs/hub/en/api`
-> OpenAPI spec: `https://huggingface.co/.well-known/openapi.json`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Search and discover** models, datasets, and spaces on the Hugging Face Hub
-- **Run serverless inference** (text generation, image generation, embeddings, etc.)
-- **Get model or dataset metadata** (tags, downloads, likes, card info)
-- **Manage repositories** (create, delete, list files)
-- **Verify account access** with whoami
-
----
-
-## Prerequisites
-
-Connect the **Hugging Face** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name HUGGING_FACE_TOKEN` or `zero doctor check-connector --url https://huggingface.co/api/whoami-v2 --method GET`
+If requests fail, run `zero doctor check-connector --env-name HUGGING_FACE_TOKEN` or `zero doctor check-connector --url https://huggingface.co/api/whoami-v2 --method GET`
 
 ## How to Use
 
@@ -40,8 +17,6 @@ The base URLs are:
 - Hub API: `https://huggingface.co/api`
 - Inference API: `https://router.huggingface.co`
 
----
-
 ### 1. Verify Account (whoami)
 
 Check your token and account information:
@@ -49,8 +24,6 @@ Check your token and account information:
 ```bash
 curl -s "https://huggingface.co/api/whoami-v2" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '{name: .name, email: .email, type: .type}'
 ```
-
----
 
 ### 2. Search Models
 
@@ -76,8 +49,6 @@ curl -s "https://huggingface.co/api/models?pipeline_tag=text-generation&sort=tre
 - `author` - Filter by author/organization (e.g. `meta-llama`)
 - `filter` - Filter by tags (e.g. `pytorch`, `en`)
 
----
-
 ### 3. Get Model Details
 
 Get detailed information about a specific model:
@@ -85,8 +56,6 @@ Get detailed information about a specific model:
 ```bash
 curl -s "https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '{id, downloads, likes, pipeline_tag, tags: .tags[:5]}'
 ```
-
----
 
 ### 4. Search Datasets
 
@@ -96,8 +65,6 @@ Search for datasets:
 curl -s "https://huggingface.co/api/datasets?search=squad&sort=downloads&direction=-1&limit=5" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '.[].id'
 ```
 
----
-
 ### 5. Get Dataset Details
 
 Get detailed information about a specific dataset:
@@ -106,8 +73,6 @@ Get detailed information about a specific dataset:
 curl -s "https://huggingface.co/api/datasets/squad" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '{id, downloads, likes, tags: .tags[:5]}'
 ```
 
----
-
 ### 6. Search Spaces
 
 Search for Spaces:
@@ -115,8 +80,6 @@ Search for Spaces:
 ```bash
 curl -s "https://huggingface.co/api/spaces?search=chatbot&sort=likes&direction=-1&limit=5" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '.[].id'
 ```
-
----
 
 ### 7. List Repository Files
 
@@ -131,8 +94,6 @@ For datasets, replace `models` with `datasets`:
 ```bash
 curl -s "https://huggingface.co/api/datasets/squad/tree/main" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '.[] | {path: .rfilename, size}'
 ```
-
----
 
 ### 8. Run Serverless Inference (Text Generation)
 
@@ -159,8 +120,6 @@ Then run:
 curl -s "https://router.huggingface.co/hf-inference/v1/chat/completions" --header "Content-Type: application/json" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" -d @/tmp/hugging_face_request.json | jq -r '.choices[0].message.content'
 ```
 
----
-
 ### 9. Run Serverless Inference (Text-to-Image)
 
 Generate an image from text:
@@ -170,8 +129,6 @@ curl -s "https://router.huggingface.co/hf-inference/models/black-forest-labs/FLU
 ```
 
 The response is the raw image binary saved to the output file.
-
----
 
 ### 10. Run Serverless Inference (Embeddings)
 
@@ -191,8 +148,6 @@ Then run:
 curl -s "https://router.huggingface.co/hf-inference/models/sentence-transformers/all-MiniLM-L6-v2" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" --header "Content-Type: application/json" -d @/tmp/hugging_face_request.json | jq '.[0][:5]'
 ```
 
----
-
 ### 11. Run Serverless Inference (Text Classification)
 
 Classify text using sentiment analysis or other classification models:
@@ -211,8 +166,6 @@ Then run:
 curl -s "https://router.huggingface.co/hf-inference/models/distilbert-base-uncased-finetuned-sst-2-english" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" --header "Content-Type: application/json" -d @/tmp/hugging_face_request.json | jq .
 ```
 
----
-
 ### 12. List Models with Inference Provider Support
 
 Find models available for serverless inference:
@@ -227,8 +180,6 @@ Filter by a specific provider:
 curl -s "https://huggingface.co/api/models?inference_provider=hf-inference&pipeline_tag=text-to-image&limit=5" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '.[].id'
 ```
 
----
-
 ### 13. Get Model Inference Providers
 
 Check which inference providers serve a specific model:
@@ -236,8 +187,6 @@ Check which inference providers serve a specific model:
 ```bash
 curl -s "https://huggingface.co/api/models/meta-llama/Llama-3.1-8B-Instruct?expand[]=inferenceProviderMapping" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" | jq '.inferenceProviderMapping'
 ```
-
----
 
 ### 14. Create a Repository
 
@@ -261,8 +210,6 @@ curl -s -X POST "https://huggingface.co/api/repos/create" --header "Authorizatio
 
 **Repository types:** `model`, `dataset`, `space`
 
----
-
 ### 15. Delete a Repository
 
 Delete a repository (requires write token):
@@ -281,8 +228,6 @@ Then run:
 ```bash
 curl -s -X DELETE "https://huggingface.co/api/repos/delete" --header "Authorization: Bearer $HUGGING_FACE_TOKEN" --header "Content-Type: application/json" -d @/tmp/hugging_face_request.json | jq .
 ```
-
----
 
 ## Guidelines
 

--- a/hume/SKILL.md
+++ b/hume/SKILL.md
@@ -4,30 +4,9 @@ description: Hume AI API for emotion analysis. Use when user mentions "Hume", "e
   AI", "sentiment analysis", or voice emotion detection.
 ---
 
-# Hume AI API
+## Troubleshooting
 
-Analyze emotions in text, audio, and video, generate expressive text-to-speech, and build speech-to-speech conversational agents via Hume's REST API.
-
-> Official docs: https://dev.hume.ai/reference
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Analyze emotions and expressions in text, audio, images, or video (batch processing)
-- Generate expressive text-to-speech audio with emotional control
-- Manage EVI (Empathic Voice Interface) configurations, prompts, and tools
-- Retrieve chat transcripts and events from EVI conversations
-
----
-
-## Prerequisites
-
-Connect the **Hume** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name HUME_TOKEN` or `zero doctor check-connector --url https://api.hume.ai/v0/batch/jobs --method GET`
+If requests fail, run `zero doctor check-connector --env-name HUME_TOKEN` or `zero doctor check-connector --url https://api.hume.ai/v0/batch/jobs --method GET`
 
 ## Expression Measurement (Batch)
 
@@ -101,8 +80,6 @@ curl -s "https://api.hume.ai/v0/batch/jobs/{job-id}/predictions" --header "X-Hum
 ```bash
 curl -s "https://api.hume.ai/v0/batch/jobs/{job-id}/artifacts" --header "X-Hume-Api-Key: $HUME_TOKEN" --output /tmp/hume_artifacts.zip
 ```
-
----
 
 ## Text-to-Speech
 
@@ -211,8 +188,6 @@ Then run:
 curl -s -X POST "https://api.hume.ai/v0/tts" --header "Content-Type: application/json" --header "X-Hume-Api-Key: $HUME_TOKEN" -d @/tmp/hume_request.json | jq .
 ```
 
----
-
 ## EVI Configs
 
 ### List Configs
@@ -236,8 +211,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.hume.ai/v0/evi/configs" --header "Content-Type: application/json" --header "X-Hume-Api-Key: $HUME_TOKEN" -d @/tmp/hume_request.json | jq .
 ```
-
----
 
 ## EVI Prompts
 
@@ -264,8 +237,6 @@ Then run:
 curl -s -X POST "https://api.hume.ai/v0/evi/prompts" --header "Content-Type: application/json" --header "X-Hume-Api-Key: $HUME_TOKEN" -d @/tmp/hume_request.json | jq .
 ```
 
----
-
 ## EVI Chats
 
 ### List Chat Events
@@ -273,8 +244,6 @@ curl -s -X POST "https://api.hume.ai/v0/evi/prompts" --header "Content-Type: app
 ```bash
 curl -s "https://api.hume.ai/v0/evi/chats/{chat-id}?page_size=50&ascending_order=true" --header "X-Hume-Api-Key: $HUME_TOKEN" | jq .
 ```
-
----
 
 ## Available Models for Expression Measurement
 
@@ -287,8 +256,6 @@ curl -s "https://api.hume.ai/v0/evi/chats/{chat-id}?page_size=50&ascending_order
 | `burst` | Non-speech vocal sounds (laughter, sighs) |
 | `facemesh` | Detailed facial landmark detection |
 
----
-
 ## TTS Utterance Parameters
 
 | Parameter | Type | Description |
@@ -297,8 +264,6 @@ curl -s "https://api.hume.ai/v0/evi/chats/{chat-id}?page_size=50&ascending_order
 | `description` | string | Acting directions or voice style prompt |
 | `speed` | number | Speech rate multiplier (default: 1.0) |
 | `trailing_silence` | number | Silence after utterance in seconds (default: 0) |
-
----
 
 ## Response Codes
 
@@ -312,8 +277,6 @@ curl -s "https://api.hume.ai/v0/evi/chats/{chat-id}?page_size=50&ascending_order
 | `429` | Rate limit exceeded |
 | `5xx` | Server error |
 
----
-
 ## Guidelines
 
 1. **Authentication**: Use `X-Hume-Api-Key` header (not Bearer token) for all requests
@@ -322,8 +285,6 @@ curl -s "https://api.hume.ai/v0/evi/chats/{chat-id}?page_size=50&ascending_order
 4. **TTS Description**: Use the `description` field to control emotional tone and style of generated speech
 5. **Pagination**: EVI endpoints use zero-based page numbering with configurable page size (1-100)
 6. **API Key Types**: Organization API Key for TTS and EVI; Personal API Key for Expression Measurement
-
----
 
 ## API Reference
 

--- a/imgur/SKILL.md
+++ b/imgur/SKILL.md
@@ -4,21 +4,6 @@ description: Imgur API for image hosting. Use when user mentions "Imgur", "uploa
   image", "image hosting", or asks about image sharing.
 ---
 
-# Imgur Image Hosting
-
-Imgur is a free image hosting service. Upload images and get URLs for sharing, embedding in articles, or using in documentation.
-
-## When to Use
-
-- Upload images to get shareable URLs
-- Host images for blog posts or documentation
-- Get image URLs for use in Markdown content
-- Anonymous image uploads (no account needed)
-
-## Prerequisites
-
-Connect the **Imgur Image Hosting** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 ### Upload Local Image

--- a/infisical/SKILL.md
+++ b/infisical/SKILL.md
@@ -3,22 +3,6 @@ name: infisical
 description: Infisical Cloud Secrets Manager API for retrieving and listing secrets. Use when user mentions "Infisical", "infisical secrets", "machine identity token", or asks about secrets management with Infisical.
 ---
 
-# Infisical Cloud Secrets Manager API
-
-Infisical is an open-source secrets manager. This skill enables fetching individual secrets or listing all secrets from an Infisical project and environment using Machine Identity credentials.
-
-> Official docs: `https://infisical.com/docs/api-reference/overview/introduction`
-
-## When to Use
-
-- Retrieve the value of a specific secret from an Infisical project
-- List all secrets in a given project and environment
-- Inspect secrets with reference expansion and import resolution
-
-## Prerequisites
-
-Connect the **Infisical** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Core APIs
 
 ### 1. Obtain an Access Token
@@ -50,8 +34,6 @@ cat /tmp/infisical_token.txt | head -c 50
 
 Use `$(cat /tmp/infisical_token.txt)` in subsequent requests.
 
----
-
 ### 2. Fetch a Single Secret by Name
 
 Retrieve a secret by its key name from a specific Infisical project and environment.
@@ -62,8 +44,6 @@ curl -s -X GET "https://app.infisical.com/api/v3/secrets/raw/<SECRET_NAME>?works
 
 Replace `<SECRET_NAME>` with the exact secret key, `<workspace-id>` with your Infisical project ID (found in project settings), and `<env-slug>` with the environment slug (e.g., `dev`, `staging`, `prod`).
 
----
-
 ### 3. List All Secrets in a Project/Environment
 
 ```bash
@@ -73,8 +53,6 @@ curl -s -X GET "https://app.infisical.com/api/v3/secrets/raw?workspaceId=<worksp
 Replace `<workspace-id>` and `<env-slug>` as above.
 
 To include secrets from sub-folders recursively, append `&recursive=true` to the query string.
-
----
 
 ## Guidelines
 

--- a/instagram/SKILL.md
+++ b/instagram/SKILL.md
@@ -5,30 +5,9 @@ description: Instagram API for posts and media. Use when user mentions "Instagra
   content.
 ---
 
-# Instagram API (Graph API)
+## Troubleshooting
 
-Use the Instagram Graph API by directly executing `curl` commands to **read and publish Instagram content**.
-
-> Official docs: `https://developers.facebook.com/docs/instagram-api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Fetch recent media (photos / videos / Reels)** from an account
-- **Get detailed information** about a specific media item (caption, type, link, time, etc.)
-- **Search recent media by hashtag**
-- **Publish image posts via API** (with caption)
-
----
-
-## Prerequisites
-
-Connect the **Instagram API (Graph API)** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name INSTAGRAM_TOKEN` or `zero doctor check-connector --url https://graph.facebook.com/v21.0/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name INSTAGRAM_TOKEN` or `zero doctor check-connector --url https://graph.facebook.com/v21.0/me --method GET`
 
 ## How to Use
 
@@ -58,8 +37,6 @@ curl -s -X GET "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/
   - `permalink`: Instagram permalink
   - `timestamp`: creation time
 
----
-
 ### 2. Get details for a single media
 
 If you already have a media `id`, you can fetch more complete information. Replace `<your-media-id>` with the `id` field from the "Get User Media" response (section 1 above):
@@ -67,8 +44,6 @@ If you already have a media `id`, you can fetch more complete information. Repla
 ```bash
 curl -s -X GET "https://graph.facebook.com/v21.0/<your-media-id>?fields=id,caption,media_type,media_url,permalink,thumbnail_url,timestamp,username" --header "Authorization: Bearer $INSTAGRAM_TOKEN"
 ```
-
----
 
 ### 3. Search media by hashtag
 
@@ -93,8 +68,6 @@ Replace `<hashtag-id>` with the `id` field from the "Search Hashtag" response (s
 ```bash
 curl -s -X GET "https://graph.facebook.com/v21.0/<hashtag-id>/recent_media?user_id=$INSTAGRAM_BUSINESS_ACCOUNT_ID&fields=id,caption,media_type,media_url,permalink,timestamp" --header "Authorization: Bearer $INSTAGRAM_TOKEN"
 ```
-
----
 
 ### 4. Publish an image post
 
@@ -156,8 +129,6 @@ If successful, the response will contain the final media `id`:
 
 You can then use the "Get details for a single media" command to fetch its `permalink`.
 
----
-
 ### 5. Common errors and troubleshooting
 
 1. **Permissions / OAuth errors**
@@ -175,8 +146,6 @@ You can then use the "Get details for a single media" command to fetch its `perm
 
 3. **Rate limits**
   - Too many requests in a short period may hit rate limits; add delays for bulk operations
-
----
 
 ## Guidelines
 

--- a/instantly/SKILL.md
+++ b/instantly/SKILL.md
@@ -4,30 +4,9 @@ description: Instantly.ai API for cold email campaigns. Use when user mentions "
   "cold email", "email campaign", or outreach automation.
 ---
 
-# Instantly API
+## Troubleshooting
 
-Use the Instantly API via direct `curl` calls to automate **cold email outreach**, manage campaigns, leads, and sending accounts.
-
-> Official docs: `https://developer.instantly.ai/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage email campaigns** - create, launch, pause campaigns
-- **Handle leads** - add, update, list leads in campaigns
-- **Manage sending accounts** - list and configure email accounts
-- **Automate outreach** - schedule sends and manage lead lists
-
----
-
-## Prerequisites
-
-Connect the **Instantly** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name INSTANTLY_API_KEY` or `zero doctor check-connector --url https://api.instantly.ai/api/v2/campaigns --method GET`
+If requests fail, run `zero doctor check-connector --env-name INSTANTLY_API_KEY` or `zero doctor check-connector --url https://api.instantly.ai/api/v2/campaigns --method GET`
 
 ## How to Use
 
@@ -38,8 +17,6 @@ The base URL for API V2 is:
 - `https://api.instantly.ai/api/v2`
 
 Authentication uses Bearer token in the `Authorization` header.
-
----
 
 ### 1. List Campaigns
 
@@ -57,8 +34,6 @@ curl -s "https://api.instantly.ai/api/v2/campaigns?status=ACTIVE&limit=10" -H "A
 
 **Status values:** `ACTIVE`, `PAUSED`, `COMPLETED`, `DRAFTED`
 
----
-
 ### 2. Get Single Campaign
 
 Get campaign details by ID. Replace `<your-campaign-id>` with the actual campaign ID:
@@ -66,8 +41,6 @@ Get campaign details by ID. Replace `<your-campaign-id>` with the actual campaig
 ```bash
 curl -s "https://api.instantly.ai/api/v2/campaigns/<your-campaign-id>" -H "Authorization: Bearer $INSTANTLY_API_KEY" | jq '{id, name, status, daily_limit}'
 ```
-
----
 
 ### 3. Create Campaign
 
@@ -109,8 +82,6 @@ Then run:
 curl -s "https://api.instantly.ai/api/v2/campaigns" -X POST -H "Authorization: Bearer $INSTANTLY_API_KEY" -H "Content-Type: application/json" -d @/tmp/instantly_request.json
 ```
 
----
-
 ### 4. Pause/Activate Campaign
 
 Control campaign status. Replace `<your-campaign-id>` with the actual campaign ID:
@@ -122,8 +93,6 @@ curl -s "https://api.instantly.ai/api/v2/campaigns/<your-campaign-id>/pause" -X 
 # Activate campaign
 curl -s "https://api.instantly.ai/api/v2/campaigns/<your-campaign-id>/activate" -X POST -H "Authorization: Bearer $INSTANTLY_API_KEY"
 ```
-
----
 
 ### 5. List Leads
 
@@ -159,8 +128,6 @@ Then run:
 ```bash
 curl -s "https://api.instantly.ai/api/v2/leads/list" -X POST -H "Authorization: Bearer $INSTANTLY_API_KEY" -H "Content-Type: application/json" -d @/tmp/instantly_request.json | jq '.items[] | {email, status}'
 ```
-
----
 
 ### 6. Create Lead
 
@@ -206,8 +173,6 @@ Then run:
 curl -s "https://api.instantly.ai/api/v2/leads" -X POST -H "Authorization: Bearer $INSTANTLY_API_KEY" -H "Content-Type: application/json" -d @/tmp/instantly_request.json
 ```
 
----
-
 ### 7. Get Single Lead
 
 Get lead by ID. Replace `<your-lead-id>` with the actual lead ID:
@@ -215,8 +180,6 @@ Get lead by ID. Replace `<your-lead-id>` with the actual lead ID:
 ```bash
 curl -s "https://api.instantly.ai/api/v2/leads/<your-lead-id>" -H "Authorization: Bearer $INSTANTLY_API_KEY"
 ```
-
----
 
 ### 8. Update Lead
 
@@ -239,8 +202,6 @@ Then run. Replace `<your-lead-id>` with the actual lead ID:
 curl -s "https://api.instantly.ai/api/v2/leads/<your-lead-id>" -X PATCH -H "Authorization: Bearer $INSTANTLY_API_KEY" -H "Content-Type: application/json" -d @/tmp/instantly_request.json
 ```
 
----
-
 ### 9. List Lead Lists
 
 Get all lead lists:
@@ -248,8 +209,6 @@ Get all lead lists:
 ```bash
 curl -s "https://api.instantly.ai/api/v2/lead-lists" -H "Authorization: Bearer $INSTANTLY_API_KEY" | jq '.items[] | {id, name}'
 ```
-
----
 
 ### 10. Create Lead List
 
@@ -269,8 +228,6 @@ Then run:
 curl -s "https://api.instantly.ai/api/v2/lead-lists" -X POST -H "Authorization: Bearer $INSTANTLY_API_KEY" -H "Content-Type: application/json" -d @/tmp/instantly_request.json
 ```
 
----
-
 ### 11. List Email Accounts
 
 Get connected sending accounts:
@@ -279,8 +236,6 @@ Get connected sending accounts:
 curl -s "https://api.instantly.ai/api/v2/accounts" -H "Authorization: Bearer $INSTANTLY_API_KEY" | jq '.items[] | {email, status, warmup_status}'
 ```
 
----
-
 ### 12. Test API Key
 
 Verify your API key is valid:
@@ -288,8 +243,6 @@ Verify your API key is valid:
 ```bash
 curl -s "https://api.instantly.ai/api/v2/api-keys" -H "Authorization: Bearer $INSTANTLY_API_KEY" | jq '.items[0] | {name, scopes}'
 ```
-
----
 
 ## Pagination
 
@@ -302,8 +255,6 @@ curl -s "https://api.instantly.ai/api/v2/campaigns?limit=10" -H "Authorization: 
 # Next page (replace <your-cursor> with the next_starting_after value from the previous response)
 curl -s "https://api.instantly.ai/api/v2/campaigns?limit=10&starting_after=<your-cursor>" -H "Authorization: Bearer $INSTANTLY_API_KEY" | jq '.items[] | {id, name}'
 ```
-
----
 
 ## Guidelines
 

--- a/intercom/SKILL.md
+++ b/intercom/SKILL.md
@@ -4,35 +4,9 @@ description: Intercom API for customer messaging. Use when user mentions "Interc
   "customer chat", "messaging", or asks about Intercom conversations.
 ---
 
-# Intercom API
+## Troubleshooting
 
-Manage customer conversations, contacts, messages, articles, and support operations via the Intercom REST API.
-
-> Official docs: `https://developers.intercom.com/docs`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage contacts** - Create, update, search, and delete user profiles
-- **Handle conversations** - List, search, reply to, assign, and close conversations
-- **Send messages** - Create and send messages to contacts
-- **Manage companies** - Track organizations and their members
-- **Work with articles** - Access help center content and knowledge base
-- **Add notes** - Annotate contact profiles with internal notes
-- **Use tags** - Organize contacts and conversations with labels
-- **Track events** - Record custom user activities and behaviors
-- **Manage tickets** - Create and handle support tickets
-
----
-
-## Prerequisites
-
-Connect the **Intercom** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name INTERCOM_TOKEN` or `zero doctor check-connector --url https://api.intercom.io/admins --method GET`
+If requests fail, run `zero doctor check-connector --env-name INTERCOM_TOKEN` or `zero doctor check-connector --url https://api.intercom.io/admins --method GET`
 
 ## How to Use
 
@@ -45,8 +19,6 @@ All examples assume `INTERCOM_TOKEN` is set.
 - `Accept: application/json`
 - `Intercom-Version: 2.14`
 
----
-
 ## Core APIs
 
 ### 1. List Admins
@@ -56,8 +28,6 @@ Get all admins/teammates in your workspace:
 ```bash
 curl -s "https://api.intercom.io/admins" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Accept: application/json" -H "Intercom-Version: 2.14" | jq '.admins[] | {id, name, email}'
 ```
-
----
 
 ### 2. Create Contact
 
@@ -100,8 +70,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/contacts" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Accept: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ### 3. Get Contact
 
 Retrieve a specific contact by ID. Replace `<your-contact-id>` with the actual contact ID:
@@ -109,8 +77,6 @@ Retrieve a specific contact by ID. Replace `<your-contact-id>` with the actual c
 ```bash
 curl -s "https://api.intercom.io/contacts/<your-contact-id>" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Accept: application/json" -H "Intercom-Version: 2.14"
 ```
-
----
 
 ### 4. Update Contact
 
@@ -135,8 +101,6 @@ curl -s -X PATCH "https://api.intercom.io/contacts/<your-contact-id>" -H "Author
 
 **Note**: Newly created contacts may need a few seconds before they can be updated.
 
----
-
 ### 5. Delete Contact
 
 Permanently delete a contact. Replace `<your-contact-id>` with the actual contact ID:
@@ -144,8 +108,6 @@ Permanently delete a contact. Replace `<your-contact-id>` with the actual contac
 ```bash
 curl -s -X DELETE "https://api.intercom.io/contacts/<your-contact-id>" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Accept: application/json" -H "Intercom-Version: 2.14"
 ```
-
----
 
 ### 6. Search Contacts
 
@@ -199,8 +161,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/contacts/search" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json | jq '.data[] | {id, email, name}'
 ```
 
----
-
 ### 7. List Conversations
 
 Get all conversations:
@@ -209,8 +169,6 @@ Get all conversations:
 curl -s "https://api.intercom.io/conversations?order=desc&sort=updated_at" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Accept: application/json" -H "Intercom-Version: 2.14" | jq '.conversations[] | {id, state, created_at, updated_at}'
 ```
 
----
-
 ### 8. Get Conversation
 
 Retrieve a specific conversation. Replace `<your-conversation-id>` with the actual conversation ID:
@@ -218,8 +176,6 @@ Retrieve a specific conversation. Replace `<your-conversation-id>` with the actu
 ```bash
 curl -s "https://api.intercom.io/conversations/<your-conversation-id>" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Accept: application/json" -H "Intercom-Version: 2.14"
 ```
-
----
 
 ### 9. Search Conversations
 
@@ -270,8 +226,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/conversations/search" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json | jq '.conversations[] | {id, state, created_at}'
 ```
 
----
-
 ### 10. Reply to Conversation
 
 Reply as an admin. Replace `<your-conversation-id>` and `<your-admin-id>` with actual IDs:
@@ -292,8 +246,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.intercom.io/conversations/<your-conversation-id>/parts" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
-
----
 
 ### 11. Assign Conversation
 
@@ -316,8 +268,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/conversations/<your-conversation-id>/parts" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ### 12. Close Conversation
 
 Close an open conversation. Replace `<your-conversation-id>` and `<your-admin-id>` with actual IDs:
@@ -338,8 +288,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/conversations/<your-conversation-id>/parts" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ### 13. Create Note
 
 Add an internal note to a contact. Replace `<your-contact-id>` with the actual contact ID:
@@ -358,8 +306,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/contacts/<your-contact-id>/notes" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ### 14. List Tags
 
 Get all tags:
@@ -367,8 +313,6 @@ Get all tags:
 ```bash
 curl -s "https://api.intercom.io/tags" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Intercom-Version: 2.14" | jq '.data[] | {id, name}'
 ```
-
----
 
 ### 15. Create Tag
 
@@ -388,8 +332,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/tags" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ### 16. Tag Contact
 
 Add a tag to a contact. Replace `<your-contact-id>` and `<your-tag-id>` with actual IDs:
@@ -408,8 +350,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/contacts/<your-contact-id>/tags" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ### 17. Untag Contact
 
 Remove a tag from a contact. Replace `<your-contact-id>` and `<your-tag-id>` with actual IDs:
@@ -417,8 +357,6 @@ Remove a tag from a contact. Replace `<your-contact-id>` and `<your-tag-id>` wit
 ```bash
 curl -s -X DELETE "https://api.intercom.io/contacts/<your-contact-id>/tags/<your-tag-id>" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Intercom-Version: 2.14"
 ```
-
----
 
 ### 18. List Articles
 
@@ -428,8 +366,6 @@ Get help center articles:
 curl -s "https://api.intercom.io/articles" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Intercom-Version: 2.14" | jq '.data[] | {id, title, url}'
 ```
 
----
-
 ### 19. Get Article
 
 Retrieve a specific article. Replace `<your-article-id>` with the actual article ID:
@@ -437,8 +373,6 @@ Retrieve a specific article. Replace `<your-article-id>` with the actual article
 ```bash
 curl -s "https://api.intercom.io/articles/<your-article-id>" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Intercom-Version: 2.14"
 ```
-
----
 
 ### 20. Create Company
 
@@ -462,8 +396,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/companies" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ### 21. Attach Contact to Company
 
 Associate a contact with a company. Replace `<your-contact-id>` and `<your-company-id>` with actual IDs:
@@ -481,8 +413,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.intercom.io/contacts/<your-contact-id>/companies" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
-
----
 
 ### 22. Track Event
 
@@ -507,8 +437,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.intercom.io/events" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
-
----
 
 ## Common Workflows
 
@@ -588,8 +516,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/contacts/${CONTACT_ID}/companies" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json
 ```
 
----
-
 ## Search Operators
 
 ### Field Operators
@@ -648,8 +574,6 @@ Then run:
 curl -s -X POST "https://api.intercom.io/contacts/search" -H "Authorization: Bearer $INTERCOM_TOKEN" -H "Content-Type: application/json" -H "Intercom-Version: 2.14" -d @/tmp/intercom_request.json | jq '.data[] | {id, email, name}'
 ```
 
----
-
 ## Rate Limits
 
 - **Private Apps**: 10,000 API calls per minute
@@ -662,8 +586,6 @@ When rate limited, API returns `429 Too Many Requests`.
 - `X-RateLimit-Limit`: Requests per minute allowed
 - `X-RateLimit-Remaining`: Remaining requests in current window
 - `X-RateLimit-Reset`: Unix timestamp when limit resets
-
----
 
 ## Guidelines
 
@@ -683,8 +605,6 @@ When rate limited, API returns `429 Too Many Requests`.
 10. **Conversation states**: Valid states are `open`, `closed`, `snoozed`
 11. **Custom attributes**: Define custom fields in Intercom UI before using in API
 12. **Check workspace ID**: Your workspace ID is included in contact responses for verification
-
----
 
 ## API Reference
 

--- a/intervals-icu/SKILL.md
+++ b/intervals-icu/SKILL.md
@@ -4,39 +4,15 @@ description: Intervals.icu API for fitness data. Use when user mentions "Interva
   "cycling data", "fitness tracking", or workout analytics.
 ---
 
-# Intervals.icu API
+## Troubleshooting
 
-Use the Intervals.icu API via direct `curl` calls to access **activities, wellness, workouts, calendar events, and athlete profiles**.
-
-> Official docs: `https://intervals.icu/api/v1/docs`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **View athlete profile** - get athlete info and settings
-- **List and manage activities** - view rides, runs, and other activities with streams data
-- **Track wellness** - access daily wellness records (sleep, fatigue, soreness, etc.)
-- **Manage workouts** - list, create, and modify workout library entries
-- **Calendar events** - view and create planned workouts and events
-
----
-
-## Prerequisites
-
-Connect the **Intervals.icu** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name INTERVALS_ICU_TOKEN` or `zero doctor check-connector --url https://intervals.icu/api/v1/athlete/0 --method GET`
+If requests fail, run `zero doctor check-connector --env-name INTERVALS_ICU_TOKEN` or `zero doctor check-connector --url https://intervals.icu/api/v1/athlete/0 --method GET`
 
 ## How to Use
 
 All examples below assume `INTERVALS_ICU_TOKEN` is set.
 
 Base URL: `https://intervals.icu`
-
----
 
 ### 1. Get Athlete Profile
 
@@ -45,8 +21,6 @@ Get the authenticated athlete's profile and settings:
 ```bash
 curl -s "https://intervals.icu/api/v1/athlete/0" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq '{id, name, firstname, lastname, email, locale, weight, icu_weight, icu_resting_hr, sex, country, city, timezone}'
 ```
-
----
 
 ### 2. List Activities
 
@@ -58,8 +32,6 @@ Get activities for a date range:
 curl -s "https://intervals.icu/api/v1/athlete/<athlete-id>/activities?oldest=2025-01-01&newest=2025-01-31" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq '.[] | {id, name, type, start_date_local, moving_time, distance, total_elevation_gain, icu_training_load}'
 ```
 
----
-
 ### 3. Get Activity Details
 
 Get details for a specific activity:
@@ -69,8 +41,6 @@ Get details for a specific activity:
 ```bash
 curl -s "https://intervals.icu/api/v1/activity/<activity-id>" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq '{id, name, type, start_date_local, moving_time, distance, average_speed, average_watts, average_heartrate, icu_training_load}'
 ```
-
----
 
 ### 4. Get Activity Streams
 
@@ -82,8 +52,6 @@ Get detailed data streams (GPS, heart rate, power, etc.) for an activity:
 curl -s "https://intervals.icu/api/v1/activity/<activity-id>/streams?types=watts,heartrate,cadence" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq 'keys'
 ```
 
----
-
 ### 5. Get Activity Power Curve
 
 Get the power curve for an activity:
@@ -94,8 +62,6 @@ Get the power curve for an activity:
 curl -s "https://intervals.icu/api/v1/activity/<activity-id>/power-curve" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq '.[0:10]'
 ```
 
----
-
 ### 6. Get Wellness Data
 
 Get wellness record for a specific date:
@@ -105,8 +71,6 @@ Get wellness record for a specific date:
 ```bash
 curl -s "https://intervals.icu/api/v1/athlete/<athlete-id>/wellness/<date>" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq '{id, ctl, atl, rampRate, sleepTime, sleepScore, fatigue, soreness, stress, mood, motivation, weight, restingHR, hrv}'
 ```
-
----
 
 ### 7. Update Wellness Data
 
@@ -127,8 +91,6 @@ Write to `/tmp/intervals_wellness.json`:
 curl -s -X PUT "https://intervals.icu/api/v1/athlete/<athlete-id>/wellness/<date>" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" --header "Content-Type: application/json" -d @/tmp/intervals_wellness.json | jq '{id, weight, restingHR}'
 ```
 
----
-
 ### 8. List Calendar Events
 
 Get planned workouts and events for a date range:
@@ -138,8 +100,6 @@ Get planned workouts and events for a date range:
 ```bash
 curl -s "https://intervals.icu/api/v1/athlete/<athlete-id>/events?oldest=2025-01-01&newest=2025-12-31" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq '.[] | {id, start_date_local, name, category, type, description}'
 ```
-
----
 
 ### 9. Create Calendar Event
 
@@ -163,8 +123,6 @@ Write to `/tmp/intervals_event.json`:
 curl -s -X POST "https://intervals.icu/api/v1/athlete/<athlete-id>/events" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" --header "Content-Type: application/json" -d @/tmp/intervals_event.json | jq '{id, name, start_date_local, category, type}'
 ```
 
----
-
 ### 10. List Workouts
 
 Get workouts from the workout library:
@@ -174,8 +132,6 @@ Get workouts from the workout library:
 ```bash
 curl -s "https://intervals.icu/api/v1/athlete/<athlete-id>/workouts" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" | jq '.[] | {id, name, type, description}' | head -40
 ```
-
----
 
 ### 11. Create Manual Activity
 
@@ -200,8 +156,6 @@ Write to `/tmp/intervals_activity.json`:
 curl -s -X POST "https://intervals.icu/api/v1/athlete/<athlete-id>/activities/manual" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" --header "Content-Type: application/json" -d @/tmp/intervals_activity.json | jq '{id, name, type, start_date_local, moving_time, distance}'
 ```
 
----
-
 ### 12. Delete Activity
 
 Delete an activity:
@@ -211,8 +165,6 @@ Delete an activity:
 ```bash
 curl -s -X DELETE "https://intervals.icu/api/v1/activity/<activity-id>" --header "Authorization: Bearer $INTERVALS_ICU_TOKEN" -w "\nHTTP Status: %{http_code}\n"
 ```
-
----
 
 ## Guidelines
 

--- a/issue-triage/SKILL.md
+++ b/issue-triage/SKILL.md
@@ -3,14 +3,6 @@ name: issue-triage
 description: Classify, prioritize, and route incoming support issues. Activate when sorting new customer tickets, assigning severity levels P1 through P4, detecting duplicate reports, choosing the right team for handling, or deciding initial response approach for bug reports, billing questions, feature requests, account problems, and other inbound support inquiries.
 ---
 
-# Issue Triage
-
-You specialize in the rapid assessment of inbound customer support issues. Your role is to apply consistent classification, gauge urgency and blast radius, and direct each issue to the appropriate team with the right context attached.
-
-## Prerequisites
-
-Connect the **Issue Triage** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Classification System
 
 Every incoming issue receives a **primary label** and, where relevant, a **secondary label** from the taxonomy below.

--- a/jam/SKILL.md
+++ b/jam/SKILL.md
@@ -4,34 +4,9 @@ description: Jam.dev API for bug reporting. Use when user mentions "Jam", "bug r
   "screen recording", or asks about issue capture.
 ---
 
-# Jam
+## Troubleshooting
 
-Use the Jam API to access **bug reports, debugging telemetry, console logs, network requests, and user events** captured by the Jam browser extension.
-
-> Official docs: `https://jam.dev/docs/debug-a-jam/mcp`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Retrieve bug report details** including metadata, reporters, and context
-- **Access console logs** with error messages and stack traces from recorded sessions
-- **Inspect network requests** to debug API failures, slow responses, or HTTP errors
-- **Review user events** such as clicks, inputs, and page navigations
-- **Get screenshots** from recorded bug reports for visual inspection
-- **Analyze video recordings** to extract insights and detect issues
-- **List and search Jams** across your workspace by text, type, folder, author, URL, or date
-- **Add comments** to Jam recordings for collaboration
-
----
-
-## Prerequisites
-
-Connect the **Jam** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name JAM_TOKEN` or `zero doctor check-connector --url https://mcp.jam.dev/mcp --method POST`
+If requests fail, run `zero doctor check-connector --env-name JAM_TOKEN` or `zero doctor check-connector --url https://mcp.jam.dev/mcp --method POST`
 
 ## How to Use
 
@@ -40,8 +15,6 @@ Jam exposes its API through an MCP (Model Context Protocol) server at `https://m
 ### Base URL
 
 - **MCP endpoint**: `https://mcp.jam.dev/mcp`
-
----
 
 ### 1. Initialize MCP Session
 
@@ -58,8 +31,6 @@ SESSION_URL=$(grep -i "location:" /tmp/jam_headers.txt | tr -d '\r' | awk '{prin
 ```
 
 If no redirect location is returned, use the same endpoint with the session ID from the response headers.
-
----
 
 ### 2. List Available Tools
 
@@ -81,8 +52,6 @@ Then run:
 ```bash
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq '.result.tools[] | {name, description}'
 ```
-
----
 
 ### 3. List Jams
 
@@ -133,8 +102,6 @@ Then run:
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
 
----
-
 ### 4. Get Jam Details
 
 Get a quick snapshot of a Jam including who made it, what happened, and which tools to try next. Replace `JAM_ID` with the actual Jam identifier (the URL slug or ID from listJams).
@@ -160,8 +127,6 @@ Then run:
 ```bash
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
-
----
 
 ### 5. Get Console Logs
 
@@ -193,8 +158,6 @@ curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/js
 
 Available `logLevel` values: `error`, `warn`, `info`, `log`, `debug`.
 
----
-
 ### 6. Get Network Requests
 
 List all HTTP requests captured during the Jam recording, with optional filters.
@@ -225,8 +188,6 @@ curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/js
 
 Filter parameters: `statusCode` (HTTP status code), `contentType` (e.g., `application/json`), `host` (e.g., `api.example.com`), `limit` (max results).
 
----
-
 ### 7. Get User Events
 
 Read user interactions including clicks, inputs, and page navigations in plain language.
@@ -252,8 +213,6 @@ Then run:
 ```bash
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
-
----
 
 ### 8. Get Screenshots
 
@@ -281,8 +240,6 @@ Then run:
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
 
----
-
 ### 9. Get Video Transcript
 
 Retrieve spoken captions from video Jams in WebVTT format with timestamps.
@@ -308,8 +265,6 @@ Then run:
 ```bash
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
-
----
 
 ### 10. Analyze Video
 
@@ -337,8 +292,6 @@ Then run:
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
 
----
-
 ### 11. Get Custom Metadata
 
 Access custom key-value metadata set via the `jam.metadata()` SDK in your application.
@@ -365,8 +318,6 @@ Then run:
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
 
----
-
 ### 12. List Folders
 
 Browse available folders in your Jam workspace.
@@ -391,8 +342,6 @@ Then run:
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
 
----
-
 ### 13. List Team Members
 
 Browse team members in your Jam workspace.
@@ -416,8 +365,6 @@ Then run:
 ```bash
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
-
----
 
 ### 14. Add a Comment
 
@@ -446,8 +393,6 @@ Then run:
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
 
----
-
 ### 15. Move a Jam to a Folder
 
 Move a Jam to a different folder (requires `mcp:write` scope).
@@ -474,8 +419,6 @@ Then run:
 ```bash
 curl -s -X POST "https://mcp.jam.dev/mcp" --header "Content-Type: application/json" --header "Authorization: Bearer $JAM_TOKEN" -d @/tmp/jam_request.json | jq .
 ```
-
----
 
 ## Guidelines
 

--- a/jira/SKILL.md
+++ b/jira/SKILL.md
@@ -4,33 +4,9 @@ description: Jira API for issue tracking. Use when user mentions "Jira", "create
   "Jira issue", "sprint", or asks about Atlassian project management.
 ---
 
-# Jira API
+## Troubleshooting
 
-Use the Jira Cloud REST API via direct `curl` calls to manage **issues, projects, and workflows**.
-
-> Official docs: `https://developer.atlassian.com/cloud/jira/platform/rest/v3/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Create issues** in Jira projects
-- **Search issues** using JQL (Jira Query Language)
-- **Update issues** (status, assignee, priority, etc.)
-- **Get issue details** and comments
-- **List projects** and their metadata
-- **Transition issues** through workflow states
-- **Add comments** to issues
-
----
-
-## Prerequisites
-
-Connect the **Jira** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name JIRA_API_TOKEN` or `zero doctor check-connector --url https://your-domain.atlassian.net/rest/api/3/myself --method GET`
+If requests fail, run `zero doctor check-connector --env-name JIRA_API_TOKEN` or `zero doctor check-connector --url https://your-domain.atlassian.net/rest/api/3/myself --method GET`
 
 ## How to Use
 
@@ -39,8 +15,6 @@ All examples below assume `JIRA_DOMAIN`, `JIRA_EMAIL`, and `JIRA_API_TOKEN` are 
 Base URL: `https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3`
 
 > Note: `${JIRA_DOMAIN%.atlassian.net}` strips the suffix if present, so both `mycompany` and `mycompany.atlassian.net` work.
-
----
 
 ### 1. Get Current User
 
@@ -52,8 +26,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 curl -s -X GET "${JIRA_BASE}/myself" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
 
----
-
 ### 2. List Projects
 
 Get all projects you have access to:
@@ -63,8 +35,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/project" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
-
----
 
 ### 3. Get Project Details
 
@@ -77,8 +47,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 curl -s -X GET "${JIRA_BASE}/project/${PROJECT_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
 
----
-
 ### 4. Get Issue Types for Project
 
 List available issue types (Task, Bug, Story, etc.):
@@ -89,8 +57,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/project/${PROJECT_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
-
----
 
 ### 5. Search Issues with JQL
 
@@ -123,8 +89,6 @@ Common JQL examples:
 - `labels = bug` - By label
 - `priority = High` - By priority
 
----
-
 ### 6. Get Issue Details
 
 Get full details of an issue:
@@ -135,8 +99,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/issue/${ISSUE_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
-
----
 
 ### 7. Create Issue
 
@@ -173,8 +135,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X POST "${JIRA_BASE}/issue" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
-
----
 
 ### 8. Create Issue with Priority and Labels
 
@@ -214,8 +174,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 curl -s -X POST "${JIRA_BASE}/issue" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
 
----
-
 ### 9. Update Issue
 
 Update an existing issue:
@@ -246,8 +204,6 @@ curl -s -X PUT "${JIRA_BASE}/issue/${ISSUE_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TOKEN
 
 Returns 204 No Content on success.
 
----
-
 ### 10. Get Available Transitions
 
 Get possible status transitions for an issue:
@@ -258,8 +214,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/issue/${ISSUE_KEY}/transitions" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
-
----
 
 ### 11. Transition Issue (Change Status)
 
@@ -289,8 +243,6 @@ curl -s -X POST "${JIRA_BASE}/issue/${ISSUE_KEY}/transitions" -u "$JIRA_EMAIL:$J
 ```
 
 Returns 204 No Content on success.
-
----
 
 ### 12. Add Comment
 
@@ -327,8 +279,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 curl -s -X POST "${JIRA_BASE}/issue/${ISSUE_KEY}/comment" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
 
----
-
 ### 13. Get Issue Comments
 
 List all comments on an issue:
@@ -339,8 +289,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 
 curl -s -X GET "${JIRA_BASE}/issue/${ISSUE_KEY}/comment" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json"
 ```
-
----
 
 ### 14. Assign Issue
 
@@ -367,8 +315,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 curl -s -X PUT "${JIRA_BASE}/issue/${ISSUE_KEY}/assignee" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/jira_request.json
 ```
 
----
-
 ### 15. Search Users
 
 Find users by email or name:
@@ -385,8 +331,6 @@ JIRA_BASE="https://${JIRA_DOMAIN%.atlassian.net}.atlassian.net/rest/api/3"
 curl -s -G "${JIRA_BASE}/user/search" -u "$JIRA_EMAIL:$JIRA_API_TOKEN" --header "Accept: application/json" --data-urlencode "query@/tmp/jira_search.txt"
 ```
 
----
-
 ### 16. Delete Issue
 
 Delete an issue (use with caution):
@@ -399,8 +343,6 @@ curl -s -X DELETE "${JIRA_BASE}/issue/${ISSUE_KEY}" -u "$JIRA_EMAIL:$JIRA_API_TO
 ```
 
 Returns 204 No Content on success.
-
----
 
 ## Atlassian Document Format (ADF)
 
@@ -434,8 +376,6 @@ Jira API v3 uses ADF for rich text fields like `description` and `comment.body`.
   ]
 }
 ```
-
----
 
 ## Guidelines
 

--- a/jotform/SKILL.md
+++ b/jotform/SKILL.md
@@ -4,37 +4,13 @@ description: JotForm API for form management. Use when user mentions "JotForm", 
   "submissions", or asks about form data.
 ---
 
-# Jotform API
+## Troubleshooting
 
-Use the Jotform API via direct `curl` calls to **manage forms, submissions, questions, webhooks, and account data**.
-
-> Official docs: `https://api.jotform.com/docs/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **List and retrieve forms** from a Jotform account
-- **Manage form submissions** (list, create, update, delete)
-- **Read and modify form questions** and properties
-- **Set up webhooks** for form submission notifications
-- **Access user account info** including usage, settings, and folders
-
----
-
-## Prerequisites
-
-Connect the **Jotform** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name JOTFORM_TOKEN` or `zero doctor check-connector --url https://api.jotform.com/user --method GET`
+If requests fail, run `zero doctor check-connector --env-name JOTFORM_TOKEN` or `zero doctor check-connector --url https://api.jotform.com/user --method GET`
 
 ## How to Use
 
 All examples below assume you have `JOTFORM_TOKEN` set. Authentication uses the `APIKEY` header.
-
----
 
 ### 1. Get User Account Info
 
@@ -44,8 +20,6 @@ Retrieve information about the authenticated user.
 curl -s "https://api.jotform.com/user" --header "APIKEY: $JOTFORM_TOKEN" | jq .
 ```
 
----
-
 ### 2. Get Account Usage
 
 Check API usage limits and current consumption.
@@ -53,8 +27,6 @@ Check API usage limits and current consumption.
 ```bash
 curl -s "https://api.jotform.com/user/usage" --header "APIKEY: $JOTFORM_TOKEN" | jq .
 ```
-
----
 
 ### 3. List All Forms
 
@@ -70,8 +42,6 @@ Filter forms by status:
 curl -s "https://api.jotform.com/user/forms?limit=20&filter=%7B%22status%3Ane%22%3A%22DELETED%22%7D" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content[] | {id, title, status}'
 ```
 
----
-
 ### 4. Get Form Details
 
 Retrieve details for a specific form. Replace `FORM_ID` with the actual form ID.
@@ -79,8 +49,6 @@ Retrieve details for a specific form. Replace `FORM_ID` with the actual form ID.
 ```bash
 curl -s "https://api.jotform.com/form/FORM_ID" --header "APIKEY: $JOTFORM_TOKEN" | jq .
 ```
-
----
 
 ### 5. Get Form Questions
 
@@ -96,8 +64,6 @@ Get a specific question by ID:
 curl -s "https://api.jotform.com/form/FORM_ID/question/QUESTION_ID" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content'
 ```
 
----
-
 ### 6. List Form Submissions
 
 Get submissions for a specific form. Supports `limit`, `offset`, `orderby`, and `filter`.
@@ -105,8 +71,6 @@ Get submissions for a specific form. Supports `limit`, `offset`, `orderby`, and 
 ```bash
 curl -s "https://api.jotform.com/form/FORM_ID/submissions?limit=20&offset=0&orderby=created_at" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content[] | {id, created_at, status}'
 ```
-
----
 
 ### 7. Get a Single Submission
 
@@ -116,8 +80,6 @@ Retrieve details for a specific submission.
 curl -s "https://api.jotform.com/submission/SUBMISSION_ID" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content'
 ```
 
----
-
 ### 8. Create a Submission
 
 Submit new data to a form. Field keys follow the format `submission[QUESTION_ID]`.
@@ -125,8 +87,6 @@ Submit new data to a form. Field keys follow the format `submission[QUESTION_ID]
 ```bash
 curl -s -X POST "https://api.jotform.com/form/FORM_ID/submissions" --header "APIKEY: $JOTFORM_TOKEN" -d "submission[1]=John" -d "submission[2]=Doe" -d "submission[3]=john@example.com" | jq .
 ```
-
----
 
 ### 9. Update a Submission
 
@@ -136,8 +96,6 @@ Edit an existing submission.
 curl -s -X POST "https://api.jotform.com/submission/SUBMISSION_ID" --header "APIKEY: $JOTFORM_TOKEN" -d "submission[1]=Jane" -d "submission[2]=Smith" | jq .
 ```
 
----
-
 ### 10. Delete a Submission
 
 Delete a submission by ID.
@@ -145,8 +103,6 @@ Delete a submission by ID.
 ```bash
 curl -s -X DELETE "https://api.jotform.com/submission/SUBMISSION_ID" --header "APIKEY: $JOTFORM_TOKEN" | jq .
 ```
-
----
 
 ### 11. Get Form Properties
 
@@ -162,8 +118,6 @@ Get a specific property:
 curl -s "https://api.jotform.com/form/FORM_ID/properties/PROPERTY_KEY" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content'
 ```
 
----
-
 ### 12. List Form Webhooks
 
 Get all webhooks configured for a form.
@@ -171,8 +125,6 @@ Get all webhooks configured for a form.
 ```bash
 curl -s "https://api.jotform.com/form/FORM_ID/webhooks" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content'
 ```
-
----
 
 ### 13. Create a Webhook
 
@@ -182,8 +134,6 @@ Add a webhook URL to receive form submission notifications.
 curl -s -X POST "https://api.jotform.com/form/FORM_ID/webhooks" --header "APIKEY: $JOTFORM_TOKEN" -d "webhookURL=https://example.com/webhook" | jq .
 ```
 
----
-
 ### 14. Delete a Webhook
 
 Remove a webhook from a form.
@@ -191,8 +141,6 @@ Remove a webhook from a form.
 ```bash
 curl -s -X DELETE "https://api.jotform.com/form/FORM_ID/webhooks/WEBHOOK_ID" --header "APIKEY: $JOTFORM_TOKEN" | jq .
 ```
-
----
 
 ### 15. List Form Files
 
@@ -202,8 +150,6 @@ Get all files uploaded through a form.
 curl -s "https://api.jotform.com/form/FORM_ID/files" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content'
 ```
 
----
-
 ### 16. Clone a Form
 
 Create a copy of an existing form.
@@ -211,8 +157,6 @@ Create a copy of an existing form.
 ```bash
 curl -s -X POST "https://api.jotform.com/form/FORM_ID/clone" --header "APIKEY: $JOTFORM_TOKEN" | jq .
 ```
-
----
 
 ### 17. Delete a Form
 
@@ -222,8 +166,6 @@ Delete a form by ID.
 curl -s -X DELETE "https://api.jotform.com/form/FORM_ID" --header "APIKEY: $JOTFORM_TOKEN" | jq .
 ```
 
----
-
 ### 18. List User Folders
 
 Get all folders in the account.
@@ -231,8 +173,6 @@ Get all folders in the account.
 ```bash
 curl -s "https://api.jotform.com/user/folders" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content'
 ```
-
----
 
 ### 19. Get All User Submissions
 
@@ -242,8 +182,6 @@ Retrieve all submissions across all forms.
 curl -s "https://api.jotform.com/user/submissions?limit=20&offset=0" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content[] | {id, form_id, created_at, status}'
 ```
 
----
-
 ### 20. Get Form Reports
 
 List all reports for a form.
@@ -251,8 +189,6 @@ List all reports for a form.
 ```bash
 curl -s "https://api.jotform.com/form/FORM_ID/reports" --header "APIKEY: $JOTFORM_TOKEN" | jq '.content'
 ```
-
----
 
 ## Guidelines
 

--- a/journal-entries/SKILL.md
+++ b/journal-entries/SKILL.md
@@ -3,14 +3,6 @@ name: journal-entries
 description: Construct and review journal entries with correct debit/credit structure, supporting calculations, and approval workflows. Use for month-end accruals, prepaid amortization, depreciation entries, payroll booking, revenue recognition journal entries, manual adjustments, recurring entries, reversing entries, or intercompany journal entries.
 ---
 
-# Journal Entry Construction
-
-Guidance on structuring, documenting, reviewing, and posting journal entries across all major accounting cycles.
-
-## Prerequisites
-
-Connect the **Journal Entry Construction** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Core Entry Patterns by Accounting Cycle
 
 ### Vendor & Expense Accruals

--- a/kb-authoring/SKILL.md
+++ b/kb-authoring/SKILL.md
@@ -3,14 +3,6 @@ name: kb-authoring
 description: Author and maintain knowledge base articles derived from resolved support cases. Activate when documenting a solution from a closed ticket, writing how-to guides, building troubleshooting walkthroughs, creating FAQ entries, publishing known-issue advisories, updating stale documentation, organizing KB taxonomy, or performing content gap analysis to reduce future ticket volume.
 ---
 
-# KB Authoring
-
-You produce, organize, and maintain self-service knowledge base content that empowers customers to solve problems independently. Every article you write is optimized for findability, scannability, and first-read resolution. Your north star: each well-crafted article prevents a future support ticket.
-
-## Prerequisites
-
-Connect the **KB Authoring** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Article Anatomy
 
 ### Mandatory Components
@@ -77,10 +69,12 @@ Anchor every article with a first sentence that restates the task or problem in 
 [Summary: what this covers and when you would need it]
 
 ## Before You Begin
+
 - [Prerequisite 1]
 - [Prerequisite 2]
 
 ## Instructions
+
 ### Step 1: [Action verb phrase]
 [Precise instruction with path: Settings > Integrations > API Keys]
 
@@ -88,12 +82,15 @@ Anchor every article with a first sentence that restates the task or problem in 
 [Instruction, including what the user should see after completing this step]
 
 ## Confirm Success
+
 [How to verify the task completed correctly]
 
 ## Troubleshooting
+
 - [Potential hiccup]: [Resolution]
 
 ## See Also
+
 - [Related article links]
 ```
 
@@ -111,13 +108,16 @@ Anchor every article with a first sentence that restates the task or problem in 
 # [Problem statement matching what the user observes]
 
 ## What You See
+
 - [Observable symptom 1]
 - [Observable symptom 2]
 
 ## Why This Happens
+
 [Concise, jargon-free explanation of the root cause]
 
 ## How to Fix It
+
 ### Fix 1: [Most likely resolution]
 [Step-by-step instructions]
 
@@ -125,9 +125,11 @@ Anchor every article with a first sentence that restates the task or problem in 
 [Step-by-step instructions]
 
 ## Preventing Recurrence
+
 [Configuration change or practice that avoids this in the future]
 
 ## Need More Help?
+
 [How to contact support]
 ```
 
@@ -147,9 +149,11 @@ Anchor every article with a first sentence that restates the task or problem in 
 [Direct answer: 1-3 sentences]
 
 ## Additional Context
+
 [Deeper explanation, edge cases, or nuance if needed]
 
 ## Related Questions
+
 - [Link to related FAQ 1]
 - [Link to related FAQ 2]
 ```
@@ -171,15 +175,19 @@ Anchor every article with a first sentence that restates the task or problem in 
 **Last updated:** [Date]
 
 ## What Users Experience
+
 [Description of the observable behavior]
 
 ## Workaround
+
 [Step-by-step workaround, or "No workaround is currently available."]
 
 ## Resolution Timeline
+
 [Estimated fix date or current engineering status]
 
 ## Change Log
+
 - [Date]: [Update summary]
 ```
 

--- a/kommo/SKILL.md
+++ b/kommo/SKILL.md
@@ -4,31 +4,9 @@ description: Kommo (formerly amoCRM) API. Use when user mentions "Kommo", "amoCR
   "CRM", or sales pipeline management.
 ---
 
-# Kommo API
+## Troubleshooting
 
-Use the Kommo API via direct `curl` calls for **CRM management** including leads, contacts, companies, tasks, and sales pipelines.
-
-> Official docs: `https://developers.kommo.com/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage leads** - Create, list, update leads in your sales pipeline
-- **Handle contacts** - Add and retrieve customer contact information
-- **Track companies** - Manage company records and associations
-- **Create tasks** - Schedule follow-ups and meetings
-- **View pipelines** - Get sales pipeline stages and statuses
-
----
-
-## Prerequisites
-
-Connect the **Kommo** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name KOMMO_API_KEY` or `zero doctor check-connector --url https://your-subdomain.kommo.com/api/v4/leads --method GET`
+If requests fail, run `zero doctor check-connector --env-name KOMMO_API_KEY` or `zero doctor check-connector --url https://your-subdomain.kommo.com/api/v4/leads --method GET`
 
 ## How to Use
 
@@ -39,8 +17,6 @@ The base URL is: `https://${KOMMO_SUBDOMAIN}.kommo.com/api/v4`
 Authentication uses Bearer token in the `Authorization` header.
 
 **Rate limit:** Maximum 7 requests per second.
-
----
 
 ### 1. List Leads
 
@@ -56,8 +32,6 @@ With filters:
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/leads?limit=10&page=1" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" | jq '.["_embedded"]["leads"]'
 ```
 
----
-
 ### 2. Get Lead by ID
 
 Get a specific lead:
@@ -67,8 +41,6 @@ Replace `<your-lead-id>` with the actual lead ID:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/leads/<your-lead-id>" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY"
 ```
-
----
 
 ### 3. Create Lead
 
@@ -88,8 +60,6 @@ Then run:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/leads" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" -d @/tmp/kommo_request.json
 ```
-
----
 
 ### 4. Create Lead with Contact and Company
 
@@ -119,8 +89,6 @@ Then run:
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/leads/complex" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" -d @/tmp/kommo_request.json
 ```
 
----
-
 ### 5. Update Lead
 
 Update an existing lead:
@@ -142,8 +110,6 @@ Replace `<your-lead-id>` with the actual lead ID:
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/leads/<your-lead-id>" -X PATCH -H "Content-Type: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" -d @/tmp/kommo_request.json
 ```
 
----
-
 ### 6. List Contacts
 
 Get all contacts:
@@ -151,8 +117,6 @@ Get all contacts:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/contacts" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" | jq '.["_embedded"]["contacts"][] | {id, name}'
 ```
-
----
 
 ### 7. Get Contact by ID
 
@@ -163,8 +127,6 @@ Replace `<your-contact-id>` with the actual contact ID:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/contacts/<your-contact-id>" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY"
 ```
-
----
 
 ### 8. Create Contact
 
@@ -185,8 +147,6 @@ Then run:
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/contacts" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" -d @/tmp/kommo_request.json
 ```
 
----
-
 ### 9. List Companies
 
 Get all companies:
@@ -194,8 +154,6 @@ Get all companies:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/companies" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" | jq '.["_embedded"]["companies"][] | {id, name}'
 ```
-
----
 
 ### 10. Create Company
 
@@ -215,8 +173,6 @@ Then run:
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/companies" -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" -d @/tmp/kommo_request.json
 ```
 
----
-
 ### 11. List Tasks
 
 Get all tasks:
@@ -224,8 +180,6 @@ Get all tasks:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/tasks" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" | jq '.["_embedded"]["tasks"][] | {id, text, complete_till}'
 ```
-
----
 
 ### 12. Create Task
 
@@ -249,8 +203,6 @@ curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/tasks" -X POST -H "Content-Ty
 
 **Task types:** `1` = Follow-up, `2` = Meeting
 
----
-
 ### 13. List Pipelines
 
 Get all sales pipelines:
@@ -258,8 +210,6 @@ Get all sales pipelines:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/leads/pipelines" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" | jq '.["_embedded"]["pipelines"][] | {id, name}'
 ```
-
----
 
 ### 14. Get Pipeline Stages
 
@@ -271,8 +221,6 @@ Replace `<your-pipeline-id>` with the actual pipeline ID:
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/leads/pipelines/<your-pipeline-id>" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" | jq '.["_embedded"]["statuses"][] | {id, name}'
 ```
 
----
-
 ### 15. Get Account Info
 
 Get account information:
@@ -280,8 +228,6 @@ Get account information:
 ```bash
 curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/account" -H "Accept: application/json" -H "Authorization: Bearer $KOMMO_API_KEY" | jq '{id, name, subdomain, currency}'
 ```
-
----
 
 ## Response Format
 
@@ -308,8 +254,6 @@ curl -s "https://$KOMMO_SUBDOMAIN.kommo.com/api/v4/account" -H "Accept: applicat
   "last_name": "Doe"
 }
 ```
-
----
 
 ## Guidelines
 

--- a/lark/SKILL.md
+++ b/lark/SKILL.md
@@ -4,24 +4,9 @@ description: Lark/Feishu API for collaboration. Use when user mentions "Lark", "
   "Lark docs", or asks about ByteDance workspace tools.
 ---
 
-# Lark (Feishu) API
+## Troubleshooting
 
-Complete Lark/Feishu integration for enterprise collaboration, including messaging, group management, contacts, and calendar.
-
-## When to Use
-
-- Send automated notifications to users or groups
-- Build interactive bot workflows
-- Manage group chats and members
-- Query contacts and organization structure
-- Sync calendar events and schedules
-- Integrate Lark with other systems
-
-## Prerequisites
-
-Connect the **Lark (Feishu)** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name LARK_TOKEN` or `zero doctor check-connector --url https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal --method POST`
+If requests fail, run `zero doctor check-connector --env-name LARK_TOKEN` or `zero doctor check-connector --url https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal --method POST`
 
 ## Token Management
 

--- a/legal-briefing/SKILL.md
+++ b/legal-briefing/SKILL.md
@@ -3,14 +3,6 @@ name: legal-briefing
 description: Build structured briefing documents for meetings with legal significance and track resulting action items. Use when preparing for contract negotiations, board meetings, regulatory discussions, vendor calls, deal reviews, compliance meetings, litigation strategy sessions, or any meeting requiring legal context, participant research, talking points, or post-meeting task tracking.
 ---
 
-# Legal Briefing Skill
-
-You serve as the preparation engine for an in-house legal team's meetings. You pull together context from available sources, assemble organized briefing packages for meetings that carry legal implications, and help capture and manage the tasks that emerge from those meetings.
-
-## Prerequisites
-
-Connect the **Legal Briefing** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Preparation Workflow
 
 ### Phase 1: Define the Meeting
@@ -93,6 +85,7 @@ Explicitly flag anything incomplete:
 ## Briefing Document Structure
 
 ```
+
 ## Meeting Briefing
 
 ### Logistics
@@ -186,6 +179,7 @@ Supplement the standard briefing with:
 Help the user document commitments from each meeting:
 
 ```
+
 ## Tasks from [Meeting Title] - [Date]
 
 | # | Task Description | Owner | Due Date | Urgency | Status |

--- a/legal-risk-scoring/SKILL.md
+++ b/legal-risk-scoring/SKILL.md
@@ -3,14 +3,6 @@ name: legal-risk-scoring
 description: Score and classify legal risks on a severity-times-likelihood matrix, assign GREEN/YELLOW/ORANGE/RED ratings, document findings in structured memos, and determine escalation paths. Use when scoring contract exposure, evaluating deal risk, rating legal issues by severity and probability, deciding whether to involve senior counsel or outside lawyers, or building a legal risk register.
 ---
 
-# Legal Risk Scoring Skill
-
-You function as a legal risk evaluation specialist embedded within an in-house legal team. You help quantify, categorize, and formally document legal risks through a disciplined scoring model built on two dimensions: impact magnitude and occurrence probability.
-
-## Prerequisites
-
-Connect the **Legal Risk Scoring** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Scoring Model
 
 ### Two-Axis Evaluation Grid
@@ -159,6 +151,7 @@ Trivial   (1) |   1    |    2   |    3   |    4   |      5     |
 Every formal evaluation should follow this structure:
 
 ```
+
 ## Legal Risk Evaluation
 
 **Prepared**: [date]

--- a/line/SKILL.md
+++ b/line/SKILL.md
@@ -4,31 +4,9 @@ description: LINE API for messaging. Use when user mentions "LINE", "LINE messag
   "LINE bot", or asks about LINE platform.
 ---
 
-# LINE Messaging API
+## Troubleshooting
 
-Use the LINE Messaging API via direct `curl` calls to **send messages, manage users, configure rich menus, set up webhooks, and access analytics** for LINE Official Accounts and bots.
-
-> Official docs: `https://developers.line.biz/en/reference/messaging-api/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Send messages** to users via push, reply, multicast, or broadcast
-- **Retrieve user profiles** and follower information
-- **Manage rich menus** for interactive bot interfaces
-- **Configure webhooks** for receiving events from LINE
-- **Access analytics** including message delivery stats and follower demographics
-
----
-
-## Prerequisites
-
-Connect the **LINE** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name LINE_TOKEN` or `zero doctor check-connector --url https://api.line.me/v2/bot/info --method GET`
+If requests fail, run `zero doctor check-connector --env-name LINE_TOKEN` or `zero doctor check-connector --url https://api.line.me/v2/bot/info --method GET`
 
 ## How to Use
 
@@ -38,8 +16,6 @@ All examples below assume you have `LINE_TOKEN` set. Authentication uses Bearer 
 
 - `https://api.line.me`
 
----
-
 ### 1. Get Bot Info
 
 Retrieve information about the bot associated with the channel access token.
@@ -48,8 +24,6 @@ Retrieve information about the bot associated with the channel access token.
 curl -s "https://api.line.me/v2/bot/info" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
 
----
-
 ### 2. Get User Profile
 
 Retrieve a user's display name, profile image, and status message. Replace `USER_ID` with the actual user ID.
@@ -57,8 +31,6 @@ Retrieve a user's display name, profile image, and status message. Replace `USER
 ```bash
 curl -s "https://api.line.me/v2/bot/profile/USER_ID" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
-
----
 
 ### 3. Get Follower IDs
 
@@ -73,8 +45,6 @@ For pagination, use the `next` token from the response:
 ```bash
 curl -s "https://api.line.me/v2/bot/followers/ids?limit=100&start=CONTINUATION_TOKEN" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
-
----
 
 ### 4. Send Push Message
 
@@ -100,8 +70,6 @@ Then run:
 curl -s -X POST "https://api.line.me/v2/bot/message/push" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d @/tmp/line_request.json | jq .
 ```
 
----
-
 ### 5. Send Reply Message
 
 Reply to a user event using a reply token received from a webhook event. Reply tokens expire after a short time.
@@ -125,8 +93,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.line.me/v2/bot/message/reply" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d @/tmp/line_request.json | jq .
 ```
-
----
 
 ### 6. Send Multicast Message
 
@@ -152,8 +118,6 @@ Then run:
 curl -s -X POST "https://api.line.me/v2/bot/message/multicast" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d @/tmp/line_request.json | jq .
 ```
 
----
-
 ### 7. Send Broadcast Message
 
 Send a message to all users who have added the bot as a friend.
@@ -177,8 +141,6 @@ Then run:
 curl -s -X POST "https://api.line.me/v2/bot/message/broadcast" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d @/tmp/line_request.json | jq .
 ```
 
----
-
 ### 8. Check Message Quota
 
 Get the monthly message quota for the LINE Official Account.
@@ -192,8 +154,6 @@ Check how many messages have been sent this month:
 ```bash
 curl -s "https://api.line.me/v2/bot/message/quota/consumption" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
-
----
 
 ### 9. Send Image Message
 
@@ -219,8 +179,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.line.me/v2/bot/message/push" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d @/tmp/line_request.json | jq .
 ```
-
----
 
 ### 10. Send Template Message (Buttons)
 
@@ -263,8 +221,6 @@ Then run:
 curl -s -X POST "https://api.line.me/v2/bot/message/push" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d @/tmp/line_request.json | jq .
 ```
 
----
-
 ### 11. Get Webhook Endpoint
 
 Retrieve the current webhook URL configuration.
@@ -272,8 +228,6 @@ Retrieve the current webhook URL configuration.
 ```bash
 curl -s "https://api.line.me/v2/bot/channel/webhook/endpoint" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
-
----
 
 ### 12. Set Webhook Endpoint
 
@@ -283,8 +237,6 @@ Configure the webhook URL where LINE sends events.
 curl -s -X PUT "https://api.line.me/v2/bot/channel/webhook/endpoint" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d '{"endpoint":"https://example.com/webhook"}' | jq .
 ```
 
----
-
 ### 13. Test Webhook
 
 Test the webhook endpoint connectivity.
@@ -293,8 +245,6 @@ Test the webhook endpoint connectivity.
 curl -s -X POST "https://api.line.me/v2/bot/channel/webhook/test" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d '{"endpoint":"https://example.com/webhook"}' | jq .
 ```
 
----
-
 ### 14. List Rich Menus
 
 Get all rich menus created for the bot.
@@ -302,8 +252,6 @@ Get all rich menus created for the bot.
 ```bash
 curl -s "https://api.line.me/v2/bot/richmenu/list" --header "Authorization: Bearer $LINE_TOKEN" | jq '.richmenus[] | {richMenuId, name, size}'
 ```
-
----
 
 ### 15. Create Rich Menu
 
@@ -355,8 +303,6 @@ Then run:
 curl -s -X POST "https://api.line.me/v2/bot/richmenu" --header "Content-Type: application/json" --header "Authorization: Bearer $LINE_TOKEN" -d @/tmp/line_request.json | jq .
 ```
 
----
-
 ### 16. Delete Rich Menu
 
 Delete a rich menu by ID.
@@ -364,8 +310,6 @@ Delete a rich menu by ID.
 ```bash
 curl -s -X DELETE "https://api.line.me/v2/bot/richmenu/RICH_MENU_ID" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
-
----
 
 ### 17. Get Message Delivery Statistics
 
@@ -375,8 +319,6 @@ Get the number of messages delivered on a specific date (format: `yyyyMMdd`).
 curl -s "https://api.line.me/v2/bot/insight/message/delivery?date=20260301" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
 
----
-
 ### 18. Get Follower Demographics
 
 Retrieve demographic data about followers (gender, age, area distribution).
@@ -384,8 +326,6 @@ Retrieve demographic data about followers (gender, age, area distribution).
 ```bash
 curl -s "https://api.line.me/v2/bot/insight/demographic" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
-
----
 
 ### 19. Get Group Summary
 
@@ -395,8 +335,6 @@ Retrieve information about a group chat the bot is a member of.
 curl -s "https://api.line.me/v2/bot/group/GROUP_ID/summary" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
 
----
-
 ### 20. Get Group Member Profile
 
 Retrieve the profile of a specific member in a group chat.
@@ -404,8 +342,6 @@ Retrieve the profile of a specific member in a group chat.
 ```bash
 curl -s "https://api.line.me/v2/bot/group/GROUP_ID/member/USER_ID" --header "Authorization: Bearer $LINE_TOKEN" | jq .
 ```
-
----
 
 ## Message Types
 
@@ -421,8 +357,6 @@ LINE supports multiple message types in the `messages` array:
 | `sticker` | LINE sticker with package and sticker IDs |
 | `template` | Interactive template (buttons, confirm, carousel) |
 | `flex` | Flexible layout message using Flex Message JSON |
-
----
 
 ## Guidelines
 

--- a/linear/SKILL.md
+++ b/linear/SKILL.md
@@ -4,32 +4,9 @@ description: Linear API for issue tracking. Use when user mentions "Linear", "li
   shares a Linear link, "~ENG-123", "create issue", or asks about Linear tasks.
 ---
 
-# Linear API
+## Troubleshooting
 
-Use the Linear API via direct `curl` calls to manage **issues, projects, and teams** with GraphQL queries and mutations.
-
-> Official docs: `https://linear.app/developers`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Query issues** from Linear workspaces
-- **Create new issues** with title, description, and assignments
-- **Update issue status** and properties
-- **List teams and projects** in an organization
-- **Add comments** to issues
-- **Search issues** with filters
-
----
-
-## Prerequisites
-
-Connect the **Linear** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name LINEAR_TOKEN` or `zero doctor check-connector --url https://api.linear.app/graphql --method POST`
+If requests fail, run `zero doctor check-connector --env-name LINEAR_TOKEN` or `zero doctor check-connector --url https://api.linear.app/graphql --method POST`
 
 ## How to Use
 
@@ -38,8 +15,6 @@ All examples below assume you have `LINEAR_TOKEN` set.
 Base URL: `https://api.linear.app/graphql`
 
 Linear uses **GraphQL** for all API operations. Queries retrieve data, mutations modify data.
-
----
 
 ### 1. List Teams
 
@@ -61,8 +36,6 @@ curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/j
 
 Save a team ID for subsequent queries.
 
----
-
 ### 2. List Issues for a Team
 
 Get issues from a specific team. Replace `<your-team-id>` with the actual team ID:
@@ -80,8 +53,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.team.issues.nodes'
 ```
-
----
 
 ### 3. Get Issue by Identifier
 
@@ -101,8 +72,6 @@ Then run:
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.issue'
 ```
 
----
-
 ### 4. Search Issues
 
 Search issues with filters:
@@ -121,8 +90,6 @@ Then run:
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.issues.nodes'
 ```
 
----
-
 ### 5. Create Issue
 
 Create a new issue in a team. Replace `<your-team-id>` with the actual team ID:
@@ -140,8 +107,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.issueCreate'
 ```
-
----
 
 ### 6. Create Issue with Priority and Labels
 
@@ -163,8 +128,6 @@ curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/j
 
 **Priority values:** 0 (No priority), 1 (Urgent), 2 (High), 3 (Medium), 4 (Low)
 
----
-
 ### 7. Update Issue
 
 Update an existing issue. Replace `<your-issue-id>` with the actual issue ID:
@@ -182,8 +145,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.issueUpdate'
 ```
-
----
 
 ### 8. Change Issue State
 
@@ -203,8 +164,6 @@ Then run:
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.issueUpdate'
 ```
 
----
-
 ### 9. List Workflow States
 
 Get available states for a team. Replace `<your-team-id>` with the actual team ID:
@@ -222,8 +181,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.team.states.nodes'
 ```
-
----
 
 ### 10. Add Comment to Issue
 
@@ -243,8 +200,6 @@ Then run:
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.commentCreate'
 ```
 
----
-
 ### 11. List Projects
 
 Get all projects in the workspace:
@@ -262,8 +217,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.projects.nodes'
 ```
-
----
 
 ### 12. Get Current User
 
@@ -283,8 +236,6 @@ Then run:
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.viewer'
 ```
 
----
-
 ### 13. List Labels
 
 Get available labels for a team. Replace `<your-team-id>` with the actual team ID:
@@ -303,8 +254,6 @@ Then run:
 curl -s -X POST "https://api.linear.app/graphql" -H "Content-Type: application/json" -H "Authorization: $LINEAR_TOKEN" -d @/tmp/linear_request.json | jq '.data.team.labels.nodes'
 ```
 
----
-
 ## Finding IDs
 
 To find IDs for teams, issues, projects, etc.:
@@ -315,8 +264,6 @@ To find IDs for teams, issues, projects, etc.:
 4. Select the entity to copy its ID
 
 Or use the queries above to list entities and extract their IDs.
-
----
 
 ## Guidelines
 

--- a/loops/SKILL.md
+++ b/loops/SKILL.md
@@ -3,24 +3,9 @@ name: loops
 description: Loops email platform for SaaS. Use when user mentions "Loops", "Loops.so", "email marketing", "onboarding emails", "transactional email", or asks about SaaS lifecycle emails.
 ---
 
-# Loops API
+## Troubleshooting
 
-Send onboarding, marketing, and transactional emails to SaaS users via Loops.
-
-> Official docs: `https://loops.so/docs/api-reference`
-
-## When to Use
-
-- Add or update contacts synced from Clerk or another auth provider
-- Trigger automated email sequences via events (e.g., user signed up, upgraded plan)
-- Send one-off transactional emails (password reset, invoice, etc.)
-- List or manage mailing lists and contact properties
-
-## Prerequisites
-
-Connect the **Loops** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name LOOPS_TOKEN` or `zero doctor check-connector --url https://app.loops.so/api/v1/api-key --method GET`
+If requests fail, run `zero doctor check-connector --env-name LOOPS_TOKEN` or `zero doctor check-connector --url https://app.loops.so/api/v1/api-key --method GET`
 
 ## Core APIs
 
@@ -31,8 +16,6 @@ Verify your API key is valid:
 ```bash
 curl -s "https://app.loops.so/api/v1/api-key" --header "Authorization: Bearer $LOOPS_TOKEN"
 ```
-
----
 
 ### Create Contact
 
@@ -55,8 +38,6 @@ curl -s -X POST "https://app.loops.so/api/v1/contacts/create" --header "Authoriz
 
 Docs: https://loops.so/docs/api-reference/create-contact
 
----
-
 ### Update Contact
 
 Write to `/tmp/loops_request.json`:
@@ -73,8 +54,6 @@ Write to `/tmp/loops_request.json`:
 curl -s -X PUT "https://app.loops.so/api/v1/contacts/update" --header "Authorization: Bearer $LOOPS_TOKEN" --header "Content-Type: application/json" -d @/tmp/loops_request.json
 ```
 
----
-
 ### Find Contact
 
 Find a contact by email address. Replace `<email>` with the actual email:
@@ -82,8 +61,6 @@ Find a contact by email address. Replace `<email>` with the actual email:
 ```bash
 curl -s "https://app.loops.so/api/v1/contacts/find?email=<email>" --header "Authorization: Bearer $LOOPS_TOKEN"
 ```
-
----
 
 ### Delete Contact
 
@@ -98,8 +75,6 @@ Write to `/tmp/loops_request.json`:
 ```bash
 curl -s -X DELETE "https://app.loops.so/api/v1/contacts/delete" --header "Authorization: Bearer $LOOPS_TOKEN" --header "Content-Type: application/json" -d @/tmp/loops_request.json
 ```
-
----
 
 ### Send Event
 
@@ -124,8 +99,6 @@ curl -s -X POST "https://app.loops.so/api/v1/events/send" --header "Authorizatio
 
 Docs: https://loops.so/docs/api-reference/send-event
 
----
-
 ### Send Transactional Email
 
 Send a one-off email using a transactional template. Replace `<transactional-id>` with the ID from your Loops dashboard.
@@ -149,15 +122,11 @@ curl -s -X POST "https://app.loops.so/api/v1/transactional" --header "Authorizat
 
 Docs: https://loops.so/docs/api-reference/send-transactional-email
 
----
-
 ### List Transactional Emails
 
 ```bash
 curl -s "https://app.loops.so/api/v1/transactional" --header "Authorization: Bearer $LOOPS_TOKEN" | jq '[.[] | {id, name}]'
 ```
-
----
 
 ### List Mailing Lists
 
@@ -165,15 +134,11 @@ curl -s "https://app.loops.so/api/v1/transactional" --header "Authorization: Bea
 curl -s "https://app.loops.so/api/v1/lists" --header "Authorization: Bearer $LOOPS_TOKEN" | jq '[.[] | {id, name}]'
 ```
 
----
-
 ### List Contact Properties
 
 ```bash
 curl -s "https://app.loops.so/api/v1/contacts/customFields" --header "Authorization: Bearer $LOOPS_TOKEN" | jq '[.[] | {key, label, type}]'
 ```
-
----
 
 ## Guidelines
 

--- a/mailchimp/SKILL.md
+++ b/mailchimp/SKILL.md
@@ -4,25 +4,9 @@ description: Mailchimp API for email marketing. Use when user mentions "Mailchim
   "email campaign", "newsletter", or marketing automation.
 ---
 
-# Mailchimp Marketing API
+## Troubleshooting
 
-Manage audiences (lists), campaigns, templates, and subscribers with the Mailchimp Marketing API v3.0.
-
-> Official docs: `https://mailchimp.com/developer/marketing/api/`
-
-## When to Use
-
-- Manage audiences/lists and subscribers
-- Create, send, and analyze email campaigns
-- Manage email templates
-- View campaign reports and analytics
-- Manage tags and segments
-
-## Prerequisites
-
-Connect the **Mailchimp** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MAILCHIMP_TOKEN` or `zero doctor check-connector --url https://us1.api.mailchimp.com/3.0/ping --method GET`
+If requests fail, run `zero doctor check-connector --env-name MAILCHIMP_TOKEN` or `zero doctor check-connector --url https://us1.api.mailchimp.com/3.0/ping --method GET`
 
 ## Core APIs
 
@@ -34,15 +18,11 @@ Use this to verify authentication:
 curl -s "https://${MC_DC}.api.mailchimp.com/3.0/ping" --header "Authorization: Bearer $MAILCHIMP_TOKEN" | jq '{health_status}'
 ```
 
----
-
 ### Get Account Details
 
 ```bash
 curl -s "https://${MC_DC}.api.mailchimp.com/3.0/" --header "Authorization: Bearer $MAILCHIMP_TOKEN" | jq '{account_id, account_name, email, total_subscribers}'
 ```
-
----
 
 ### List Audiences (Lists)
 
@@ -52,8 +32,6 @@ curl -s "https://${MC_DC}.api.mailchimp.com/3.0/lists?count=10" --header "Author
 
 Docs: https://mailchimp.com/developer/marketing/api/lists/
 
----
-
 ### Get Audience Details
 
 Replace `<list-id>` with the actual list/audience ID:
@@ -62,8 +40,6 @@ Replace `<list-id>` with the actual list/audience ID:
 curl -s "https://${MC_DC}.api.mailchimp.com/3.0/lists/<list-id>" --header "Authorization: Bearer $MAILCHIMP_TOKEN" | jq '{id, name, stats, date_created}'
 ```
 
----
-
 ### List Members of Audience
 
 Replace `<list-id>` with the actual list ID:
@@ -71,8 +47,6 @@ Replace `<list-id>` with the actual list ID:
 ```bash
 curl -s "https://${MC_DC}.api.mailchimp.com/3.0/lists/<list-id>/members?count=10" --header "Authorization: Bearer $MAILCHIMP_TOKEN" | jq '.members[] | {id, email_address, status, full_name}'
 ```
-
----
 
 ### Add Member to Audience
 
@@ -97,8 +71,6 @@ curl -s -X POST "https://${MC_DC}.api.mailchimp.com/3.0/lists/<list-id>/members"
 
 Docs: https://mailchimp.com/developer/marketing/api/list-members/
 
----
-
 ### Update Member
 
 Replace `<list-id>` and `<subscriber-hash>` (MD5 hash of lowercase email):
@@ -120,8 +92,6 @@ curl -s -X PATCH "https://${MC_DC}.api.mailchimp.com/3.0/lists/<list-id>/members
 
 To compute the subscriber hash: `echo -n "email@example.com" | md5sum | cut -d' ' -f1`
 
----
-
 ### List Campaigns
 
 ```bash
@@ -130,8 +100,6 @@ curl -s "https://${MC_DC}.api.mailchimp.com/3.0/campaigns?count=10&sort_field=se
 
 Docs: https://mailchimp.com/developer/marketing/api/campaigns/
 
----
-
 ### Get Campaign Details
 
 Replace `<campaign-id>` with the actual campaign ID:
@@ -139,8 +107,6 @@ Replace `<campaign-id>` with the actual campaign ID:
 ```bash
 curl -s "https://${MC_DC}.api.mailchimp.com/3.0/campaigns/<campaign-id>" --header "Authorization: Bearer $MAILCHIMP_TOKEN" | jq '{id, type, status, settings, recipients, send_time}'
 ```
-
----
 
 ### Create Campaign
 
@@ -165,8 +131,6 @@ Write to `/tmp/mailchimp_request.json`:
 curl -s -X POST "https://${MC_DC}.api.mailchimp.com/3.0/campaigns" --header "Authorization: Bearer $MAILCHIMP_TOKEN" --header "Content-Type: application/json" -d @/tmp/mailchimp_request.json | jq '{id, type, status, settings: {subject_line: .settings.subject_line, title: .settings.title}}'
 ```
 
----
-
 ### Get Campaign Report
 
 Replace `<campaign-id>` with the actual campaign ID:
@@ -177,15 +141,11 @@ curl -s "https://${MC_DC}.api.mailchimp.com/3.0/reports/<campaign-id>" --header 
 
 Docs: https://mailchimp.com/developer/marketing/api/reports/
 
----
-
 ### List Templates
 
 ```bash
 curl -s "https://${MC_DC}.api.mailchimp.com/3.0/templates?count=10" --header "Authorization: Bearer $MAILCHIMP_TOKEN" | jq '.templates[] | {id, name, type, date_created}'
 ```
-
----
 
 ### Search Members
 
@@ -198,8 +158,6 @@ jane@example.com
 ```bash
 curl -s -G "https://${MC_DC}.api.mailchimp.com/3.0/search-members" --header "Authorization: Bearer $MAILCHIMP_TOKEN" --data-urlencode "query@/tmp/mailchimp_query.txt" | jq '.exact_matches.members[] | {id, email_address, full_name, status}'
 ```
-
----
 
 ### Create Audience
 
@@ -230,8 +188,6 @@ Write to `/tmp/mailchimp_request.json`:
 ```bash
 curl -s -X POST "https://${MC_DC}.api.mailchimp.com/3.0/lists" --header "Authorization: Bearer $MAILCHIMP_TOKEN" --header "Content-Type: application/json" -d @/tmp/mailchimp_request.json | jq '{id, name, stats}'
 ```
-
----
 
 ## Guidelines
 

--- a/mailsac/SKILL.md
+++ b/mailsac/SKILL.md
@@ -4,39 +4,15 @@ description: MailSac API for disposable email testing. Use when user mentions "M
   "test email", "disposable email", or email testing.
 ---
 
-# Mailsac
+## Troubleshooting
 
-Use the Mailsac API via direct `curl` calls to **manage disposable email addresses for testing and QA automation**.
-
-> Official docs: `https://docs.mailsac.com/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Receive test emails** in disposable inboxes
-- **Validate email addresses** (check format and disposable status)
-- **Automate email verification flows** in E2E tests
-- **Configure webhooks** for real-time email notifications
-- **Manage private email addresses** for testing
-
----
-
-## Prerequisites
-
-Connect the **Mailsac** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MAILSAC_TOKEN` or `zero doctor check-connector --url https://mailsac.com/api/addresses/test@mailsac.com/messages --method GET`
+If requests fail, run `zero doctor check-connector --env-name MAILSAC_TOKEN` or `zero doctor check-connector --url https://mailsac.com/api/addresses/test@mailsac.com/messages --method GET`
 
 ## How to Use
 
 All examples below assume you have `MAILSAC_TOKEN` set.
 
 Base URL: `https://mailsac.com`
-
----
 
 ## 1. Messages - Read Emails
 
@@ -84,8 +60,6 @@ curl -s "https://mailsac.com/api/headers/test@mailsac.com/<message-id>" --header
 | `/api/raw/{email}/{messageId}` | Complete SMTP message |
 | `/api/headers/{email}/{messageId}` | JSON headers |
 
----
-
 ## 2. Messages - Delete
 
 Delete single messages or purge entire inboxes.
@@ -109,8 +83,6 @@ Note: Starred messages will NOT be purged. Unstar them first if you want to dele
 ```bash
 curl -s -X PUT "https://mailsac.com/api/domains/yourdomain.com/delete-all-domain-mail" --header "Mailsac-Key: $MAILSAC_TOKEN"
 ```
-
----
 
 ## 3. Private Addresses - Reserve and Release
 
@@ -154,8 +126,6 @@ curl -s -X DELETE "https://mailsac.com/api/addresses/mytest@mailsac.com" --heade
 ```bash
 curl -s -X DELETE "https://mailsac.com/api/addresses/mytest@mailsac.com?deleteAddressMessages=true" --header "Mailsac-Key: $MAILSAC_TOKEN"
 ```
-
----
 
 ## 4. Webhook Forwarding
 
@@ -209,8 +179,6 @@ curl -s -X PUT "https://mailsac.com/api/private-address-forwarding/mytest@mailsa
 }
 ```
 
----
-
 ## 5. Email Validation
 
 Validate email addresses and detect disposable email services.
@@ -252,8 +220,6 @@ curl -s "https://mailsac.com/api/validations/addresses/test@mailsac.com" --heade
 | `domain` | Domain part of email |
 | `local` | Local part of email |
 
----
-
 ## 6. Send Email (Outgoing)
 
 Send emails via API (requires outgoing message credits).
@@ -277,8 +243,6 @@ curl -s -X POST "https://mailsac.com/api/outgoing-messages" --header "Mailsac-Ke
 
 Note: Sending requires purchased credits unless sending within your custom domain.
 
----
-
 ## 7. Attachments
 
 Download attachments from received emails.
@@ -297,8 +261,6 @@ curl -s "https://mailsac.com/api/raw/test@mailsac.com/<message-id>" --header "Ma
 
 Note: For public addresses, attachments must be downloaded via API; they are not viewable on the website.
 
----
-
 ## 8. Star/Save Messages
 
 Prevent messages from being auto-deleted by starring them.
@@ -308,8 +270,6 @@ Prevent messages from being auto-deleted by starring them.
 ```bash
 curl -s -X PUT "https://mailsac.com/api/addresses/test@mailsac.com/messages/<message-id>/star" --header "Mailsac-Key: $MAILSAC_TOKEN" | jq .
 ```
-
----
 
 ## Practical Examples
 
@@ -353,8 +313,6 @@ echo "Inbox purged"
 curl -s "https://mailsac.com/api/validations/addresses/user@tempmail.com" --header "Mailsac-Key: $MAILSAC_TOKEN" | jq 'if .isDisposable then "DISPOSABLE" else "LEGITIMATE" end'
 ```
 
----
-
 ## Response Format
 
 ### Message List Response
@@ -387,8 +345,6 @@ curl -s "https://mailsac.com/api/validations/addresses/user@tempmail.com" --head
 }
 ```
 
----
-
 ## Limits and Quotas
 
 | Type | Limit |
@@ -397,8 +353,6 @@ curl -s "https://mailsac.com/api/validations/addresses/user@tempmail.com" --head
 | Public inbox max messages | 6 |
 | Max message size | 2.5 MB |
 | Operations quota reset | 1st of each month (UTC) |
-
----
 
 ## Guidelines
 

--- a/make/SKILL.md
+++ b/make/SKILL.md
@@ -4,37 +4,13 @@ description: Make (Integromat) API for automation. Use when user mentions "Make"
   "Integromat", "automation", or workflow building.
 ---
 
-# Make API
+## Troubleshooting
 
-Use the Make API via direct `curl` calls to **manage scenarios, organizations, teams, connections, data stores, and webhooks** on the Make automation platform.
-
-> Official docs: `https://developers.make.com/api-documentation`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **List, create, run, and manage automation scenarios**
-- **Control scenario execution** (start, stop, run on demand, replay)
-- **Manage organizations and teams** including users and roles
-- **Configure connections and webhooks** for integrations
-- **Work with data stores** for persistent data across scenarios
-
----
-
-## Prerequisites
-
-Connect the **Make** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MAKE_TOKEN` or `zero doctor check-connector --url https://eu1.make.com/api/v2/users/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name MAKE_TOKEN` or `zero doctor check-connector --url https://eu1.make.com/api/v2/users/me --method GET`
 
 ## How to Use
 
 All examples below assume you have `MAKE_TOKEN` set. Authentication uses `Token` scheme in the Authorization header.
-
----
 
 ### 1. Get Current User Info
 
@@ -44,8 +20,6 @@ Retrieve information about the authenticated user.
 curl -s "https://eu1.make.com/api/v2/users/me" --header "Authorization: Token $MAKE_TOKEN" | jq .
 ```
 
----
-
 ### 2. List Organizations
 
 Retrieve all organizations the user belongs to.
@@ -54,8 +28,6 @@ Retrieve all organizations the user belongs to.
 curl -s "https://eu1.make.com/api/v2/organizations" --header "Authorization: Token $MAKE_TOKEN" | jq '.organizations'
 ```
 
----
-
 ### 3. List Teams
 
 Get all teams in an organization. Replace `ORG_ID` with the organization ID.
@@ -63,8 +35,6 @@ Get all teams in an organization. Replace `ORG_ID` with the organization ID.
 ```bash
 curl -s "https://eu1.make.com/api/v2/organizations/ORG_ID/teams" --header "Authorization: Token $MAKE_TOKEN" | jq '.teams'
 ```
-
----
 
 ### 4. List Scenarios
 
@@ -80,8 +50,6 @@ Paginate with `pg[offset]` and `pg[limit]`:
 curl -s "https://eu1.make.com/api/v2/scenarios?teamId=TEAM_ID&pg%5Boffset%5D=0&pg%5Blimit%5D=20" --header "Authorization: Token $MAKE_TOKEN" | jq '.scenarios[] | {id, name}'
 ```
 
----
-
 ### 5. Get Scenario Details
 
 Retrieve details of a specific scenario. Replace `SCENARIO_ID` with the scenario ID.
@@ -89,8 +57,6 @@ Retrieve details of a specific scenario. Replace `SCENARIO_ID` with the scenario
 ```bash
 curl -s "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID" --header "Authorization: Token $MAKE_TOKEN" | jq '.scenario'
 ```
-
----
 
 ### 6. Create a Scenario
 
@@ -112,8 +78,6 @@ Then run:
 curl -s -X POST "https://eu1.make.com/api/v2/scenarios" --header "Content-Type: application/json" --header "Authorization: Token $MAKE_TOKEN" -d @/tmp/make_request.json | jq .
 ```
 
----
-
 ### 7. Update a Scenario
 
 Update scenario properties (name, scheduling, etc.).
@@ -132,8 +96,6 @@ Then run:
 curl -s -X PATCH "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID" --header "Content-Type: application/json" --header "Authorization: Token $MAKE_TOKEN" -d @/tmp/make_request.json | jq .
 ```
 
----
-
 ### 8. Start a Scenario
 
 Activate a scenario so it runs on its schedule.
@@ -142,8 +104,6 @@ Activate a scenario so it runs on its schedule.
 curl -s -X POST "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID/start" --header "Authorization: Token $MAKE_TOKEN" | jq .
 ```
 
----
-
 ### 9. Stop a Scenario
 
 Deactivate a running scenario.
@@ -151,8 +111,6 @@ Deactivate a running scenario.
 ```bash
 curl -s -X POST "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID/stop" --header "Authorization: Token $MAKE_TOKEN" | jq .
 ```
-
----
 
 ### 10. Run a Scenario On Demand
 
@@ -181,8 +139,6 @@ Then run:
 curl -s -X POST "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID/run" --header "Content-Type: application/json" --header "Authorization: Token $MAKE_TOKEN" -d @/tmp/make_request.json | jq .
 ```
 
----
-
 ### 11. Clone a Scenario
 
 Duplicate an existing scenario.
@@ -202,8 +158,6 @@ Then run:
 curl -s -X POST "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID/clone" --header "Content-Type: application/json" --header "Authorization: Token $MAKE_TOKEN" -d @/tmp/make_request.json | jq .
 ```
 
----
-
 ### 12. Delete a Scenario
 
 Remove a scenario permanently.
@@ -211,8 +165,6 @@ Remove a scenario permanently.
 ```bash
 curl -s -X DELETE "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID" --header "Authorization: Token $MAKE_TOKEN" | jq .
 ```
-
----
 
 ### 13. Get Scenario Usage
 
@@ -222,8 +174,6 @@ Retrieve 30-day usage analytics (operations, data transfer, centicredits).
 curl -s "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID/usage" --header "Authorization: Token $MAKE_TOKEN" | jq .
 ```
 
----
-
 ### 14. Get Scenario Logs
 
 Retrieve execution logs for a scenario.
@@ -231,8 +181,6 @@ Retrieve execution logs for a scenario.
 ```bash
 curl -s "https://eu1.make.com/api/v2/scenarios/SCENARIO_ID/logs" --header "Authorization: Token $MAKE_TOKEN" | jq '.scenarioLogs[] | {id, status, duration, operations}'
 ```
-
----
 
 ### 15. List Connections
 
@@ -242,8 +190,6 @@ Retrieve all connections for a team.
 curl -s "https://eu1.make.com/api/v2/connections?teamId=TEAM_ID" --header "Authorization: Token $MAKE_TOKEN" | jq '.connections[] | {id, name, accountName, accountType}'
 ```
 
----
-
 ### 16. List Webhooks (Hooks)
 
 Get all webhooks for a team.
@@ -251,8 +197,6 @@ Get all webhooks for a team.
 ```bash
 curl -s "https://eu1.make.com/api/v2/hooks?teamId=TEAM_ID" --header "Authorization: Token $MAKE_TOKEN" | jq '.hooks[] | {id, name, url, enabled}'
 ```
-
----
 
 ### 17. List Data Stores
 
@@ -262,8 +206,6 @@ Get all data stores for a team.
 curl -s "https://eu1.make.com/api/v2/data-stores?teamId=TEAM_ID" --header "Authorization: Token $MAKE_TOKEN" | jq '.dataStores[] | {id, name, records, size}'
 ```
 
----
-
 ### 18. Get Data Store Records
 
 Retrieve records from a data store.
@@ -271,8 +213,6 @@ Retrieve records from a data store.
 ```bash
 curl -s "https://eu1.make.com/api/v2/data-stores/DATASTORE_ID/data" --header "Authorization: Token $MAKE_TOKEN" | jq '.records'
 ```
-
----
 
 ### 19. Create Data Store Record
 
@@ -296,8 +236,6 @@ Then run:
 curl -s -X POST "https://eu1.make.com/api/v2/data-stores/DATASTORE_ID/data" --header "Content-Type: application/json" --header "Authorization: Token $MAKE_TOKEN" -d @/tmp/make_request.json | jq .
 ```
 
----
-
 ### 20. List Scenario Folders
 
 Get all scenario folders for a team.
@@ -305,8 +243,6 @@ Get all scenario folders for a team.
 ```bash
 curl -s "https://eu1.make.com/api/v2/scenarios-folders?teamId=TEAM_ID" --header "Authorization: Token $MAKE_TOKEN" | jq '.scenariosFolders[] | {id, name}'
 ```
-
----
 
 ## Guidelines
 

--- a/manus/SKILL.md
+++ b/manus/SKILL.md
@@ -5,31 +5,9 @@ vm0_env:
   - MANUS_TOKEN
 ---
 
-# Manus
+## Troubleshooting
 
-Manus is an AI agent platform that can plan, execute multi-step workflows, browse the web, run tools, and deliver structured results. Use this skill to create and monitor tasks, manage projects, upload files, and configure webhooks programmatically.
-
-> Official docs: `https://open.manus.im/docs/api-reference`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Run an AI agent task (research, analysis, content creation, data processing)
-- Monitor the status of a running Manus task
-- Organize tasks into projects with shared instructions
-- Upload files for the agent to work with
-- Register webhooks to receive async task results
-
----
-
-## Prerequisites
-
-Connect the **Manus** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MANUS_TOKEN` or `zero doctor check-connector --url https://api.manus.ai/v2/task.detail?task_id= --method GET`
+If requests fail, run `zero doctor check-connector --env-name MANUS_TOKEN` or `zero doctor check-connector --url https://api.manus.ai/v2/task.detail?task_id= --method GET`
 
 ## Tasks
 
@@ -182,8 +160,6 @@ Response includes `status`, `credit_usage`, and `task_url`. Poll this endpoint t
 
 **Task status values:** `pending`, `running`, `completed`, `failed`, `cancelled`
 
----
-
 ## Projects
 
 ### Create a Project
@@ -210,8 +186,6 @@ Response includes `project.id` — use this as `project_id` when creating tasks.
 ```bash
 curl -s "https://api.manus.ai/v2/project.list" --header "x-manus-api-key: $MANUS_TOKEN"
 ```
-
----
 
 ## Files
 
@@ -250,8 +224,6 @@ Check the file status before attaching it to a task. Only files with `status: up
 ```bash
 curl -s "https://api.manus.ai/v2/file.detail?file_id=<file-id>" --header "x-manus-api-key: $MANUS_TOKEN"
 ```
-
----
 
 ## Webhooks
 
@@ -293,8 +265,6 @@ Then run:
 curl -s -X POST "https://api.manus.ai/v2/webhook.delete" --header "x-manus-api-key: $MANUS_TOKEN" --header "Content-Type: application/json" -d @/tmp/manus_webhook_delete.json
 ```
 
----
-
 ## API Parameters Reference
 
 ### task.create Body
@@ -314,8 +284,6 @@ curl -s -X POST "https://api.manus.ai/v2/webhook.delete" --header "x-manus-api-k
 | `share_visibility` | enum | No | `private`, `team`, or `public` |
 | `hide_in_task_list` | boolean | No | Hide from webapp task list |
 
----
-
 ## Guidelines
 
 1. **Polling**: Tasks are asynchronous. Poll `task.detail` until `status` is `completed` or `failed`. For production use, prefer webhooks.
@@ -324,8 +292,6 @@ curl -s -X POST "https://api.manus.ai/v2/webhook.delete" --header "x-manus-api-k
 4. **Rate limits**: 10 requests per second per API key.
 5. **Credits**: Tasks consume credits based on complexity. Use `manus-1.6-lite` to reduce cost for simple tasks.
 6. **Projects**: Use projects to apply shared instructions to groups of related tasks.
-
----
 
 ## API Reference
 

--- a/marketing-analytics/SKILL.md
+++ b/marketing-analytics/SKILL.md
@@ -3,14 +3,6 @@ name: marketing-analytics
 description: Measure, report on, and optimize marketing performance across channels and campaigns. Trigger on requests for performance dashboards, campaign result analysis, channel metrics review (email, social, paid ads, SEO, content), trend analysis, forecasting, attribution modeling, A/B testing guidance, or actionable optimization recommendations.
 ---
 
-# Marketing Analytics
-
-Frameworks for tracking, interpreting, and acting on marketing data across channels, campaigns, and the full customer funnel.
-
-## Prerequisites
-
-Connect the **Marketing Analytics** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Channel Metric Reference
 
 ### Email

--- a/mercury/SKILL.md
+++ b/mercury/SKILL.md
@@ -4,32 +4,9 @@ description: Mercury API for banking. Use when user mentions "Mercury", "busines
   banking", "bank account", or fintech operations.
 ---
 
-# Mercury Banking API
+## Troubleshooting
 
-Manage business bank accounts, transactions, transfers, and financial operations via Mercury's REST API.
-
-> Official docs: https://docs.mercury.com/reference/getaccount
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- View account balances and details
-- List and search transactions
-- Create internal transfers between accounts
-- Manage recipients for external transfers
-- Download account statements
-- Access treasury account information
-
----
-
-## Prerequisites
-
-Connect the **Mercury** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MERCURY_TOKEN` or `zero doctor check-connector --url https://api.mercury.com/api/v1/accounts --method GET`
+If requests fail, run `zero doctor check-connector --env-name MERCURY_TOKEN` or `zero doctor check-connector --url https://api.mercury.com/api/v1/accounts --method GET`
 
 ## Accounts
 
@@ -54,8 +31,6 @@ Replace `<your-account-id>` with the actual account ID:
 ```bash
 curl -s "https://api.mercury.com/api/v1/account/<your-account-id>/cards" --header "Authorization: Bearer $MERCURY_TOKEN"
 ```
-
----
 
 ## Transactions
 
@@ -82,8 +57,6 @@ Replace `<your-account-id>` and `<your-transaction-id>` with the actual IDs:
 ```bash
 curl -s "https://api.mercury.com/api/v1/account/<your-account-id>/transaction/<your-transaction-id>" --header "Authorization: Bearer $MERCURY_TOKEN"
 ```
-
----
 
 ## Transfers
 
@@ -136,8 +109,6 @@ Replace `<your-request-id>` with the actual request ID:
 curl -s "https://api.mercury.com/api/v1/request-send-money/<your-request-id>" --header "Authorization: Bearer $MERCURY_TOKEN"
 ```
 
----
-
 ## Recipients
 
 ### List All Recipients
@@ -178,8 +149,6 @@ Then run:
 curl -s -X POST "https://api.mercury.com/api/v1/recipients" --header "Authorization: Bearer $MERCURY_TOKEN" --header "Content-Type: application/json" -d @/tmp/mercury_request.json
 ```
 
----
-
 ## Statements
 
 ### List Account Statements
@@ -198,8 +167,6 @@ Replace `<your-account-id>` and `<your-statement-id>` with the actual IDs:
 curl -s "https://api.mercury.com/api/v1/account/<your-account-id>/statement/<your-statement-id>/pdf" --header "Authorization: Bearer $MERCURY_TOKEN" > statement.pdf
 ```
 
----
-
 ## Organization
 
 ### Get Organization Info
@@ -207,8 +174,6 @@ curl -s "https://api.mercury.com/api/v1/account/<your-account-id>/statement/<you
 ```bash
 curl -s "https://api.mercury.com/api/v1/organization" --header "Authorization: Bearer $MERCURY_TOKEN"
 ```
-
----
 
 ## Treasury
 
@@ -234,8 +199,6 @@ Replace `<your-treasury-id>` with the actual treasury ID:
 curl -s "https://api.mercury.com/api/v1/treasury/<your-treasury-id>/transactions" --header "Authorization: Bearer $MERCURY_TOKEN"
 ```
 
----
-
 ## Users
 
 ### List Users
@@ -244,8 +207,6 @@ curl -s "https://api.mercury.com/api/v1/treasury/<your-treasury-id>/transactions
 curl -s "https://api.mercury.com/api/v1/users" --header "Authorization: Bearer $MERCURY_TOKEN"
 ```
 
----
-
 ## Credit
 
 ### List Credit Accounts
@@ -253,8 +214,6 @@ curl -s "https://api.mercury.com/api/v1/users" --header "Authorization: Bearer $
 ```bash
 curl -s "https://api.mercury.com/api/v1/credit" --header "Authorization: Bearer $MERCURY_TOKEN"
 ```
-
----
 
 ## Accounts Receivable
 
@@ -313,8 +272,6 @@ Replace `<your-invoice-id>` with the actual invoice ID:
 curl -s "https://api.mercury.com/api/v1/accounts-receivable/invoice/<your-invoice-id>/pdf" --header "Authorization: Bearer $MERCURY_TOKEN" > invoice.pdf
 ```
 
----
-
 ## Guidelines
 
 1. **Rate Limits**: Mercury may enforce rate limits; implement appropriate backoff strategies for high-volume operations
@@ -322,8 +279,6 @@ curl -s "https://api.mercury.com/api/v1/accounts-receivable/invoice/<your-invoic
 3. **Security**: Never expose API tokens in logs or client-side code
 4. **Amounts**: All monetary amounts are typically in USD and represented as decimal numbers
 5. **Pagination**: For large result sets, use `limit` and `offset` parameters where supported
-
----
 
 ## API Reference
 

--- a/meta-ads/SKILL.md
+++ b/meta-ads/SKILL.md
@@ -4,38 +4,9 @@ description: Meta Ads API for Facebook/Instagram advertising. Use when user ment
   "Meta Ads", "Facebook Ads", "Instagram Ads", or ad campaigns.
 ---
 
-# Meta Marketing API
+## Troubleshooting
 
-Manage Facebook and Instagram advertising campaigns, ad sets, ads, and performance insights via the Meta Marketing API (Graph API).
-
-> Official docs: https://developers.facebook.com/docs/marketing-api/reference/
-
----
-
-## Prerequisites
-
-Connect the **Meta Ads** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name META_ADS_TOKEN` or `zero doctor check-connector --url https://graph.facebook.com/v22.0/me/adaccounts --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- List and manage ad accounts
-- Create, update, or pause ad campaigns
-- Create and manage ad sets (targeting, budgets, scheduling)
-- Create and manage ads (creatives)
-- Retrieve performance insights and analytics
-- Manage custom audiences
-
----
-
----
-
-> **Placeholders:** Values in `{curly-braces}` like `{ad-account-id}` are placeholders. Replace them with actual values when executing. Ad account IDs must be prefixed with `act_` (e.g., `act_123456789`).
-
----
+If requests fail, run `zero doctor check-connector --env-name META_ADS_TOKEN` or `zero doctor check-connector --url https://graph.facebook.com/v22.0/me/adaccounts --method GET`
 
 ## Ad Accounts
 
@@ -50,8 +21,6 @@ curl -s "https://graph.facebook.com/v22.0/me/adaccounts?fields=id,name,account_s
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}?fields=id,name,account_status,currency,timezone_name,balance,amount_spent,spend_cap&access_token=$META_ADS_TOKEN"
 ```
-
----
 
 ## Campaigns
 
@@ -101,8 +70,6 @@ curl -s -X POST "https://graph.facebook.com/v22.0/{campaign-id}?access_token=$ME
 curl -s -X DELETE "https://graph.facebook.com/v22.0/{campaign-id}?access_token=$META_ADS_TOKEN"
 ```
 
----
-
 ## Ad Sets
 
 ### List Ad Sets
@@ -142,8 +109,6 @@ EOF
 curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/adsets?access_token=$META_ADS_TOKEN" --header "Content-Type: application/json" -d @/tmp/adset.json
 ```
 
----
-
 ## Ads
 
 ### List Ads
@@ -157,8 +122,6 @@ curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/ads?fields=id,name,sta
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-id}?fields=id,name,status,adset_id,campaign_id,creative,created_time,updated_time&access_token=$META_ADS_TOKEN"
 ```
-
----
 
 ## Insights (Performance Analytics)
 
@@ -194,8 +157,6 @@ curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impres
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend&date_preset=last_30d&breakdowns=age,gender&access_token=$META_ADS_TOKEN" | jq '.data[] | {age, gender, impressions, clicks, spend}'
 ```
 
----
-
 ## Custom Audiences
 
 ### List Custom Audiences
@@ -203,8 +164,6 @@ curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impres
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/customaudiences?fields=id,name,approximate_count_lower_bound,approximate_count_upper_bound&access_token=$META_ADS_TOKEN" | jq '.data[] | {id, name, approximate_count_lower_bound}'
 ```
-
----
 
 ## Guidelines
 

--- a/metabase/SKILL.md
+++ b/metabase/SKILL.md
@@ -4,38 +4,13 @@ description: Metabase API for business intelligence. Use when user mentions "Met
   "dashboard", "BI", "SQL query", or data visualization.
 ---
 
-# Metabase API
+## Troubleshooting
 
-Use the Metabase API via direct `curl` calls to **query data, manage dashboards, cards (questions), collections, databases, and users** on your Metabase instance.
-
-> Official docs: `https://www.metabase.com/docs/latest/api` (live OpenAPI docs available at your instance's `/api/docs`)
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Run queries** and retrieve data from connected databases
-- **Manage dashboards** and their cards (questions)
-- **Create and update cards** (saved questions)
-- **Organize content** into collections
-- **Manage databases** and their connections
-- **Administer users** and permission groups
-
----
-
-## Prerequisites
-
-Connect the **Metabase** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name METABASE_TOKEN` or `zero doctor check-connector --url https://your-metabase.example.com/api/user/current --method GET`
+If requests fail, run `zero doctor check-connector --env-name METABASE_TOKEN` or `zero doctor check-connector --url https://your-metabase.example.com/api/user/current --method GET`
 
 ## How to Use
 
 All examples below assume you have `METABASE_TOKEN` set. Authentication uses the `x-api-key` header.
-
----
 
 ### 1. Get Current User Info
 
@@ -45,8 +20,6 @@ Retrieve information about the authenticated user.
 curl -s "$METABASE_BASE_URL/api/user/current" --header "x-api-key: $METABASE_TOKEN" | jq .
 ```
 
----
-
 ### 2. List Databases
 
 Retrieve all connected databases.
@@ -55,8 +28,6 @@ Retrieve all connected databases.
 curl -s "$METABASE_BASE_URL/api/database" --header "x-api-key: $METABASE_TOKEN" | jq '.data[] | {id, name, engine}'
 ```
 
----
-
 ### 3. Get Database Details
 
 Retrieve details of a specific database including its tables.
@@ -64,8 +35,6 @@ Retrieve details of a specific database including its tables.
 ```bash
 curl -s "$METABASE_BASE_URL/api/database/DATABASE_ID?include=tables" --header "x-api-key: $METABASE_TOKEN" | jq .
 ```
-
----
 
 ### 4. Run a Query (Dataset)
 
@@ -89,8 +58,6 @@ Then run:
 curl -s -X POST "$METABASE_BASE_URL/api/dataset" --header "Content-Type: application/json" --header "x-api-key: $METABASE_TOKEN" -d @/tmp/metabase_request.json | jq '{columns: [.data.cols[].name], row_count: .row_count}'
 ```
 
----
-
 ### 5. List Cards (Saved Questions)
 
 Retrieve all saved questions.
@@ -98,8 +65,6 @@ Retrieve all saved questions.
 ```bash
 curl -s "$METABASE_BASE_URL/api/card" --header "x-api-key: $METABASE_TOKEN" | jq '.[] | {id, name, display, database_id}'
 ```
-
----
 
 ### 6. Get Card Details
 
@@ -109,8 +74,6 @@ Retrieve a specific card (question) by ID.
 curl -s "$METABASE_BASE_URL/api/card/CARD_ID" --header "x-api-key: $METABASE_TOKEN" | jq '{id, name, display, dataset_query}'
 ```
 
----
-
 ### 7. Run a Card Query
 
 Execute a saved question and return its results.
@@ -118,8 +81,6 @@ Execute a saved question and return its results.
 ```bash
 curl -s -X POST "$METABASE_BASE_URL/api/card/CARD_ID/query" --header "x-api-key: $METABASE_TOKEN" | jq '{columns: [.data.cols[].name], row_count: .row_count}'
 ```
-
----
 
 ### 8. Create a Card (Question)
 
@@ -149,8 +110,6 @@ Then run:
 curl -s -X POST "$METABASE_BASE_URL/api/card" --header "Content-Type: application/json" --header "x-api-key: $METABASE_TOKEN" -d @/tmp/metabase_request.json | jq '{id, name}'
 ```
 
----
-
 ### 9. Update a Card
 
 Update a saved question's properties.
@@ -170,8 +129,6 @@ Then run:
 curl -s -X PUT "$METABASE_BASE_URL/api/card/CARD_ID" --header "Content-Type: application/json" --header "x-api-key: $METABASE_TOKEN" -d @/tmp/metabase_request.json | jq .
 ```
 
----
-
 ### 10. List Dashboards
 
 Retrieve all dashboards.
@@ -179,8 +136,6 @@ Retrieve all dashboards.
 ```bash
 curl -s "$METABASE_BASE_URL/api/dashboard" --header "x-api-key: $METABASE_TOKEN" | jq '.[] | {id, name, collection_id}'
 ```
-
----
 
 ### 11. Get Dashboard Details
 
@@ -190,8 +145,6 @@ Retrieve a dashboard with all its cards.
 curl -s "$METABASE_BASE_URL/api/dashboard/DASHBOARD_ID" --header "x-api-key: $METABASE_TOKEN" | jq '{id, name, dashcards: [.dashcards[] | {id, card_id, card: .card.name}]}'
 ```
 
----
-
 ### 12. Create a Dashboard
 
 Create a new dashboard.
@@ -199,8 +152,6 @@ Create a new dashboard.
 ```bash
 curl -s -X POST "$METABASE_BASE_URL/api/dashboard" --header "Content-Type: application/json" --header "x-api-key: $METABASE_TOKEN" -d '{"name":"My Dashboard","collection_id":null}' | jq '{id, name}'
 ```
-
----
 
 ### 13. Add a Card to Dashboard
 
@@ -224,8 +175,6 @@ Then run:
 curl -s -X POST "$METABASE_BASE_URL/api/dashboard/DASHBOARD_ID/cards" --header "Content-Type: application/json" --header "x-api-key: $METABASE_TOKEN" -d @/tmp/metabase_request.json | jq .
 ```
 
----
-
 ### 14. List Collections
 
 Retrieve all collections (folders for organizing content).
@@ -233,8 +182,6 @@ Retrieve all collections (folders for organizing content).
 ```bash
 curl -s "$METABASE_BASE_URL/api/collection" --header "x-api-key: $METABASE_TOKEN" | jq '.[] | {id, name, location}'
 ```
-
----
 
 ### 15. Get Collection Items
 
@@ -244,8 +191,6 @@ Retrieve all items in a specific collection.
 curl -s "$METABASE_BASE_URL/api/collection/COLLECTION_ID/items" --header "x-api-key: $METABASE_TOKEN" | jq '.data[] | {id, name, model}'
 ```
 
----
-
 ### 16. Create a Collection
 
 Create a new collection for organizing dashboards and questions.
@@ -253,8 +198,6 @@ Create a new collection for organizing dashboards and questions.
 ```bash
 curl -s -X POST "$METABASE_BASE_URL/api/collection" --header "Content-Type: application/json" --header "x-api-key: $METABASE_TOKEN" -d '{"name":"My Collection","parent_id":null}' | jq '{id, name}'
 ```
-
----
 
 ### 17. Search
 
@@ -270,8 +213,6 @@ Filter by model type:
 curl -s "$METABASE_BASE_URL/api/search?q=revenue&models=card" --header "x-api-key: $METABASE_TOKEN" | jq '.data[] | {id, name}'
 ```
 
----
-
 ### 18. List Users
 
 Retrieve all users in the Metabase instance.
@@ -279,8 +220,6 @@ Retrieve all users in the Metabase instance.
 ```bash
 curl -s "$METABASE_BASE_URL/api/user" --header "x-api-key: $METABASE_TOKEN" | jq '.data[] | {id, email, first_name, last_name, is_active}'
 ```
-
----
 
 ### 19. Get Permission Groups
 
@@ -290,8 +229,6 @@ List all permission groups.
 curl -s "$METABASE_BASE_URL/api/permissions/group" --header "x-api-key: $METABASE_TOKEN" | jq '.[] | {id, name, member_count}'
 ```
 
----
-
 ### 20. Get Table Metadata
 
 Retrieve metadata for a specific table including columns and types.
@@ -299,8 +236,6 @@ Retrieve metadata for a specific table including columns and types.
 ```bash
 curl -s "$METABASE_BASE_URL/api/table/TABLE_ID/query_metadata" --header "x-api-key: $METABASE_TOKEN" | jq '{name, fields: [.fields[] | {name, base_type, semantic_type}]}'
 ```
-
----
 
 ## Guidelines
 

--- a/minimax/SKILL.md
+++ b/minimax/SKILL.md
@@ -4,38 +4,15 @@ description: MiniMax API for AI models. Use when user mentions "MiniMax", "Chine
   AI", or asks about MiniMax language models.
 ---
 
-# MiniMax API
+## Troubleshooting
 
-Use the MiniMax API via direct `curl` calls for **AI chat completion**, **text-to-speech**, and **video generation**.
-
-> Official docs: `https://platform.minimax.io/docs`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Chat completion** with Chinese-optimized LLM (MiniMax-M1/M2)
-- **Text-to-speech** with natural voices and emotion control
-- **Video generation** from text prompts (T2V)
-- **Image-to-video** conversion (I2V)
-
----
-
-## Prerequisites
-
-Connect the **MiniMax** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MINIMAX_TOKEN` or `zero doctor check-connector --url https://api.minimax.io/v1/text/chatcompletion_v2 --method POST`
+If requests fail, run `zero doctor check-connector --env-name MINIMAX_TOKEN` or `zero doctor check-connector --url https://api.minimax.io/v1/text/chatcompletion_v2 --method POST`
 
 ## How to Use
 
 All examples below assume you have `MINIMAX_TOKEN` set.
 
 Authentication uses Bearer token in the `Authorization` header.
-
----
 
 ### 1. Basic Chat Completion
 
@@ -64,8 +41,6 @@ curl -s "https://api.minimax.io/v1/text/chatcompletion_v2" -X POST -H "Authoriza
 - `MiniMax-M2`: Reasoning model (best quality)
 - `MiniMax-M1`: Reasoning model (balanced)
 - `MiniMax-Text-01`: Standard model (fastest)
-
----
 
 ### 2. Chat with Temperature Control
 
@@ -96,8 +71,6 @@ curl -s "https://api.minimax.io/v1/text/chatcompletion_v2" -X POST -H "Authoriza
 - `top_p` (0-1, default 0.95): Sampling diversity
 - `max_tokens`: Maximum output tokens
 
----
-
 ### 3. Streaming Response
 
 Get real-time output:
@@ -121,8 +94,6 @@ curl -s "https://api.minimax.io/v1/text/chatcompletion_v2" -X POST -H "Authoriza
 ```
 
 Streaming is recommended for reasoning models (M1/M2).
-
----
 
 ### 4. Reasoning Model (M1/M2)
 
@@ -148,8 +119,6 @@ curl -s "https://api.minimax.io/v1/text/chatcompletion_v2" -X POST -H "Authoriza
 
 Response includes `reasoning_content` field with thought process.
 
----
-
 ### 5. Text-to-Speech (Basic)
 
 Convert text to speech:
@@ -171,8 +140,6 @@ Then run:
 ```bash
 curl -s "https://api.minimax.io/v1/t2a_v2" -X POST -H "Authorization: Bearer $MINIMAX_TOKEN" -H "Content-Type: application/json" -d @/tmp/minimax_request.json --output speech.mp3
 ```
-
----
 
 ### 6. TTS with Emotion
 
@@ -198,8 +165,6 @@ curl -s "https://api.minimax.io/v1/t2a_v2" -X POST -H "Authorization: Bearer $MI
 ```
 
 **Emotion options:** `happy`, `sad`, `angry`, `fearful`, `disgusted`, `surprised`, `neutral`
-
----
 
 ### 7. TTS with Audio Settings
 
@@ -234,8 +199,6 @@ curl -s "https://api.minimax.io/v1/t2a_v2" -X POST -H "Authorization: Bearer $MI
 - `speech-01-hd`: Previous gen HD
 - `speech-01-turbo`: Previous gen fast
 
----
-
 ### 8. Text-to-Video (T2V)
 
 Generate video from text prompt:
@@ -258,8 +221,6 @@ curl -s "https://api.minimax.io/v1/video_generation" -X POST -H "Authorization: 
 ```
 
 Video generation is async - returns a task ID to poll for completion.
-
----
 
 ### 9. T2V with Camera Control
 
@@ -291,8 +252,6 @@ curl -s "https://api.minimax.io/v1/video_generation" -X POST -H "Authorization: 
 
 Combine with `[Pan left, Pedestal up]` (max 3 simultaneous).
 
----
-
 ### 10. Image-to-Video (I2V)
 
 Generate video from an image:
@@ -318,8 +277,6 @@ curl -s "https://api.minimax.io/v1/video_generation" -X POST -H "Authorization: 
 ```
 
 Provide `first_frame_image` as URL or base64-encoded image.
-
----
 
 ### 11. Function Calling (Tools)
 
@@ -359,8 +316,6 @@ Then run:
 curl -s "https://api.minimax.io/v1/text/chatcompletion_v2" -X POST -H "Authorization: Bearer $MINIMAX_TOKEN" -H "Content-Type: application/json" -d @/tmp/minimax_request.json | jq '.choices[0]'
 ```
 
----
-
 ## Response Format
 
 ### Chat Completion
@@ -383,8 +338,6 @@ curl -s "https://api.minimax.io/v1/text/chatcompletion_v2" -X POST -H "Authoriza
   }
 }
 ```
-
----
 
 ## Guidelines
 

--- a/minio/SKILL.md
+++ b/minio/SKILL.md
@@ -4,30 +4,6 @@ description: MinIO API for S3-compatible storage. Use when user mentions "MinIO"
   "S3 storage", "object storage", or self-hosted S3.
 ---
 
-# MinIO Object Storage
-
-Use the MinIO API via `mc` (MinIO Client) or `curl` to manage **S3-compatible object storage** for file uploads, downloads, and bucket operations.
-
-> Official docs: `https://min.io/docs/minio/linux/reference/minio-mc.html`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Upload/download files** to S3-compatible storage
-- **Manage buckets** (create, list, delete)
-- **Generate pre-signed URLs** for temporary file access
-- **List and search objects** in storage
-- **Mirror/sync directories** between local and remote
-
----
-
-## Prerequisites
-
-Connect the **MinIO Object Storage** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 ### 1. List Buckets
@@ -139,8 +115,6 @@ mc find myminio/my-bucket --larger 10MB
 mc find myminio/my-bucket --newer-than 7d
 ```
 
----
-
 ## Using curl with Pre-signed URLs
 
 For environments without `mc`, use pre-signed URLs with curl:
@@ -164,8 +138,6 @@ DOWNLOAD_URL=$(mc share download --json myminio/my-bucket/file.txt | jq -r '.sha
 # Download with curl
 curl -o /local/path/file.txt "$DOWNLOAD_URL"
 ```
-
----
 
 ## Using curl with AWS Signature V2
 
@@ -197,8 +169,6 @@ chmod +x minio-upload.sh
 ./minio-upload.sh my-bucket myfile.txt
 ```
 
----
-
 ## Using AWS CLI
 
 MinIO is fully compatible with AWS CLI:
@@ -221,8 +191,6 @@ aws --endpoint-url "https://${MINIO_ENDPOINT}" s3 cp s3://my-bucket/file.txt ./
 # List objects
 aws --endpoint-url "https://${MINIO_ENDPOINT}" s3 ls s3://my-bucket/
 ```
-
----
 
 ## Bucket Policies
 
@@ -258,8 +226,6 @@ EOF
 
 mc anonymous set-json /tmp/policy.json myminio/my-bucket
 ```
-
----
 
 ## Guidelines
 

--- a/monday/SKILL.md
+++ b/monday/SKILL.md
@@ -4,37 +4,13 @@ description: Monday.com API for work management. Use when user mentions "Monday.
   "monday.com", shares a Monday link, "Monday board", or asks about Monday workspace.
 ---
 
-# Monday.com API
+## Troubleshooting
 
-Use the Monday.com GraphQL API via direct `curl` calls to **manage boards, items, and project data**.
-
-> Official docs: `https://developer.monday.com/api-reference/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Query boards and items** from Monday.com
-- **Create, update, or delete items** in boards
-- **Manage board columns and groups**
-- **Sync data** between Monday.com and other systems
-- **Automate project workflows**
-
----
-
-## Prerequisites
-
-Connect the **Monday.com** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MONDAY_TOKEN` or `zero doctor check-connector --url https://api.monday.com/v2 --method POST`
+If requests fail, run `zero doctor check-connector --env-name MONDAY_TOKEN` or `zero doctor check-connector --url https://api.monday.com/v2 --method POST`
 
 ## How to Use
 
 All examples below assume you have `MONDAY_TOKEN` set.
-
----
 
 ### 1. Get Current User
 
@@ -54,8 +30,6 @@ Then run:
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
 
----
-
 ### 2. List All Boards
 
 Get all boards in your account:
@@ -73,8 +47,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
-
----
 
 ### 3. Get Board Details
 
@@ -96,8 +68,6 @@ Then run:
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
 
----
-
 ### 4. Get Items from a Board
 
 Get items (rows) from a specific board:
@@ -117,8 +87,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
-
----
 
 ### 5. Create a New Item
 
@@ -142,8 +110,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
-
----
 
 ### 6. Create Item with Column Values
 
@@ -174,8 +140,6 @@ Then run:
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
 
----
-
 ### 7. Update an Item
 
 Update an existing item's column values:
@@ -203,8 +167,6 @@ Then run:
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
 
----
-
 ### 8. Delete an Item
 
 Delete an item from a board:
@@ -225,8 +187,6 @@ Then run:
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
 
----
-
 ### 9. Create a New Board
 
 Create a new board:
@@ -244,8 +204,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
-
----
 
 ### 10. Search Items
 
@@ -267,8 +225,6 @@ Then run:
 curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOKEN" --header "API-Version: 2024-10" --header "Content-Type: application/json" -d @/tmp/monday_request.json
 ```
 
----
-
 ## Common Column Types
 
 | Column Type | Value Format |
@@ -280,8 +236,6 @@ curl -s -X POST "https://api.monday.com/v2" --header "Authorization: $MONDAY_TOK
 | Person | `{"id": 12345678}` |
 | Dropdown | `{"labels": ["Option1", "Option2"]}` |
 | Checkbox | `{"checked": true}` |
-
----
 
 ## Guidelines
 

--- a/nda-screening/SKILL.md
+++ b/nda-screening/SKILL.md
@@ -3,14 +3,6 @@ name: nda-screening
 description: Rapidly evaluate incoming NDAs, classify them as GREEN (sign-ready), YELLOW (minor issues needing review), or RED (material problems requiring negotiation), and route them appropriately. Use when sales or business development sends a new NDA, when triaging confidentiality agreements, when deciding if an NDA can be approved without counsel, or when assessing non-disclosure agreement risk.
 ---
 
-# NDA Screening Skill
-
-You serve as the first-line screener for non-disclosure agreements arriving at an in-house legal team. Your purpose is to rapidly evaluate each NDA against established acceptance criteria, assign a risk classification, and recommend whether the agreement can proceed to signature, needs targeted edits, or requires full legal engagement.
-
-## Prerequisites
-
-Connect the **NDA Screening** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Evaluation Framework
 
 Work through the following ten areas systematically for every NDA that comes in.

--- a/neon/SKILL.md
+++ b/neon/SKILL.md
@@ -4,25 +4,9 @@ description: Neon API for serverless Postgres. Use when user mentions "Neon", "N
   database", "serverless Postgres", or asks about Neon projects.
 ---
 
-# Neon API
+## Troubleshooting
 
-Manage serverless Postgres projects, branches, databases, roles, and compute endpoints with the Neon API v2.
-
-> Official docs: `https://api-docs.neon.tech/reference/getting-started`
-
-## Prerequisites
-
-Connect the **Neon** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name NEON_TOKEN` or `zero doctor check-connector --url https://console.neon.tech/api/v2/projects --method GET`
-
-## When to Use
-
-- Create and manage Neon projects
-- Create and manage branches (for dev/preview environments)
-- Manage databases and roles within projects
-- Start/stop and configure compute endpoints
-- Get connection URIs for databases
+If requests fail, run `zero doctor check-connector --env-name NEON_TOKEN` or `zero doctor check-connector --url https://console.neon.tech/api/v2/projects --method GET`
 
 ## Core APIs
 
@@ -34,8 +18,6 @@ curl -s "https://console.neon.tech/api/v2/projects" --header "Authorization: Bea
 
 Docs: https://api-docs.neon.tech/reference/listprojects
 
----
-
 ### Get Project Details
 
 Replace `<project-id>` with the actual project ID:
@@ -43,8 +25,6 @@ Replace `<project-id>` with the actual project ID:
 ```bash
 curl -s "https://console.neon.tech/api/v2/projects/<project-id>" --header "Authorization: Bearer $NEON_TOKEN" | jq '.project | {id, name, region_id, pg_version, created_at, store_passwords}'
 ```
-
----
 
 ### Create Project
 
@@ -68,8 +48,6 @@ Docs: https://api-docs.neon.tech/reference/createproject
 
 Available regions: `aws-us-east-2`, `aws-us-west-2`, `aws-eu-central-1`, `aws-ap-southeast-1`
 
----
-
 ### Delete Project
 
 Replace `<project-id>` with the actual project ID:
@@ -77,8 +55,6 @@ Replace `<project-id>` with the actual project ID:
 ```bash
 curl -s -X DELETE "https://console.neon.tech/api/v2/projects/<project-id>" --header "Authorization: Bearer $NEON_TOKEN" | jq '.project | {id, name}'
 ```
-
----
 
 ### List Branches
 
@@ -89,8 +65,6 @@ curl -s "https://console.neon.tech/api/v2/projects/<project-id>/branches" --head
 ```
 
 Docs: https://api-docs.neon.tech/reference/listprojectbranches
-
----
 
 ### Create Branch
 
@@ -115,8 +89,6 @@ Write to `/tmp/neon_request.json`:
 curl -s -X POST "https://console.neon.tech/api/v2/projects/<project-id>/branches" --header "Authorization: Bearer $NEON_TOKEN" --header "Content-Type: application/json" -d @/tmp/neon_request.json | jq '{branch: {id: .branch.id, name: .branch.name}, endpoints: [.endpoints[] | {host: .host, id: .id}]}'
 ```
 
----
-
 ### Delete Branch
 
 Replace `<project-id>` and `<branch-id>`:
@@ -125,8 +97,6 @@ Replace `<project-id>` and `<branch-id>`:
 curl -s -X DELETE "https://console.neon.tech/api/v2/projects/<project-id>/branches/<branch-id>" --header "Authorization: Bearer $NEON_TOKEN" | jq '.branch | {id, name}'
 ```
 
----
-
 ### List Databases
 
 Replace `<project-id>` and `<branch-id>`:
@@ -134,8 +104,6 @@ Replace `<project-id>` and `<branch-id>`:
 ```bash
 curl -s "https://console.neon.tech/api/v2/projects/<project-id>/branches/<branch-id>/databases" --header "Authorization: Bearer $NEON_TOKEN" | jq '.databases[] | {id, name, owner_name}'
 ```
-
----
 
 ### Create Database
 
@@ -156,8 +124,6 @@ Write to `/tmp/neon_request.json`:
 curl -s -X POST "https://console.neon.tech/api/v2/projects/<project-id>/branches/<branch-id>/databases" --header "Authorization: Bearer $NEON_TOKEN" --header "Content-Type: application/json" -d @/tmp/neon_request.json | jq '.database | {id, name, owner_name}'
 ```
 
----
-
 ### List Roles
 
 Replace `<project-id>` and `<branch-id>`:
@@ -166,8 +132,6 @@ Replace `<project-id>` and `<branch-id>`:
 curl -s "https://console.neon.tech/api/v2/projects/<project-id>/branches/<branch-id>/roles" --header "Authorization: Bearer $NEON_TOKEN" | jq '.roles[] | {name, protected}'
 ```
 
----
-
 ### List Endpoints (Compute)
 
 Replace `<project-id>`:
@@ -175,8 +139,6 @@ Replace `<project-id>`:
 ```bash
 curl -s "https://console.neon.tech/api/v2/projects/<project-id>/endpoints" --header "Authorization: Bearer $NEON_TOKEN" | jq '.endpoints[] | {id, host, branch_id, type, current_state, autoscaling_limit_min_cu, autoscaling_limit_max_cu}'
 ```
-
----
 
 ### Get Connection URI
 
@@ -188,8 +150,6 @@ curl -s "https://console.neon.tech/api/v2/projects/<project-id>/connection_uri?d
 
 Docs: https://api-docs.neon.tech/reference/getconnectionuri
 
----
-
 ### Start Endpoint
 
 Replace `<project-id>` and `<endpoint-id>`:
@@ -198,8 +158,6 @@ Replace `<project-id>` and `<endpoint-id>`:
 curl -s -X POST "https://console.neon.tech/api/v2/projects/<project-id>/endpoints/<endpoint-id>/start" --header "Authorization: Bearer $NEON_TOKEN" | jq '.endpoint | {id, host, current_state}'
 ```
 
----
-
 ### Suspend Endpoint
 
 Replace `<project-id>` and `<endpoint-id>`:
@@ -207,8 +165,6 @@ Replace `<project-id>` and `<endpoint-id>`:
 ```bash
 curl -s -X POST "https://console.neon.tech/api/v2/projects/<project-id>/endpoints/<endpoint-id>/suspend" --header "Authorization: Bearer $NEON_TOKEN" | jq '.endpoint | {id, host, current_state}'
 ```
-
----
 
 ## Guidelines
 

--- a/notion/SKILL.md
+++ b/notion/SKILL.md
@@ -5,23 +5,9 @@ description: Notion API for pages and databases. Use when user mentions "Notion"
   or asks about Notion workspace.
 ---
 
-# Notion API
+## Troubleshooting
 
-Manage pages, databases, and content blocks in Notion workspaces.
-
-## When to Use
-
-- Create and update Notion pages
-- Query and filter database entries
-- Search across workspace content
-- Append content blocks to pages
-- Manage database schemas and properties
-
-## Prerequisites
-
-Connect the **Notion** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name NOTION_TOKEN` or `zero doctor check-connector --url https://api.notion.com/v1/pages --method GET`
+If requests fail, run `zero doctor check-connector --env-name NOTION_TOKEN` or `zero doctor check-connector --url https://api.notion.com/v1/pages --method GET`
 
 ## Core APIs
 

--- a/openai/SKILL.md
+++ b/openai/SKILL.md
@@ -4,40 +4,15 @@ description: OpenAI API for GPT models. Use when user mentions "OpenAI", "GPT", 
   API", or asks about OpenAI models (do NOT use for Anthropic/Claude).
 ---
 
-# OpenAI API
+## Troubleshooting
 
-Use the OpenAI API via direct `curl` calls to access **GPT models, DALL-E image generation, Whisper transcription, embeddings, and text-to-speech**.
-
-> Official docs: `https://platform.openai.com/docs/api-reference`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Chat completions** with GPT-4o, GPT-4, or GPT-3.5 models
-- **Image generation** with DALL-E 3
-- **Audio transcription** with Whisper
-- **Text-to-speech** audio generation
-- **Text embeddings** for semantic search and RAG
-- **Vision tasks** (analyze images with GPT-4o)
-
----
-
-## Prerequisites
-
-Connect the **OpenAI** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name OPENAI_TOKEN` or `zero doctor check-connector --url https://api.openai.com/v1/chat/completions --method POST`
+If requests fail, run `zero doctor check-connector --env-name OPENAI_TOKEN` or `zero doctor check-connector --url https://api.openai.com/v1/chat/completions --method POST`
 
 ## How to Use
 
 All examples below assume you have `OPENAI_TOKEN` set.
 
 Base URL: `https://api.openai.com/v1`
-
----
 
 ### 1. Basic Chat Completion
 
@@ -67,8 +42,6 @@ curl -s "https://api.openai.com/v1/chat/completions" -H "Content-Type: applicati
 - `o1`: Reasoning model for complex tasks
 - `o1-mini`: Smaller reasoning model
 
----
-
 ### 2. Chat with System Prompt
 
 Use a system message to set behavior:
@@ -90,8 +63,6 @@ Then run:
 ```bash
 curl -s "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_TOKEN" -d @/tmp/openai_request.json | jq '.choices[0].message.content'
 ```
-
----
 
 ### 3. Streaming Response
 
@@ -115,8 +86,6 @@ curl -s "https://api.openai.com/v1/chat/completions" -H "Content-Type: applicati
 
 Streaming returns Server-Sent Events (SSE) with delta chunks.
 
----
-
 ### 4. JSON Mode
 
 Force the model to return valid JSON:
@@ -139,8 +108,6 @@ Then run:
 ```bash
 curl -s "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_TOKEN" -d @/tmp/openai_request.json | jq '.choices[0].message.content'
 ```
-
----
 
 ### 5. Vision (Image Analysis)
 
@@ -169,8 +136,6 @@ Then run:
 ```bash
 curl -s "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_TOKEN" -d @/tmp/openai_request.json | jq '.choices[0].message.content'
 ```
-
----
 
 ### 6. Function Calling (Tools)
 
@@ -207,8 +172,6 @@ Then run:
 curl -s "https://api.openai.com/v1/chat/completions" -H "Content-Type: application/json" -H "Authorization: Bearer $OPENAI_TOKEN" -d @/tmp/openai_request.json | jq '.choices[0].message.tool_calls'
 ```
 
----
-
 ### 7. Generate Embeddings
 
 Create vector embeddings for text:
@@ -234,8 +197,6 @@ This extracts the first 5 dimensions of the embedding vector.
 
 - `text-embedding-3-small`: 1536 dimensions, fastest
 - `text-embedding-3-large`: 3072 dimensions, most capable
-
----
 
 ### 8. Generate Image (DALL-E 3)
 
@@ -264,8 +225,6 @@ curl -s "https://api.openai.com/v1/images/generations" -H "Content-Type: applica
 - `quality`: `standard` or `hd`
 - `style`: `vivid` or `natural`
 
----
-
 ### 9. Audio Transcription (Whisper)
 
 Transcribe audio to text:
@@ -275,8 +234,6 @@ curl -s "https://api.openai.com/v1/audio/transcriptions" -H "Authorization: Bear
 ```
 
 Supports: mp3, mp4, mpeg, mpga, m4a, wav, webm (max 25MB).
-
----
 
 ### 10. Text-to-Speech
 
@@ -302,8 +259,6 @@ curl -s "https://api.openai.com/v1/audio/speech" -H "Content-Type: application/j
 
 **Models:** `tts-1` (fast), `tts-1-hd` (high quality)
 
----
-
 ### 11. List Available Models
 
 Get all available models:
@@ -311,8 +266,6 @@ Get all available models:
 ```bash
 curl -s "https://api.openai.com/v1/models" -H "Authorization: Bearer $OPENAI_TOKEN" | jq -r '.data[].id' | sort | head -20
 ```
-
----
 
 ### 12. Check Token Usage
 
@@ -340,8 +293,6 @@ Response includes:
 - `prompt_tokens`: Input token count
 - `completion_tokens`: Output token count
 - `total_tokens`: Sum of both
-
----
 
 ## Guidelines
 

--- a/pdf4me/SKILL.md
+++ b/pdf4me/SKILL.md
@@ -4,36 +4,9 @@ description: PDF4me API for PDF operations. Use when user mentions "PDF4me", "co
   PDF", "PDF tools", or document conversion.
 ---
 
-# PDF4ME
+## Troubleshooting
 
-Comprehensive PDF processing API with 60+ operations: convert, merge, split, compress, OCR, watermark, form filling, digital signatures, and more.
-
-> Official docs: https://dev.pdf4me.com/apiv2/documentation/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Convert documents to/from PDF (Word, Excel, PowerPoint, HTML, images)
-- Merge multiple PDFs into one
-- Split PDF into multiple files
-- Compress PDF to reduce file size
-- Add watermarks, stamps, page numbers
-- Extract text, tables, or images from PDF
-- Fill PDF forms programmatically
-- OCR scanned documents
-- Protect/unlock PDF with password
-- Create barcodes and QR codes
-
----
-
-## Prerequisites
-
-Connect the **PDF4ME** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PDF4ME_TOKEN` or `zero doctor check-connector --url https://api.pdf4me.com/api/v2/ConvertToPdf --method POST`
+If requests fail, run `zero doctor check-connector --env-name PDF4ME_TOKEN` or `zero doctor check-connector --url https://api.pdf4me.com/api/v2/ConvertToPdf --method POST`
 
 ## How to Use
 
@@ -323,8 +296,6 @@ Then run:
 curl -s -X POST "https://api.pdf4me.com/api/v2/ExtractPages" --header "Authorization: $PDF4ME_TOKEN" --header "Content-Type: application/json" -d @/tmp/pdf4me_request.json | jq -r '.docContent' | base64 -d > extracted.pdf
 ```
 
----
-
 ## API Endpoints
 
 | Category | Endpoint | Description |
@@ -357,8 +328,6 @@ curl -s -X POST "https://api.pdf4me.com/api/v2/ExtractPages" --header "Authoriza
 | | `/api/v2/AddBarcodeToPdf` | Add barcode to PDF |
 | | `/api/v2/ReadBarcodeFromPdf` | Read barcode from PDF |
 
----
-
 ## Request Format
 
 All endpoints use POST with JSON body:
@@ -389,8 +358,6 @@ curl -s -X POST "https://api.pdf4me.com/api/v2/{endpoint}" --header "Authorizati
 }
 ```
 
----
-
 ## Guidelines
 
 1. **File Size**: Max 20MB per file (varies by plan)
@@ -400,8 +367,6 @@ curl -s -X POST "https://api.pdf4me.com/api/v2/{endpoint}" --header "Authorizati
 5. **Rate Limits**: Check your plan at https://dev.pdf4me.com/pricing/
 6. **Free Tier**: 50 API calls/month
 7. **Postman**: Import from https://dev.pdf4me.com/apiv2/documentation/postman/
-
----
 
 ## Resources
 

--- a/pdfco/SKILL.md
+++ b/pdfco/SKILL.md
@@ -4,33 +4,9 @@ description: PDF.co API for PDF processing. Use when user mentions "PDF.co", "ex
   PDF", "parse PDF", or PDF automation.
 ---
 
-# PDF.co
+## Troubleshooting
 
-All-in-one PDF processing API. Convert, extract, merge, split, compress PDFs and more. Supports OCR for scanned documents.
-
-> Official docs: https://docs.pdf.co/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Extract text from PDF files (with OCR support)
-- Convert PDF to CSV, JSON, or other formats
-- Merge multiple PDFs into one
-- Split PDF into multiple files
-- Compress PDF to reduce file size
-- Convert HTML/URL to PDF
-- Parse invoices and documents with AI
-
----
-
-## Prerequisites
-
-Connect the **PDF.co** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PDFCO_TOKEN` or `zero doctor check-connector --url https://api.pdf.co/v1/pdf/convert/to/text --method POST`
+If requests fail, run `zero doctor check-connector --env-name PDFCO_TOKEN` or `zero doctor check-connector --url https://api.pdf.co/v1/pdf/convert/to/text --method POST`
 
 ## How to Use
 
@@ -258,8 +234,6 @@ Write to `/tmp/request.json`:
 curl --location --request POST "https://api.pdf.co/v1/job/check" --header "x-api-key: $PDFCO_TOKEN" --header "Content-Type: application/json" -d @/tmp/request.json
 ```
 
----
-
 ## Common Parameters
 
 | Parameter | Type | Description |
@@ -271,8 +245,6 @@ curl --location --request POST "https://api.pdf.co/v1/job/check" --header "x-api
 | `name` | string | Output filename |
 | `password` | string | PDF password if protected |
 | `expiration` | integer | Output link expiration in minutes (default: 60) |
-
----
 
 ## Response Format
 
@@ -290,8 +262,6 @@ curl --location --request POST "https://api.pdf.co/v1/job/check" --header "x-api
 
 With `inline: true`, the response includes `body` field with extracted content.
 
----
-
 ## API Endpoints
 
 | Endpoint | Description |
@@ -308,8 +278,6 @@ With `inline: true`, the response includes `body` field with extracted content.
 | `/document-parser` | Template-based document parsing |
 | `/file/upload/get-presigned-url` | Get upload URL |
 | `/job/check` | Check async job status |
-
----
 
 ## Guidelines
 

--- a/pdforge/SKILL.md
+++ b/pdforge/SKILL.md
@@ -4,41 +4,15 @@ description: PDForge API for PDF generation. Use when user mentions "PDForge", "
   PDF", "PDF template", or document generation.
 ---
 
-# PDForge API (PDF Noodle)
+## Troubleshooting
 
-Use the PDForge API via direct `curl` calls to **generate PDFs** from templates or raw HTML.
-
-> Official docs: `https://docs.pdforge.com/`
-
-Note: PDForge has been rebranded to PDF Noodle. Both `api.pdforge.com` and `api.pdfnoodle.com` work.
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Generate PDFs from reusable templates** with dynamic data
-- **Convert HTML to PDF** directly
-- **Create invoices, reports, or documents** programmatically
-- **Export PNG images** instead of PDFs
-- **Batch generate documents** using async endpoints with webhooks
-
----
-
-## Prerequisites
-
-Connect the **PDForge API (PDF Noodle)** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PDFORGE_API_KEY` or `zero doctor check-connector --url https://api.pdfnoodle.com/v1/pdf/sync --method POST`
+If requests fail, run `zero doctor check-connector --env-name PDFORGE_API_KEY` or `zero doctor check-connector --url https://api.pdfnoodle.com/v1/pdf/sync --method POST`
 
 ## How to Use
 
 All examples below assume you have `PDFORGE_API_KEY` set.
 
 Base URL: `https://api.pdfnoodle.com/v1`
-
----
 
 ### 1. Generate PDF from Template (Sync)
 
@@ -77,8 +51,6 @@ curl -s -X POST "https://api.pdfnoodle.com/v1/pdf/sync" --header "Authorization:
 
 The `signedUrl` is a temporary URL (expires in 1 hour) to download the generated PDF.
 
----
-
 ### 2. Generate PDF from Template (Async)
 
 For batch processing, use the async endpoint with a webhook.
@@ -112,8 +84,6 @@ curl -s -X POST "https://api.pdfnoodle.com/v1/pdf/async" --header "Authorization
 
 The webhook will receive the `signedUrl` when generation is complete.
 
----
-
 ### 3. Convert HTML to PDF (Sync)
 
 Convert raw HTML directly to PDF without a template.
@@ -132,8 +102,6 @@ Then run:
 curl -s -X POST "https://api.pdfnoodle.com/v1/html-to-pdf/sync" --header "Authorization: Bearer $PDFORGE_API_KEY" --header "Content-Type: application/json" -d @/tmp/pdforge_request.json
 ```
 
----
-
 ### 4. Convert HTML to PDF with Styling
 
 Include CSS for styled PDFs.
@@ -151,8 +119,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.pdfnoodle.com/v1/html-to-pdf/sync" --header "Authorization: Bearer $PDFORGE_API_KEY" --header "Content-Type: application/json" -d @/tmp/pdforge_request.json
 ```
-
----
 
 ### 5. Generate PNG Instead of PDF
 
@@ -173,8 +139,6 @@ Then run:
 curl -s -X POST "https://api.pdfnoodle.com/v1/html-to-pdf/sync" --header "Authorization: Bearer $PDFORGE_API_KEY" --header "Content-Type: application/json" -d @/tmp/pdforge_request.json
 ```
 
----
-
 ### 6. Download Generated PDF
 
 After getting the `signedUrl`, download the PDF:
@@ -184,8 +148,6 @@ Replace `<your-signed-url>` with the actual signed URL from the previous respons
 ```bash
 curl -s -o output.pdf "https://storage.googleapis.com/<your-signed-url>"
 ```
-
----
 
 ## Request Parameters
 
@@ -222,8 +184,6 @@ curl -s -o output.pdf "https://storage.googleapis.com/<your-signed-url>"
   }
 }
 ```
-
----
 
 ## Guidelines
 

--- a/period-close/SKILL.md
+++ b/period-close/SKILL.md
@@ -3,14 +3,6 @@ name: period-close
 description: Orchestrate the month-end and quarter-end accounting close with task sequencing, dependency management, and progress tracking. Use for close calendar planning, close checklist management, close task tracking, close timeline optimization, close day activities, hard close procedures, accelerated close planning, or close process improvement.
 ---
 
-# Period Close Orchestration
-
-Task sequences, dependency logic, progress measurement, and continuous improvement practices for executing a controlled and timely accounting close.
-
-## Prerequisites
-
-Connect the **Period Close Orchestration** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Close Activity Checklist
 
 ### Pre-Close Window (Final 2-3 Business Days of the Period)

--- a/perplexity/SKILL.md
+++ b/perplexity/SKILL.md
@@ -4,31 +4,9 @@ description: Perplexity API for AI search. Use when user mentions "Perplexity", 
   search", or asks to search with citations.
 ---
 
-# Perplexity AI
+## Troubleshooting
 
-AI search engine that provides real-time web-grounded answers with source citations. Unlike traditional search, Perplexity synthesizes information from multiple sources into coherent responses.
-
-> Official docs: https://docs.perplexity.ai/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Get real-time information with source citations
-- Research topics that require up-to-date web data
-- Answer complex questions that need multi-source synthesis
-- Perform academic or SEC filings research
-- Get AI-generated summaries grounded in current web content
-
----
-
-## Prerequisites
-
-Connect the **Perplexity AI** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PERPLEXITY_TOKEN` or `zero doctor check-connector --url https://api.perplexity.ai/chat/completions --method POST`
+If requests fail, run `zero doctor check-connector --env-name PERPLEXITY_TOKEN` or `zero doctor check-connector --url https://api.perplexity.ai/chat/completions --method POST`
 
 ## How to Use
 
@@ -287,8 +265,6 @@ Then run:
 curl -s -X POST "https://api.perplexity.ai/chat/completions" --header "Authorization: Bearer $PERPLEXITY_TOKEN" --header "Content-Type: application/json" -d @/tmp/perplexity_request.json
 ```
 
----
-
 ## Models
 
 | Model | Description | Best For |
@@ -297,8 +273,6 @@ curl -s -X POST "https://api.perplexity.ai/chat/completions" --header "Authoriza
 | `sonar-pro` | Advanced search, deeper understanding | Complex queries, detailed research |
 | `sonar-reasoning-pro` | Multi-step reasoning with search | Problem-solving, analysis |
 | `sonar-deep-research` | Exhaustive research, reports | Academic research, market analysis |
-
----
 
 ## Response Format
 
@@ -331,8 +305,6 @@ Chat completions return:
   }
 }
 ```
-
----
 
 ## Guidelines
 

--- a/pika/SKILL.md
+++ b/pika/SKILL.md
@@ -3,18 +3,9 @@ name: pikastream
 description: Pika Developer API for joining video meetings (Google Meet, Zoom) as a real-time AI avatar with voice cloning. Use when user mentions "Pika", "PikaStream", "pikastream", "join a meeting as AI", "AI avatar meeting", or "video meeting bot".
 ---
 
-# Pika Developer API (PikaStream)
+## Troubleshooting
 
-PikaStream lets an AI agent join Google Meet or Zoom calls as a real-time avatar with voice cloning. Billed at **$0.275/min**.
-
-> GitHub: `https://github.com/Pika-Labs/Pika-Skills`
-> Dev portal: `https://www.pika.me/dev/`
-
-## Prerequisites
-
-Connect the **Pika Developer API (PikaStream)** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PIKA_TOKEN` or `zero doctor check-connector --url https://srkibaanghvsriahb.pika.art/developer/balance --method GET`
+If requests fail, run `zero doctor check-connector --env-name PIKA_TOKEN` or `zero doctor check-connector --url https://srkibaanghvsriahb.pika.art/developer/balance --method GET`
 
 ## Base URL
 
@@ -30,8 +21,6 @@ All requests use a `DevKey` header:
 Authorization: DevKey $PIKA_TOKEN
 ```
 
----
-
 ## Core APIs
 
 ### Check Balance
@@ -42,8 +31,6 @@ curl -s "https://srkibaanghvsriahb.pika.art/developer/balance" \
 ```
 
 Returns `{ "balance": <int> }`. Minimum 100 credits required before joining a meeting.
-
----
 
 ### Join a Meeting
 
@@ -71,8 +58,6 @@ curl -s -X POST "https://srkibaanghvsriahb.pika.art/proxy/realtime/meeting-sessi
 
 Returns: `{ "session_id": "...", "platform": "...", "status": "created" }`
 
----
-
 ### Poll Session Status
 
 ```bash
@@ -89,8 +74,6 @@ curl -s "https://srkibaanghvsriahb.pika.art/proxy/realtime/session/<session_id>"
 
 Poll every 2 seconds. The bot is ready when `status == "ready"` or both `video_worker_connected` and `meeting_bot_connected` are `true`. Default timeout: 90s.
 
----
-
 ### Leave a Meeting
 
 ```bash
@@ -102,16 +85,12 @@ Returns: `{ "session_id": "...", "closed": true }`
 
 Billing stops when this call completes.
 
----
-
 ### List Topup Products
 
 ```bash
 curl -s "https://srkibaanghvsriahb.pika.art/developer/topup/products" \
   -H "Authorization: DevKey $PIKA_TOKEN" | jq '.data // . | .products[]? | {name, numCredits, productId}'
 ```
-
----
 
 ### Create Topup Checkout
 
@@ -131,8 +110,6 @@ curl -s -X POST "https://srkibaanghvsriahb.pika.art/developer/topup" \
 ```
 
 Returns a `checkout_url`. Share with the user to complete payment, then poll `/developer/balance` until balance ≥ 100.
-
----
 
 ## Guidelines
 

--- a/pikvm/SKILL.md
+++ b/pikvm/SKILL.md
@@ -4,23 +4,6 @@ description: PiKVM API for remote KVM. Use when user mentions "PiKVM", "KVM over
   "remote server", or hardware management.
 ---
 
-# PiKVM Remote Control
-
-Control remote computers via PiKVM REST API with mouse, keyboard, and power management.
-
-## When to Use
-
-- Take screenshots of remote machine
-- Move mouse and click
-- Type text or press keyboard keys
-- Execute keyboard shortcuts (Cmd+Space, Ctrl+Alt+Del, etc.)
-- Power control (on/off/reset)
-- Automate remote desktop operations
-
-## Prerequisites
-
-Connect the **PiKVM Remote Control** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Coordinate System
 
 **Mouse coordinates use screen center as origin (0,0)**:
@@ -31,8 +14,6 @@ For 1920x1080 screen:
 - Top-left: `(-960, -540)`
 - Center: `(0, 0)`
 - Bottom-right: `(960, 540)`
-
----
 
 ## Usage
 
@@ -141,8 +122,6 @@ curl -k -s -X POST -u "$PIKVM_AUTH" "$PIKVM_URL/api/atx/power?action=off"
 # Hard reset
 curl -k -s -X POST -u "$PIKVM_AUTH" "$PIKVM_URL/api/atx/power?action=reset_hard"
 ```
-
----
 
 ## Common Key Names
 

--- a/plain/SKILL.md
+++ b/plain/SKILL.md
@@ -5,32 +5,9 @@ vm0_env:
   - PLAIN_TOKEN
 ---
 
-# Plain
+## Troubleshooting
 
-Manage customer support threads, customers, and labels via Plain's GraphQL API.
-
-> Official docs: `https://www.plain.com/docs/graphql/introduction`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- List and search support threads by status or customer
-- Get thread details and conversation history
-- Reply to customer threads
-- Create or update customer records
-- Add labels to threads for categorization
-- Create customer events for lifecycle tracking
-
----
-
-## Prerequisites
-
-Connect the **Plain** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PLAIN_TOKEN` or `zero doctor check-connector --url https://core-api.uk.plain.com/graphql/v1 --method POST`
+If requests fail, run `zero doctor check-connector --env-name PLAIN_TOKEN` or `zero doctor check-connector --url https://core-api.uk.plain.com/graphql/v1 --method POST`
 
 ## Threads
 
@@ -101,8 +78,6 @@ Then run:
 curl -s -X POST "https://core-api.uk.plain.com/graphql/v1" --header "Authorization: Bearer $PLAIN_TOKEN" --header "Content-Type: application/json" -d @/tmp/plain_request.json
 ```
 
----
-
 ## Customers
 
 ### Upsert Customer
@@ -160,8 +135,6 @@ Then run:
 curl -s -X POST "https://core-api.uk.plain.com/graphql/v1" --header "Authorization: Bearer $PLAIN_TOKEN" --header "Content-Type: application/json" -d @/tmp/plain_request.json
 ```
 
----
-
 ## Labels
 
 ### List Label Types
@@ -204,8 +177,6 @@ Then run:
 curl -s -X POST "https://core-api.uk.plain.com/graphql/v1" --header "Authorization: Bearer $PLAIN_TOKEN" --header "Content-Type: application/json" -d @/tmp/plain_request.json
 ```
 
----
-
 ## Error Handling
 
 All mutations return an `error` field. Always check it — a `200` HTTP response can still contain an error:
@@ -225,8 +196,6 @@ All mutations return an `error` field. Always check it — a `200` HTTP response
 }
 ```
 
----
-
 ## Guidelines
 
 1. **GraphQL only**: All requests go to `POST https://core-api.uk.plain.com/graphql/v1`
@@ -235,8 +204,6 @@ All mutations return an `error` field. Always check it — a `200` HTTP response
 4. **Machine User permissions**: Grant the minimum permissions needed (e.g., `threads:read`, `customers:write`)
 5. **Thread statuses**: `TODO` (needs action), `SNOOZED` (waiting), `DONE` (resolved)
 6. **Full schema**: Available at `https://core-api.uk.plain.com/graphql/v1/schema.graphql`
-
----
 
 ## API Reference
 

--- a/plausible/SKILL.md
+++ b/plausible/SKILL.md
@@ -4,23 +4,9 @@ description: Plausible Analytics API for privacy-friendly stats. Use when user m
   "Plausible", "analytics", "page views", or website stats.
 ---
 
-# Plausible Analytics API
+## Troubleshooting
 
-Query website analytics and manage sites with Plausible's privacy-friendly analytics platform.
-
-## When to Use
-
-- Query visitor statistics and pageviews
-- Analyze traffic sources and referrers
-- Get geographic and device breakdowns
-- Track conversions and goals
-- Manage analytics sites programmatically
-
-## Prerequisites
-
-Connect the **Plausible** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PLAUSIBLE_TOKEN` or `zero doctor check-connector --url https://plausible.io/api/v2/query --method POST`
+If requests fail, run `zero doctor check-connector --env-name PLAUSIBLE_TOKEN` or `zero doctor check-connector --url https://plausible.io/api/v2/query --method POST`
 
 ## Stats API (v2)
 

--- a/podchaser/SKILL.md
+++ b/podchaser/SKILL.md
@@ -4,32 +4,9 @@ description: Podchaser API for podcast data. Use when user mentions "Podchaser",
   "podcast search", or asks about podcast information.
 ---
 
-# Podchaser API
+## Troubleshooting
 
-Access comprehensive podcast data including shows, episodes, creators, networks, charts, and sponsorship information via GraphQL.
-
-> Official docs: `https://api-docs.podchaser.com/docs/overview`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Search and discover podcasts by topic, category, or keywords
-- Get detailed podcast and episode metadata
-- Access Apple Podcasts and Spotify chart rankings
-- Find sponsorship and advertising data
-- Retrieve episode transcripts
-- Look up podcast creators and networks
-
----
-
-## Prerequisites
-
-Connect the **Podchaser** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PODCHASER_TOKEN` or `zero doctor check-connector --url https://api.podchaser.com/graphql --method POST`
+If requests fail, run `zero doctor check-connector --env-name PODCHASER_TOKEN` or `zero doctor check-connector --url https://api.podchaser.com/graphql --method POST`
 
 ## How to Use
 
@@ -215,8 +192,6 @@ Then run:
 curl -s -X POST "https://api.podchaser.com/graphql/cost" --header "Content-Type: application/json" --header "Authorization: Bearer $PODCHASER_TOKEN" -d @/tmp/podchaser_request.json
 ```
 
----
-
 ## GraphQL Schema Reference
 
 ### Main Queries
@@ -300,8 +275,6 @@ The `type` field is required when using `identifier` to fetch a podcast or episo
 | `SPOTIFY_CHART_RANK` | Spotify ranking |
 | `LATEST_EPISODE` | Most recent episode |
 
----
-
 ## Rate Limits
 
 - **Request Limit**: 50 requests per 10 seconds
@@ -313,8 +286,6 @@ The `type` field is required when using `identifier` to fetch a podcast or episo
 **Example costs:**
 - Basic podcast metadata: ~9 points
 - Search 10 podcasts with details: ~100 points
-
----
 
 ## Guidelines
 

--- a/posthog/SKILL.md
+++ b/posthog/SKILL.md
@@ -4,43 +4,15 @@ description: PostHog API for product analytics. Use when user mentions "PostHog"
   "product analytics", "event tracking", or user analytics.
 ---
 
-# PostHog API
+## Troubleshooting
 
-Use the PostHog API via direct `curl` calls to manage **product analytics, feature flags, experiments, insights, dashboards, cohorts, annotations, and surveys**.
-
-> Official docs: `https://posthog.com/docs/api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage feature flags** - create, update, list, and toggle feature flags
-- **Run experiments** - create and monitor A/B tests
-- **Query analytics** - run HogQL queries for custom analytics
-- **Manage insights** - create and retrieve saved insights (trends, funnels, retention)
-- **Manage dashboards** - create and organize dashboards
-- **Track persons and events** - query user data and event streams
-- **Manage cohorts** - create and query user segments
-- **Create annotations** - add timeline markers for deployments or incidents
-- **Manage surveys** - create and monitor in-app surveys
-
----
-
-## Prerequisites
-
-Connect the **PostHog** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name POSTHOG_TOKEN` or `zero doctor check-connector --url https://us.posthog.com/api/organizations/ --method GET`
+If requests fail, run `zero doctor check-connector --env-name POSTHOG_TOKEN` or `zero doctor check-connector --url https://us.posthog.com/api/organizations/ --method GET`
 
 ## How to Use
 
 All examples below assume `POSTHOG_TOKEN` is set. Replace `<project-id>` with your actual project ID from the prerequisites step.
 
 Base URL: `https://us.posthog.com/api`
-
----
 
 ## Organizations
 
@@ -58,8 +30,6 @@ Replace `<org-id>` with your organization ID:
 curl -s "https://us.posthog.com/api/organizations/<org-id>/" --header "Authorization: Bearer $POSTHOG_TOKEN" | jq '{id, name, slug, created_at, membership_level}'
 ```
 
----
-
 ## Projects
 
 ### List Projects
@@ -75,8 +45,6 @@ Replace `<project-id>` with your project ID:
 ```bash
 curl -s "https://us.posthog.com/api/projects/<project-id>/" --header "Authorization: Bearer $POSTHOG_TOKEN" | jq '{id, name, timezone, completed_snippet_onboarding, ingested_event}'
 ```
-
----
 
 ## Feature Flags
 
@@ -142,8 +110,6 @@ Replace `<flag-id>` with the feature flag ID:
 curl -s -X DELETE "https://us.posthog.com/api/projects/<project-id>/feature_flags/<flag-id>/" --header "Authorization: Bearer $POSTHOG_TOKEN"
 ```
 
----
-
 ## Experiments
 
 ### List Experiments
@@ -184,8 +150,6 @@ Write to `/tmp/posthog_request.json`:
 ```bash
 curl -s -X POST "https://us.posthog.com/api/projects/<project-id>/experiments/" --header "Authorization: Bearer $POSTHOG_TOKEN" --header "Content-Type: application/json" -d @/tmp/posthog_request.json | jq '{id, name, feature_flag_key}'
 ```
-
----
 
 ## Insights
 
@@ -253,8 +217,6 @@ Replace `<insight-id>` with the insight ID:
 curl -s -X DELETE "https://us.posthog.com/api/projects/<project-id>/insights/<insight-id>/" --header "Authorization: Bearer $POSTHOG_TOKEN"
 ```
 
----
-
 ## Dashboards
 
 ### List Dashboards
@@ -293,8 +255,6 @@ Replace `<dashboard-id>` with the dashboard ID:
 ```bash
 curl -s -X DELETE "https://us.posthog.com/api/projects/<project-id>/dashboards/<dashboard-id>/" --header "Authorization: Bearer $POSTHOG_TOKEN"
 ```
-
----
 
 ## HogQL Queries
 
@@ -351,8 +311,6 @@ Write to `/tmp/posthog_request.json`:
 curl -s -X POST "https://us.posthog.com/api/projects/<project-id>/query/" --header "Authorization: Bearer $POSTHOG_TOKEN" --header "Content-Type: application/json" -d @/tmp/posthog_request.json | jq '{columns, results}'
 ```
 
----
-
 ## Events
 
 ### List Recent Events
@@ -368,8 +326,6 @@ Replace `$pageview` with the event name you want to filter:
 ```bash
 curl -s "https://us.posthog.com/api/projects/<project-id>/events/?event=%24pageview&limit=10" --header "Authorization: Bearer $POSTHOG_TOKEN" | jq '.results[] | {id, event, distinct_id, timestamp, properties}'
 ```
-
----
 
 ## Persons
 
@@ -392,8 +348,6 @@ Replace `<person-id>` with the person ID:
 ```bash
 curl -s "https://us.posthog.com/api/projects/<project-id>/persons/<person-id>/" --header "Authorization: Bearer $POSTHOG_TOKEN" | jq '{id, distinct_ids, properties, created_at}'
 ```
-
----
 
 ## Cohorts
 
@@ -432,8 +386,6 @@ Write to `/tmp/posthog_request.json`:
 curl -s -X POST "https://us.posthog.com/api/projects/<project-id>/cohorts/" --header "Authorization: Bearer $POSTHOG_TOKEN" --header "Content-Type: application/json" -d @/tmp/posthog_request.json | jq '{id, name}'
 ```
 
----
-
 ## Annotations
 
 ### List Annotations
@@ -466,8 +418,6 @@ Replace `<annotation-id>` with the annotation ID:
 curl -s -X DELETE "https://us.posthog.com/api/projects/<project-id>/annotations/<annotation-id>/" --header "Authorization: Bearer $POSTHOG_TOKEN"
 ```
 
----
-
 ## Actions
 
 ### List Actions
@@ -497,8 +447,6 @@ Write to `/tmp/posthog_request.json`:
 ```bash
 curl -s -X POST "https://us.posthog.com/api/projects/<project-id>/actions/" --header "Authorization: Bearer $POSTHOG_TOKEN" --header "Content-Type: application/json" -d @/tmp/posthog_request.json | jq '{id, name}'
 ```
-
----
 
 ## Surveys
 
@@ -533,8 +481,6 @@ Write to `/tmp/posthog_request.json`:
 curl -s -X POST "https://us.posthog.com/api/projects/<project-id>/surveys/" --header "Authorization: Bearer $POSTHOG_TOKEN" --header "Content-Type: application/json" -d @/tmp/posthog_request.json | jq '{id, name, type}'
 ```
 
----
-
 ## Event Definitions
 
 ### List Event Definitions
@@ -545,8 +491,6 @@ Discover what events are tracked in your project:
 curl -s "https://us.posthog.com/api/projects/<project-id>/event_definitions/" --header "Authorization: Bearer $POSTHOG_TOKEN" | jq '.results[] | {name, volume_30_day, query_usage_30_day}'
 ```
 
----
-
 ## Property Definitions
 
 ### List Property Definitions
@@ -556,8 +500,6 @@ Discover what properties are available:
 ```bash
 curl -s "https://us.posthog.com/api/projects/<project-id>/property_definitions/" --header "Authorization: Bearer $POSTHOG_TOKEN" | jq '.results[] | {name, property_type, is_numerical}'
 ```
-
----
 
 ## Guidelines
 

--- a/prd-writing/SKILL.md
+++ b/prd-writing/SKILL.md
@@ -3,14 +3,6 @@ name: prd-writing
 description: Author product requirements documents with structured problem framing, user narratives, prioritized requirements, and measurable outcomes. Activate when drafting a PRD, writing a product spec, defining user stories, setting acceptance criteria, scoping MVP requirements, managing feature scope, or documenting what to build and why.
 ---
 
-# PRD Writing Skill
-
-You are a seasoned product requirements author who transforms ambiguous product ideas into precise, actionable specification documents. You guide product managers through every aspect of defining what to build, who it serves, and how to validate success.
-
-## Prerequisites
-
-Connect the **PRD Writing** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Document Architecture
 
 Organize every PRD around these core sections. Adapt the depth of each section to the complexity of the initiative.

--- a/prisma-postgres/SKILL.md
+++ b/prisma-postgres/SKILL.md
@@ -4,29 +4,9 @@ description: Prisma Postgres API for database. Use when user mentions "Prisma Po
   "Prisma database", or asks about Prisma acceleration.
 ---
 
-# Prisma Postgres Management API
+## Troubleshooting
 
-Manage Prisma Postgres projects, databases, connections, backups, and usage metrics via the Management API.
-
-> Official docs: `https://www.prisma.io/docs/postgres/introduction/management-api`
-
----
-
-## When to Use
-
-- Create and manage Prisma Postgres projects and databases
-- Create and manage database connections (pooled, direct, accelerate)
-- List available regions for deploying databases
-- View database usage metrics (operations and storage)
-- Manage database backups and restore from backups
-
----
-
-## Prerequisites
-
-Connect the **Prisma Postgres** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PRISMA_POSTGRES_TOKEN` or `zero doctor check-connector --url https://api.prisma.io/v1/projects --method GET`
+If requests fail, run `zero doctor check-connector --env-name PRISMA_POSTGRES_TOKEN` or `zero doctor check-connector --url https://api.prisma.io/v1/projects --method GET`
 
 ## Core APIs
 
@@ -38,8 +18,6 @@ curl -s "https://api.prisma.io/v1/projects" --header "Authorization: Bearer $PRI
 
 Docs: https://www.prisma.io/docs/postgres/introduction/management-api
 
----
-
 ### Get Project Details
 
 Replace `<project-id>` with the actual project ID:
@@ -47,8 +25,6 @@ Replace `<project-id>` with the actual project ID:
 ```bash
 curl -s "https://api.prisma.io/v1/projects/<project-id>" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" | jq '{id, name, createdAt}'
 ```
-
----
 
 ### Create Project
 
@@ -68,8 +44,6 @@ curl -s -X POST "https://api.prisma.io/v1/projects" --header "Authorization: Bea
 
 Available regions can be listed with the regions endpoint below.
 
----
-
 ### Update Project
 
 Replace `<project-id>` with the actual project ID.
@@ -86,8 +60,6 @@ Write to `/tmp/prisma_request.json`:
 curl -s -X PATCH "https://api.prisma.io/v1/projects/<project-id>" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" --header "Content-Type: application/json" -d @/tmp/prisma_request.json | jq '{id, name}'
 ```
 
----
-
 ### Delete Project
 
 Replace `<project-id>` with the actual project ID:
@@ -98,8 +70,6 @@ curl -s -X DELETE "https://api.prisma.io/v1/projects/<project-id>" --header "Aut
 
 Returns HTTP 204 on success.
 
----
-
 ### List Databases
 
 List all databases, optionally filtered by project:
@@ -108,8 +78,6 @@ List all databases, optionally filtered by project:
 curl -s "https://api.prisma.io/v1/databases?projectId=<project-id>" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" | jq '.[] | {id, name, region, createdAt}'
 ```
 
----
-
 ### Get Database Details
 
 Replace `<database-id>` with the actual database ID:
@@ -117,8 +85,6 @@ Replace `<database-id>` with the actual database ID:
 ```bash
 curl -s "https://api.prisma.io/v1/databases/<database-id>" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" | jq '{id, name, region, connections}'
 ```
-
----
 
 ### Create Database
 
@@ -137,8 +103,6 @@ Write to `/tmp/prisma_request.json`:
 curl -s -X POST "https://api.prisma.io/v1/projects/<project-id>/databases" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" --header "Content-Type: application/json" -d @/tmp/prisma_request.json | jq '{id, name, region, connections}'
 ```
 
----
-
 ### Update Database
 
 Replace `<database-id>` with the actual database ID.
@@ -155,8 +119,6 @@ Write to `/tmp/prisma_request.json`:
 curl -s -X PATCH "https://api.prisma.io/v1/databases/<database-id>" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" --header "Content-Type: application/json" -d @/tmp/prisma_request.json | jq '{id, name}'
 ```
 
----
-
 ### Delete Database
 
 Replace `<database-id>` with the actual database ID (cannot delete default databases):
@@ -167,8 +129,6 @@ curl -s -X DELETE "https://api.prisma.io/v1/databases/<database-id>" --header "A
 
 Returns HTTP 204 on success.
 
----
-
 ### List Connections
 
 List all connections for a specific database. Replace `<database-id>`:
@@ -176,8 +136,6 @@ List all connections for a specific database. Replace `<database-id>`:
 ```bash
 curl -s "https://api.prisma.io/v1/databases/<database-id>/connections" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" | jq '.[] | {id, name, endpoints}'
 ```
-
----
 
 ### Create Connection
 
@@ -189,8 +147,6 @@ curl -s -X POST "https://api.prisma.io/v1/databases/<database-id>/connections" -
 
 The response includes connection strings for direct, pooled, and accelerate endpoints.
 
----
-
 ### Delete Connection
 
 Replace `<connection-id>` with the actual connection ID:
@@ -201,8 +157,6 @@ curl -s -X DELETE "https://api.prisma.io/v1/connections/<connection-id>" --heade
 
 Returns HTTP 204 on success.
 
----
-
 ### List Database Backups
 
 Replace `<database-id>` with the actual database ID:
@@ -210,8 +164,6 @@ Replace `<database-id>` with the actual database ID:
 ```bash
 curl -s "https://api.prisma.io/v1/databases/<database-id>/backups?limit=10" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" | jq '.[] | {id, createdAt}'
 ```
-
----
 
 ### Restore Database from Backup
 
@@ -235,8 +187,6 @@ curl -s -X POST "https://api.prisma.io/v1/databases/<target-database-id>/restore
 
 Cannot restore to default databases.
 
----
-
 ### Get Database Usage Metrics
 
 Replace `<database-id>` with the actual database ID:
@@ -247,23 +197,17 @@ curl -s "https://api.prisma.io/v1/databases/<database-id>/usage?startDate=2025-0
 
 Returns operations (ops) and storage (GiB) metrics for the specified period.
 
----
-
 ### List Available Regions
 
 ```bash
 curl -s "https://api.prisma.io/v1/regions/postgres" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" | jq '.[] | {id, displayName, status}'
 ```
 
----
-
 ### List Workspaces
 
 ```bash
 curl -s "https://api.prisma.io/v1/workspaces" --header "Authorization: Bearer $PRISMA_POSTGRES_TOKEN" | jq '.[] | {id, name}'
 ```
-
----
 
 ## Guidelines
 

--- a/privacy-compliance/SKILL.md
+++ b/privacy-compliance/SKILL.md
@@ -3,14 +3,6 @@ name: privacy-compliance
 description: Guide teams through GDPR, CCPA/CPRA, and international privacy law obligations including DPA reviews, data subject access and deletion requests, cross-border data transfers, breach notification, and regulatory monitoring. Use when evaluating data processing agreements, handling DSAR or right-to-delete requests, assessing international data transfer mechanisms, reviewing privacy notices, or tracking privacy regulation changes.
 ---
 
-# Privacy Compliance Skill
-
-You operate as a privacy and data protection advisor within an in-house legal function. You help the team navigate global privacy regulations, scrutinize data processing agreements, manage individual rights requests, and stay current with regulatory developments.
-
-## Prerequisites
-
-Connect the **Privacy Compliance** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Global Privacy Landscape
 
 ### EU General Data Protection Regulation (GDPR)

--- a/product-metrics/SKILL.md
+++ b/product-metrics/SKILL.md
@@ -3,14 +3,6 @@ name: product-metrics
 description: Define, instrument, and analyze product metrics across acquisition, activation, engagement, retention, and monetization. Activate when setting OKRs, designing a metrics dashboard, running a weekly or monthly metrics review, diagnosing metric movements, choosing KPIs for a product area, building a metrics framework, or evaluating product health.
 ---
 
-# Product Metrics Skill
-
-You are a product analytics expert who helps teams select the right measurements, establish meaningful targets, build effective review rhythms, and design dashboards that surface actionable insight rather than decorative numbers.
-
-## Prerequisites
-
-Connect the **Product Metrics** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Metrics Architecture
 
 Structure product measurement into three layers, each serving a distinct purpose.

--- a/productlane/SKILL.md
+++ b/productlane/SKILL.md
@@ -4,32 +4,9 @@ description: Productlane API for feedback management. Use when user mentions "Pr
   "feedback", "feature request", or product insights.
 ---
 
-# Productlane API
+## Troubleshooting
 
-Manage your public roadmap, helpdesk, feedback threads, companies, contacts, changelogs, and documentation via Productlane's REST API.
-
-> Official docs: `https://productlane.mintlify.dev/docs/api-reference`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage feedback threads** — create, list, update, and send messages
-- **Manage companies and contacts** — create, update, delete, and query customer data
-- **Publish changelogs** — create and update changelog entries with markdown content
-- **View roadmap** — list projects and issues from the public portal
-- **Manage documentation** — create and organize help articles
-- **Manage users** — invite members and update roles
-
----
-
-## Prerequisites
-
-Connect the **Productlane** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PRODUCTLANE_TOKEN` or `zero doctor check-connector --url https://productlane.com/api/v1/workspaces --method GET`
+If requests fail, run `zero doctor check-connector --env-name PRODUCTLANE_TOKEN` or `zero doctor check-connector --url https://productlane.com/api/v1/workspaces --method GET`
 
 ## Workspaces
 
@@ -40,8 +17,6 @@ Retrieve workspace information. Replace `<workspace-id>` with the actual workspa
 ```bash
 curl -s "https://productlane.com/api/v1/workspaces/<workspace-id>" --header "Authorization: Bearer $PRODUCTLANE_TOKEN"
 ```
-
----
 
 ## Companies
 
@@ -119,8 +94,6 @@ Get available Linear customer statuses and tiers. Requires Linear integration wi
 curl -s "https://productlane.com/api/v1/companies/linear-options" --header "Authorization: Bearer $PRODUCTLANE_TOKEN"
 ```
 
----
-
 ## Contacts
 
 ### List Contacts
@@ -180,8 +153,6 @@ Replace `<contact-id>` with the actual contact ID:
 ```bash
 curl -s -X DELETE "https://productlane.com/api/v1/contacts/<contact-id>" --header "Authorization: Bearer $PRODUCTLANE_TOKEN"
 ```
-
----
 
 ## Threads (Feedback)
 
@@ -265,8 +236,6 @@ Then run:
 curl -s -X POST "https://productlane.com/api/v1/threads/<thread-id>/messages" --header "Authorization: Bearer $PRODUCTLANE_TOKEN" --header "Content-Type: application/json" -d @/tmp/productlane_request.json
 ```
 
----
-
 ## Changelogs
 
 ### List Changelogs
@@ -326,8 +295,6 @@ Replace `<changelog-id>` with the actual changelog ID:
 ```bash
 curl -s -X DELETE "https://productlane.com/api/v1/changelogs/<changelog-id>" --header "Authorization: Bearer $PRODUCTLANE_TOKEN"
 ```
-
----
 
 ## Portal / Roadmap
 
@@ -393,8 +360,6 @@ Replace `<upvote-id>` with the actual upvote ID:
 ```bash
 curl -s -X DELETE "https://productlane.com/api/v1/portal/upvotes/<upvote-id>" --header "Authorization: Bearer $PRODUCTLANE_TOKEN"
 ```
-
----
 
 ## Documentation
 
@@ -492,8 +457,6 @@ Then run:
 curl -s -X POST "https://productlane.com/api/v1/docs/groups/move-articles" --header "Authorization: Bearer $PRODUCTLANE_TOKEN" --header "Content-Type: application/json" -d @/tmp/productlane_request.json
 ```
 
----
-
 ## Users
 
 ### List Members
@@ -537,8 +500,6 @@ Then run:
 curl -s -X PATCH "https://productlane.com/api/v1/users/role" --header "Authorization: Bearer $PRODUCTLANE_TOKEN" --header "Content-Type: application/json" -d @/tmp/productlane_request.json
 ```
 
----
-
 ## Guidelines
 
 1. **Base URL**: All endpoints use `https://productlane.com/api/v1/`
@@ -550,8 +511,6 @@ curl -s -X PATCH "https://productlane.com/api/v1/users/role" --header "Authoriza
 7. **Company linking**: When creating contacts, use exactly one of `companyId` (recommended), `companyName`, or `companyExternalId`
 8. **Public endpoints**: Workspace, portal issues/projects, and published changelogs/articles can be accessed without authentication
 9. **Security**: Never expose API keys in logs or client-side code
-
----
 
 ## API Reference
 

--- a/pushinator/SKILL.md
+++ b/pushinator/SKILL.md
@@ -4,30 +4,9 @@ description: Pushinator API for push notifications. Use when user mentions "Push
   "push notification", "web push", or notifications.
 ---
 
-# Pushinator API
+## Troubleshooting
 
-Use the Pushinator API via direct `curl` calls to **send push notifications** to mobile devices.
-
-> Official docs: `https://pushinator.com/api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Send push notifications** to mobile devices
-- **Alert users** about events, deployments, or updates
-- **Integrate notifications** into CI/CD pipelines
-- **Notify yourself** when long-running tasks complete
-
----
-
-## Prerequisites
-
-Connect the **Pushinator** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name PUSHINATOR_TOKEN` or `zero doctor check-connector --url https://api.pushinator.com/api/v2/notifications/send --method POST`
+If requests fail, run `zero doctor check-connector --env-name PUSHINATOR_TOKEN` or `zero doctor check-connector --url https://api.pushinator.com/api/v2/notifications/send --method POST`
 
 ## How to Use
 
@@ -36,8 +15,6 @@ Base URL: `https://api.pushinator.com`
 **Required headers:**
 - `Authorization: Bearer $PUSHINATOR_TOKEN`
 - `Content-Type: application/json`
-
----
 
 ### 1. Send a Push Notification
 
@@ -69,8 +46,6 @@ curl -s -X POST "https://api.pushinator.com/api/v2/notifications/send" \
 }
 ```
 
----
-
 ### 2. Send Deployment Notification
 
 Notify when a deployment completes.
@@ -92,8 +67,6 @@ curl -s -X POST "https://api.pushinator.com/api/v2/notifications/send" \
   --header "Content-Type: application/json" \
   -d @/tmp/pushinator_request.json
 ```
-
----
 
 ### 3. Send Alert with Emoji
 
@@ -117,16 +90,12 @@ curl -s -X POST "https://api.pushinator.com/api/v2/notifications/send" \
   -d @/tmp/pushinator_request.json
 ```
 
----
-
 ## Request Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `channel_id` | string | Yes | UUID of the notification channel |
 | `content` | string | Yes | Notification message text |
-
----
 
 ## HTTP Status Codes
 
@@ -135,8 +104,6 @@ curl -s -X POST "https://api.pushinator.com/api/v2/notifications/send" \
 | 2xx | Success - notification sent |
 | 4xx | Invalid request or missing parameters |
 | 5xx | Server error - retry recommended |
-
----
 
 ## Guidelines
 

--- a/qdrant/SKILL.md
+++ b/qdrant/SKILL.md
@@ -4,37 +4,13 @@ description: Qdrant API for vector search. Use when user mentions "Qdrant", "vec
   database", "semantic search", or embeddings storage.
 ---
 
-# Qdrant API
+## Troubleshooting
 
-Use the Qdrant REST API via direct `curl` calls to **store and search vector embeddings** for RAG, semantic search, and recommendations.
-
-> Official docs: `https://qdrant.tech/documentation/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Store vector embeddings** for semantic search
-- **Search for similar vectors** using cosine, dot product, or euclidean distance
-- **Build RAG applications** with retrieval from vector store
-- **Implement recommendations** based on similarity
-- **Filter search results** by metadata/payload
-
----
-
-## Prerequisites
-
-Connect the **Qdrant** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name QDRANT_TOKEN` or `zero doctor check-connector --url https://your-cluster.cloud.qdrant.io/collections --method GET`
+If requests fail, run `zero doctor check-connector --env-name QDRANT_TOKEN` or `zero doctor check-connector --url https://your-cluster.cloud.qdrant.io/collections --method GET`
 
 ## How to Use
 
 All examples below assume you have `QDRANT_BASE_URL` and `QDRANT_TOKEN` set.
-
----
 
 ### 1. Check Server Status
 
@@ -44,8 +20,6 @@ Verify connection to Qdrant:
 curl -s -X GET "$QDRANT_BASE_URL" --header "api-key: $QDRANT_TOKEN"
 ```
 
----
-
 ### 2. List Collections
 
 Get all collections:
@@ -53,8 +27,6 @@ Get all collections:
 ```bash
 curl -s -X GET "$QDRANT_BASE_URL/collections" --header "api-key: $QDRANT_TOKEN"
 ```
-
----
 
 ### 3. Create a Collection
 
@@ -88,8 +60,6 @@ curl -s -X PUT "$QDRANT_BASE_URL/collections/my_collection" --header "api-key: $
 - OpenAI `text-embedding-3-large`: 3072
 - Cohere: 1024
 
----
-
 ### 4. Get Collection Info
 
 Get details about a collection:
@@ -97,8 +67,6 @@ Get details about a collection:
 ```bash
 curl -s -X GET "$QDRANT_BASE_URL/collections/my_collection" --header "api-key: $QDRANT_TOKEN"
 ```
-
----
 
 ### 5. Upsert Points (Insert/Update Vectors)
 
@@ -128,8 +96,6 @@ Then run:
 ```bash
 curl -s -X PUT "$QDRANT_BASE_URL/collections/my_collection/points" --header "api-key: $QDRANT_TOKEN" --header "Content-Type: application/json" -d @/tmp/qdrant_request.json
 ```
-
----
 
 ### 6. Search Similar Vectors
 
@@ -162,8 +128,6 @@ curl -s -X POST "$QDRANT_BASE_URL/collections/my_collection/points/query" --head
 }
 ```
 
----
-
 ### 7. Search with Filters
 
 Filter results by payload fields:
@@ -194,8 +158,6 @@ curl -s -X POST "$QDRANT_BASE_URL/collections/my_collection/points/query" --head
 - `should` - At least one must match (OR)
 - `must_not` - None should match (NOT)
 
----
-
 ### 8. Get Points by ID
 
 Retrieve specific points:
@@ -215,8 +177,6 @@ Then run:
 ```bash
 curl -s -X POST "$QDRANT_BASE_URL/collections/my_collection/points" --header "api-key: $QDRANT_TOKEN" --header "Content-Type: application/json" -d @/tmp/qdrant_request.json
 ```
-
----
 
 ### 9. Delete Points
 
@@ -256,8 +216,6 @@ Then run:
 curl -s -X POST "$QDRANT_BASE_URL/collections/my_collection/points/delete" --header "api-key: $QDRANT_TOKEN" --header "Content-Type: application/json" -d @/tmp/qdrant_request.json
 ```
 
----
-
 ### 10. Delete Collection
 
 Remove a collection entirely:
@@ -265,8 +223,6 @@ Remove a collection entirely:
 ```bash
 curl -s -X DELETE "$QDRANT_BASE_URL/collections/my_collection" --header "api-key: $QDRANT_TOKEN"
 ```
-
----
 
 ### 11. Count Points
 
@@ -285,8 +241,6 @@ Then run:
 ```bash
 curl -s -X POST "$QDRANT_BASE_URL/collections/my_collection/points/count" --header "api-key: $QDRANT_TOKEN" --header "Content-Type: application/json" -d @/tmp/qdrant_request.json
 ```
-
----
 
 ## Filter Syntax
 
@@ -309,8 +263,6 @@ Common filter conditions:
 - `match.any` - Match any in list
 - `match.except` - Match none in list
 - `range` - Numeric range (gt, gte, lt, lte)
-
----
 
 ## Guidelines
 

--- a/qiita/SKILL.md
+++ b/qiita/SKILL.md
@@ -4,29 +4,11 @@ description: Qiita API for Japanese tech articles. Use when user mentions "Qiita
   "Japanese tech blog", or asks about Qiita posts.
 ---
 
-# Qiita API
-
-Qiita is a technical knowledge sharing platform popular in Japan. This skill provides integration for searching articles, publishing content, and interacting with the community.
-
-## When to Use
-
-- Search technical articles on Qiita
-- Get articles by tag or user
-- Publish technical articles
-- Read and post comments
-- Get trending tags and topics
-
-## Prerequisites
-
-Connect the **Qiita** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 ### Commands
 
 The script supports 5 modules: `item`, `user`, `tag`, `comment`, `auth`
-
----
 
 ### 1. Item - Articles
 
@@ -83,8 +65,6 @@ scripts/qiita.sh item update --id "article_id" --title "New Title" --body "Updat
 scripts/qiita.sh item delete --id "article_id"
 ```
 
----
-
 ### 2. User - User Information
 
 #### Get Current User
@@ -118,8 +98,6 @@ scripts/qiita.sh user followers --id "username"
 scripts/qiita.sh user following --id "username"
 ```
 
----
-
 ### 3. Tag - Tags
 
 #### List Popular Tags
@@ -147,8 +125,6 @@ scripts/qiita.sh tag get --id "Python"
 scripts/qiita.sh tag items --id "JavaScript" --per-page 10
 ```
 
----
-
 ### 4. Comment - Comments
 
 #### Get Article Comments
@@ -169,8 +145,6 @@ scripts/qiita.sh comment post --item-id "article_id" --body "Great article!"
 scripts/qiita.sh comment delete --id "comment_id"
 ```
 
----
-
 ### 5. Auth - Authentication
 
 #### Verify Token
@@ -180,8 +154,6 @@ scripts/qiita.sh auth verify
 ```
 
 Returns current user info if token is valid.
-
----
 
 ## Search Query Syntax
 

--- a/reddit/SKILL.md
+++ b/reddit/SKILL.md
@@ -5,21 +5,9 @@ description: Reddit API for accessing discussions and content. Use when user men
   discussions.
 ---
 
-# Reddit
+## Troubleshooting
 
-Access Reddit discussions, posts, and content through the Reddit API.
-
-## Prerequisites
-
-Connect the **Reddit** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name REDDIT_TOKEN` or `zero doctor check-connector --url https://oauth.reddit.com/api/v1/me --method GET`
-
-## When to Use
-
-- Search and read Reddit posts and comments
-- Browse subreddit content
-- Access Reddit discussions for research or monitoring
+If requests fail, run `zero doctor check-connector --env-name REDDIT_TOKEN` or `zero doctor check-connector --url https://oauth.reddit.com/api/v1/me --method GET`
 
 ## Authentication
 

--- a/reply-templates/SKILL.md
+++ b/reply-templates/SKILL.md
@@ -3,14 +3,6 @@ name: reply-templates
 description: Build, manage, and generate standardized response templates for recurring legal inquiries. Activate when handling data subject access requests (DSARs), litigation hold notices, NDA workflows, vendor contract questions, subpoena responses, privacy policy inquiries, insurance claim notifications, or when creating and maintaining a library of reusable legal response templates with proper escalation safeguards.
 ---
 
-# Reply Templates
-
-You assist in-house legal teams by maintaining a library of reusable response templates for frequently occurring legal inquiries. You generate customized responses from these templates and -- critically -- you identify situations where a formulaic reply is inappropriate and individualized legal judgment is required.
-
-## Prerequisites
-
-Connect the **Reply Templates** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Template Architecture
 
 ### Required Components for Every Template
@@ -319,7 +311,9 @@ Before producing any response, scan for conditions that disqualify template use:
 ### Standard Template Format
 
 ```markdown
+
 ## Template: {{template_label}}
+
 **Category**: {{category}}
 **Version**: {{version}} | **Reviewed**: {{review_date}}
 **Approved By**: {{approver_name}}

--- a/reportei/SKILL.md
+++ b/reportei/SKILL.md
@@ -4,35 +4,11 @@ description: Reportei API for marketing reports. Use when user mentions "Reporte
   "marketing report", "digital marketing", or report automation.
 ---
 
-# Reportei
+## Troubleshooting
 
-Use Reportei via direct `curl` calls to **generate and manage marketing reports** with automated analytics.
-
-> Official docs: `https://app.reportei.com/docs/api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Retrieve company and template information**
-- **List and manage client projects**
-- **Generate and access marketing reports**
-- **Manage integrations** (Google Analytics, Meta, etc.)
-- **Set up webhooks** for automated notifications
-
----
-
-## Prerequisites
-
-Connect the **Reportei** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name REPORTEI_TOKEN` or `zero doctor check-connector --url https://app.reportei.com/api/v1/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name REPORTEI_TOKEN` or `zero doctor check-connector --url https://app.reportei.com/api/v1/me --method GET`
 
 ## How to Use
-
----
 
 ### 1. Get Company Details
 
@@ -57,8 +33,6 @@ Response:
 }
 ```
 
----
-
 ### 2. List Templates
 
 Retrieve all report templates in your company:
@@ -66,8 +40,6 @@ Retrieve all report templates in your company:
 ```bash
 curl -s -X GET "https://app.reportei.com/api/v1/templates" -H "Authorization: Bearer $REPORTEI_TOKEN" | jq '.data[] | {id, title, used_count}'
 ```
-
----
 
 ### 3. List Clients (Projects)
 
@@ -77,8 +49,6 @@ Retrieve all client projects:
 curl -s -X GET "https://app.reportei.com/api/v1/clients" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
 
----
-
 ### 4. Get Client Details
 
 Retrieve details of a specific client. Replace `<your-client-id>` with the actual client ID:
@@ -86,8 +56,6 @@ Retrieve details of a specific client. Replace `<your-client-id>` with the actua
 ```bash
 curl -s -X GET "https://app.reportei.com/api/v1/clients/<your-client-id>" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
-
----
 
 ### 5. List Client Reports
 
@@ -97,8 +65,6 @@ Get all reports for a specific client. Replace `<your-client-id>` with the actua
 curl -s -X GET "https://app.reportei.com/api/v1/clients/<your-client-id>/reports" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
 
----
-
 ### 6. Get Report Details
 
 Retrieve details of a specific report. Replace `<your-report-id>` with the actual report ID:
@@ -106,8 +72,6 @@ Retrieve details of a specific report. Replace `<your-report-id>` with the actua
 ```bash
 curl -s -X GET "https://app.reportei.com/api/v1/reports/<your-report-id>" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
-
----
 
 ### 7. List Client Integrations
 
@@ -117,8 +81,6 @@ Get all integrations for a specific client. Replace `<your-client-id>` with the 
 curl -s -X GET "https://app.reportei.com/api/v1/clients/<your-client-id>/integrations" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
 
----
-
 ### 8. Get Integration Details
 
 Retrieve details of a specific integration. Replace `<your-integration-id>` with the actual integration ID:
@@ -127,8 +89,6 @@ Retrieve details of a specific integration. Replace `<your-integration-id>` with
 curl -s -X GET "https://app.reportei.com/api/v1/integrations/<your-integration-id>" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
 
----
-
 ### 9. Get Integration Widgets
 
 List available widgets for an integration. Replace `<your-integration-id>` with the actual integration ID:
@@ -136,8 +96,6 @@ List available widgets for an integration. Replace `<your-integration-id>` with 
 ```bash
 curl -s -X GET "https://app.reportei.com/api/v1/integrations/<your-integration-id>/widgets" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
-
----
 
 ### 10. Get Widget Value
 
@@ -158,8 +116,6 @@ Then run (replace `<your-integration-id>` with the actual integration ID):
 ```bash
 curl -s -X POST "https://app.reportei.com/api/v1/integrations/<your-integration-id>/widgets/value" -H "Authorization: Bearer $REPORTEI_TOKEN" -H "Content-Type: application/json" -d @/tmp/reportei_request.json
 ```
-
----
 
 ### 11. Create Report (Connector Action)
 
@@ -182,8 +138,6 @@ Then run:
 curl -s -X POST "https://app.reportei.com/api/v1/create_report" -H "Authorization: Bearer $REPORTEI_TOKEN" -H "Content-Type: application/json" -d @/tmp/reportei_request.json
 ```
 
----
-
 ### 12. Create Dashboard (Connector Action)
 
 Create a new dashboard.
@@ -202,8 +156,6 @@ Then run:
 ```bash
 curl -s -X POST "https://app.reportei.com/api/v1/create_dashboard" -H "Authorization: Bearer $REPORTEI_TOKEN" -H "Content-Type: application/json" -d @/tmp/reportei_request.json
 ```
-
----
 
 ### 13. Add to Timeline (Connector Action)
 
@@ -225,8 +177,6 @@ Then run:
 curl -s -X POST "https://app.reportei.com/api/v1/add_to_timeline" -H "Authorization: Bearer $REPORTEI_TOKEN" -H "Content-Type: application/json" -d @/tmp/reportei_request.json
 ```
 
----
-
 ### 14. List Webhook Events
 
 Get available webhook event types:
@@ -234,8 +184,6 @@ Get available webhook event types:
 ```bash
 curl -s -X GET "https://app.reportei.com/api/v1/webhook/events" -H "Authorization: Bearer $REPORTEI_TOKEN"
 ```
-
----
 
 ### 15. Subscribe to Webhook
 
@@ -256,8 +204,6 @@ Then run:
 curl -s -X POST "https://app.reportei.com/api/v1/webhooks/subscribe" -H "Authorization: Bearer $REPORTEI_TOKEN" -H "Content-Type: application/json" -d @/tmp/reportei_request.json
 ```
 
----
-
 ### 16. Unsubscribe from Webhook
 
 Unsubscribe from webhook notifications.
@@ -276,8 +222,6 @@ Then run:
 curl -s -X POST "https://app.reportei.com/api/v1/webhooks/unsubscribe" -H "Authorization: Bearer $REPORTEI_TOKEN" -H "Content-Type: application/json" -d @/tmp/reportei_request.json
 ```
 
----
-
 ## Company Types
 
 | Type | Description |
@@ -285,8 +229,6 @@ curl -s -X POST "https://app.reportei.com/api/v1/webhooks/unsubscribe" -H "Autho
 | `agency` | Marketing agency |
 | `freelancer` | Independent professional |
 | `company` | In-house marketing team |
-
----
 
 ## Response Fields
 
@@ -311,8 +253,6 @@ curl -s -X POST "https://app.reportei.com/api/v1/webhooks/unsubscribe" -H "Autho
 | `used_count` | Times template has been used |
 | `created_at` | Creation timestamp |
 | `updated_at` | Last update timestamp |
-
----
 
 ## Guidelines
 

--- a/research-synthesis/SKILL.md
+++ b/research-synthesis/SKILL.md
@@ -3,14 +3,6 @@ name: research-synthesis
 description: Transform raw user research data into actionable product insights, personas, and prioritized opportunities. Activate for interview analysis, survey interpretation, usability test findings, support ticket pattern mining, behavioral data synthesis, thematic coding, affinity diagramming, persona building, or opportunity scoring.
 ---
 
-# Research Synthesis
-
-You are skilled at converting unstructured user research — interviews, surveys, usability sessions, support logs, product analytics — into clear findings that inform product decisions. You apply rigorous qualitative and quantitative methods to surface patterns, build personas grounded in evidence, and size opportunities with transparent assumptions.
-
-## Prerequisites
-
-Connect the **Research Synthesis** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Core Analytical Methods
 
 ### Thematic Coding

--- a/resend/SKILL.md
+++ b/resend/SKILL.md
@@ -4,31 +4,9 @@ description: Resend API for email delivery. Use when user mentions "Resend", "se
   email", "email API", or transactional email.
 ---
 
-# Resend Email API
+## Troubleshooting
 
-Send transactional emails, manage contacts, and domains via Resend's REST API.
-
-> Official docs: https://resend.com/docs/api-reference/introduction
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Send transactional emails (welcome, password reset, notifications)
-- Send batch emails to multiple recipients
-- Manage email contacts and audiences
-- Verify and manage sending domains
-- Track email delivery status
-
----
-
-## Prerequisites
-
-Connect the **Resend** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name RESEND_TOKEN` or `zero doctor check-connector --url https://api.resend.com/emails --method POST`
+If requests fail, run `zero doctor check-connector --env-name RESEND_TOKEN` or `zero doctor check-connector --url https://api.resend.com/emails --method POST`
 
 ## Emails
 
@@ -180,8 +158,6 @@ curl -s "https://api.resend.com/emails" --header "Authorization: Bearer $RESEND_
 curl -s -X POST "https://api.resend.com/emails/<your-email-id>/cancel" --header "Authorization: Bearer $RESEND_TOKEN"
 ```
 
----
-
 ## Contacts
 
 ### Create Contact
@@ -266,8 +242,6 @@ curl -s -X PATCH "https://api.resend.com/contacts/<your-contact-id>" --header "A
 curl -s -X DELETE "https://api.resend.com/contacts/<your-contact-id>" --header "Authorization: Bearer $RESEND_TOKEN"
 ```
 
----
-
 ## Domains
 
 ### List Domains
@@ -309,8 +283,6 @@ curl -s -X POST "https://api.resend.com/domains/<your-domain-id>/verify" --heade
 ```bash
 curl -s -X DELETE "https://api.resend.com/domains/<your-domain-id>" --header "Authorization: Bearer $RESEND_TOKEN"
 ```
-
----
 
 ## API Keys
 
@@ -359,8 +331,6 @@ curl -s -X POST "https://api.resend.com/api-keys" --header "Authorization: Beare
 curl -s -X DELETE "https://api.resend.com/api-keys/<your-api-key-id>" --header "Authorization: Bearer $RESEND_TOKEN"
 ```
 
----
-
 ## Email Parameters Reference
 
 | Parameter | Type | Description |
@@ -377,8 +347,6 @@ curl -s -X DELETE "https://api.resend.com/api-keys/<your-api-key-id>" --header "
 | `tags` | array | Custom tags for tracking |
 | `attachments` | array | File attachments (max 40MB total) |
 
----
-
 ## Response Codes
 
 | Status | Description |
@@ -391,8 +359,6 @@ curl -s -X DELETE "https://api.resend.com/api-keys/<your-api-key-id>" --header "
 | `429` | Rate limit exceeded (2 req/sec) |
 | `5xx` | Server error |
 
----
-
 ## Guidelines
 
 1. **Rate Limits**: Default is 2 requests per second; implement backoff for 429 errors
@@ -400,8 +366,6 @@ curl -s -X DELETE "https://api.resend.com/api-keys/<your-api-key-id>" --header "
 3. **Batch Emails**: Use `/emails/batch` for sending to multiple recipients efficiently
 4. **Idempotency**: Use `Idempotency-Key` header to prevent duplicate sends
 5. **Scheduling**: Use natural language (`in 1 hour`) or ISO 8601 format for `scheduled_at`
-
----
 
 ## API Reference
 

--- a/revenuecat/SKILL.md
+++ b/revenuecat/SKILL.md
@@ -4,35 +4,9 @@ description: RevenueCat API for in-app purchases. Use when user mentions "Revenu
   "in-app purchase", "subscription", or mobile monetization.
 ---
 
-# RevenueCat API
+## Troubleshooting
 
-Manage in-app subscriptions, customers, entitlements, offerings, and products in RevenueCat via the REST API.
-
-> Official docs: `https://www.revenuecat.com/docs/api-v2`
->
-> API v1 reference: `https://www.revenuecat.com/docs/api-v1`
-
----
-
-## Prerequisites
-
-Connect the **RevenueCat** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name REVENUECAT_TOKEN` or `zero doctor check-connector --url https://api.revenuecat.com/v1/subscribers/APP_USER_ID --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- Look up customer subscription status and entitlements
-- Manage offerings, products, and entitlements configuration
-- Grant or revoke promotional entitlements
-- Retrieve purchase and transaction history
-- Delete customers for GDPR compliance
-
----
-
----
+If requests fail, run `zero doctor check-connector --env-name REVENUECAT_TOKEN` or `zero doctor check-connector --url https://api.revenuecat.com/v1/subscribers/APP_USER_ID --method GET`
 
 ## How to Use
 
@@ -45,8 +19,6 @@ RevenueCat has two API versions:
 Both use Bearer token authentication.
 
 Replace `PROJECT_ID` with your RevenueCat project ID and `APP_USER_ID` with the customer's app user ID.
-
----
 
 ## Customers (API v1)
 
@@ -82,8 +54,6 @@ Permanently delete a customer and their data (for GDPR compliance).
 curl -s -X DELETE "https://api.revenuecat.com/v1/subscribers/APP_USER_ID" --header "Authorization: Bearer $REVENUECAT_TOKEN" | jq .
 ```
 
----
-
 ## Promotional Entitlements (API v1)
 
 ### Grant a Promotional Entitlement
@@ -113,8 +83,6 @@ Revoke all promotional entitlements for a customer.
 curl -s -X POST "https://api.revenuecat.com/v1/subscribers/APP_USER_ID/entitlements/ENTITLEMENT_ID/revoke_promotionals" --header "Authorization: Bearer $REVENUECAT_TOKEN" | jq .
 ```
 
----
-
 ## Receipts (API v1)
 
 ### Submit a Receipt
@@ -134,8 +102,6 @@ Write to `/tmp/revenuecat_request.json`:
 ```bash
 curl -s -X POST "https://api.revenuecat.com/v1/receipts" --header "Content-Type: application/json" --header "Authorization: Bearer $REVENUECAT_TOKEN" -d @/tmp/revenuecat_request.json | jq .
 ```
-
----
 
 ## Offerings (API v2)
 
@@ -172,8 +138,6 @@ curl -s -X POST "https://api.revenuecat.com/v2/projects/PROJECT_ID/offerings" --
 curl -s -X DELETE "https://api.revenuecat.com/v2/projects/PROJECT_ID/offerings/OFFERING_ID" --header "Authorization: Bearer $REVENUECAT_TOKEN" | jq .
 ```
 
----
-
 ## Products (API v2)
 
 ### List Products
@@ -209,8 +173,6 @@ curl -s -X POST "https://api.revenuecat.com/v2/projects/PROJECT_ID/products" --h
 ```bash
 curl -s -X DELETE "https://api.revenuecat.com/v2/projects/PROJECT_ID/products/PRODUCT_ID" --header "Authorization: Bearer $REVENUECAT_TOKEN" | jq .
 ```
-
----
 
 ## Entitlements (API v2)
 
@@ -253,8 +215,6 @@ curl -s -X POST "https://api.revenuecat.com/v2/projects/PROJECT_ID/entitlements/
 curl -s -X DELETE "https://api.revenuecat.com/v2/projects/PROJECT_ID/entitlements/ENTITLEMENT_ID" --header "Authorization: Bearer $REVENUECAT_TOKEN" | jq .
 ```
 
----
-
 ## Packages (API v2)
 
 ### List Packages in an Offering
@@ -285,8 +245,6 @@ curl -s -X POST "https://api.revenuecat.com/v2/projects/PROJECT_ID/offerings/OFF
 curl -s -X POST "https://api.revenuecat.com/v2/projects/PROJECT_ID/offerings/OFFERING_ID/packages/PACKAGE_ID/actions/attach_products" --header "Content-Type: application/json" --header "Authorization: Bearer $REVENUECAT_TOKEN" -d '{"product_ids": ["PRODUCT_ID"]}' | jq .
 ```
 
----
-
 ## Customer Subscriptions (API v2)
 
 ### List Customer Subscriptions
@@ -300,8 +258,6 @@ curl -s "https://api.revenuecat.com/v2/projects/PROJECT_ID/customers/APP_USER_ID
 ```bash
 curl -s "https://api.revenuecat.com/v2/projects/PROJECT_ID/customers/APP_USER_ID/active_entitlements" --header "Authorization: Bearer $REVENUECAT_TOKEN" | jq '.items[] | {entitlement_identifier, expires_date}'
 ```
-
----
 
 ## Guidelines
 

--- a/roadmap-planning/SKILL.md
+++ b/roadmap-planning/SKILL.md
@@ -3,14 +3,6 @@ name: roadmap-planning
 description: Build and prioritize product roadmaps using scoring models like RICE, ICE, and value-effort matrices. Activate when creating a product roadmap, prioritizing features, sequencing initiatives, mapping dependencies, balancing team capacity, choosing between Now/Next/Later or quarterly planning, or communicating roadmap tradeoffs to executives and stakeholders.
 ---
 
-# Roadmap Planning Skill
-
-You are an experienced product strategist who builds roadmaps that translate company objectives into sequenced, capacity-aware delivery plans. You help product managers prioritize ruthlessly, surface hidden dependencies, and communicate plans that stakeholders trust.
-
-## Prerequisites
-
-Connect the **Roadmap Planning** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Roadmap Formats
 
 Choose the format that matches your audience and planning horizon.

--- a/rss-fetch/SKILL.md
+++ b/rss-fetch/SKILL.md
@@ -3,29 +3,6 @@ name: rss-fetch
 description: RSS feed API for fetching news and articles. Use when user mentions "RSS", "feed", "RSS reader", "fetch feed", or asks to get news from RSS sources.
 ---
 
-# RSS Feed Fetcher
-
-Use `curl` to **fetch and parse RSS/Atom feeds** from any source.
-
-> RSS feeds return XML that can be parsed with `xmllint` or converted to JSON.
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Fetch news articles** from RSS feeds
-- **Monitor blog updates** or content sources
-- **Aggregate content** from multiple feeds
-- **Track topics** via RSS subscriptions
-
----
-
-## Prerequisites
-
-Connect the **RSS Feed Fetcher** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 ### 1. Fetch Raw RSS Feed
@@ -62,8 +39,6 @@ Atom feeds use `<entry>` instead of `<item>`:
 curl -s "https://github.com/blog.atom" | xmllint --xpath '//entry/title/text()' - 2>/dev/null
 ```
 
----
-
 ## Popular RSS Feeds
 
 | Source | URL |
@@ -75,8 +50,6 @@ curl -s "https://github.com/blog.atom" | xmllint --xpath '//entry/title/text()' 
 | The Verge | `https://www.theverge.com/rss/index.xml` |
 | Reddit (any sub) | `https://www.reddit.com/r/programming/.rss` |
 | GitHub Blog | `https://github.blog/feed/` |
-
----
 
 ## Examples
 
@@ -126,8 +99,6 @@ curl -s "https://hnrss.org/frontpage" -o /tmp/hn-feed.xml
 xmllint --xpath '//item/title/text()' /tmp/hn-feed.xml
 ```
 
----
-
 ## HN RSS Options
 
 Hacker News RSS (`hnrss.org`) supports parameters:
@@ -147,8 +118,6 @@ curl -s "https://hnrss.org/frontpage?points=100&count=10"
 curl -s "https://hnrss.org/frontpage?q=AI&count=10"
 ```
 
----
-
 ## RSS vs Atom Format
 
 | Element | RSS | Atom |
@@ -158,8 +127,6 @@ curl -s "https://hnrss.org/frontpage?q=AI&count=10"
 | Link | `<link>` | `<link href="...">` |
 | Summary | `<description>` | `<summary>` |
 | Date | `<pubDate>` | `<published>` |
-
----
 
 ## Guidelines
 

--- a/runway/SKILL.md
+++ b/runway/SKILL.md
@@ -4,32 +4,9 @@ description: Runway ML API for AI video generation. Use when user mentions "Runw
   "Runway ML", "AI video", "Gen-2", or video generation.
 ---
 
-# Runway API
+## Troubleshooting
 
-Use the Runway API via direct `curl` calls to **generate AI videos** from images, text, or video inputs.
-
-> Official docs: `https://docs.dev.runwayml.com/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Generate video from images** (image-to-video)
-- **Generate video from text prompts** (text-to-video)
-- **Transform existing videos** (video-to-video)
-- **Generate images from text** (text-to-image)
-- **Upscale video resolution** (4X upscale)
-- **Generate sound effects or speech**
-
----
-
-## Prerequisites
-
-Connect the **Runway** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name RUNWAY_TOKEN` or `zero doctor check-connector --url https://api.dev.runwayml.com/v1/organization --method GET`
+If requests fail, run `zero doctor check-connector --env-name RUNWAY_TOKEN` or `zero doctor check-connector --url https://api.dev.runwayml.com/v1/organization --method GET`
 
 ## How to Use
 
@@ -42,8 +19,6 @@ Base URL: `https://api.dev.runwayml.com/v1`
 - `X-Runway-Version: 2024-11-06`
 - `Content-Type: application/json`
 
----
-
 ### 1. Check Organization Credits
 
 Check your credit balance:
@@ -51,8 +26,6 @@ Check your credit balance:
 ```bash
 curl -s -X GET "https://api.dev.runwayml.com/v1/organization" --header "Authorization: Bearer $RUNWAY_TOKEN" --header "X-Runway-Version: 2024-11-06"
 ```
-
----
 
 ### 2. Image to Video
 
@@ -83,8 +56,6 @@ curl -s -X POST "https://api.dev.runwayml.com/v1/image_to_video" --header "Autho
 }
 ```
 
----
-
 ### 3. Text to Video
 
 Generate a video from text only:
@@ -108,8 +79,6 @@ Then run:
 curl -s -X POST "https://api.dev.runwayml.com/v1/text_to_video" --header "Authorization: Bearer $RUNWAY_TOKEN" --header "X-Runway-Version: 2024-11-06" --header "Content-Type: application/json" -d @/tmp/runway_request.json
 ```
 
----
-
 ### 4. Video to Video
 
 Transform an existing video:
@@ -130,8 +99,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.dev.runwayml.com/v1/video_to_video" --header "Authorization: Bearer $RUNWAY_TOKEN" --header "X-Runway-Version: 2024-11-06" --header "Content-Type: application/json" -d @/tmp/runway_request.json
 ```
-
----
 
 ### 5. Text to Image
 
@@ -154,8 +121,6 @@ Then run:
 curl -s -X POST "https://api.dev.runwayml.com/v1/text_to_image" --header "Authorization: Bearer $RUNWAY_TOKEN" --header "X-Runway-Version: 2024-11-06" --header "Content-Type: application/json" -d @/tmp/runway_request.json
 ```
 
----
-
 ### 6. Check Task Status
 
 Poll for task completion. Replace `<your-task-id>` with the actual task ID:
@@ -175,8 +140,6 @@ curl -s -X GET "https://api.dev.runwayml.com/v1/tasks/<your-task-id>" --header "
 
 **Possible statuses:** `PENDING`, `RUNNING`, `SUCCEEDED`, `FAILED`
 
----
-
 ### 7. Cancel a Task
 
 Cancel a running task. Replace `<your-task-id>` with the actual task ID:
@@ -184,8 +147,6 @@ Cancel a running task. Replace `<your-task-id>` with the actual task ID:
 ```bash
 curl -s -X DELETE "https://api.dev.runwayml.com/v1/tasks/<your-task-id>" --header "Authorization: Bearer $RUNWAY_TOKEN" --header "X-Runway-Version: 2024-11-06"
 ```
-
----
 
 ### 8. Video Upscale (4X)
 
@@ -206,8 +167,6 @@ Then run:
 curl -s -X POST "https://api.dev.runwayml.com/v1/video_upscale" --header "Authorization: Bearer $RUNWAY_TOKEN" --header "X-Runway-Version: 2024-11-06" --header "Content-Type: application/json" -d @/tmp/runway_request.json
 ```
 
----
-
 ### 9. Generate Sound Effects
 
 Generate audio from text:
@@ -227,8 +186,6 @@ Then run:
 curl -s -X POST "https://api.dev.runwayml.com/v1/sound_effect" --header "Authorization: Bearer $RUNWAY_TOKEN" --header "X-Runway-Version: 2024-11-06" --header "Content-Type: application/json" -d @/tmp/runway_request.json
 ```
 
----
-
 ## Available Models
 
 | Endpoint | Models |
@@ -239,16 +196,12 @@ curl -s -X POST "https://api.dev.runwayml.com/v1/sound_effect" --header "Authori
 | Text to Image | `gen4_image_turbo`, `gen4_image` |
 | Video Upscale | `upscale_v1` |
 
----
-
 ## Aspect Ratios
 
 Common ratios for video generation:
 - `1280:720` (16:9 landscape)
 - `720:1280` (9:16 portrait)
 - `1024:1024` (1:1 square)
-
----
 
 ## Guidelines
 

--- a/salesforce/SKILL.md
+++ b/salesforce/SKILL.md
@@ -3,24 +3,9 @@ name: salesforce
 description: Salesforce CRM REST API. Use when user mentions "Salesforce", "SFDC", "Salesforce CRM", "leads", "opportunities", "SOQL", or asks about enterprise CRM data.
 ---
 
-# Salesforce REST API
+## Troubleshooting
 
-Manage Contacts, Leads, Accounts, and Opportunities via the Salesforce REST API.
-
-> Official docs: `https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/`
-
-## When to Use
-
-- Create or update Contacts and Leads from Clerk user data
-- Query CRM records using SOQL
-- Manage Accounts and Opportunities
-- Search across Salesforce objects
-
-## Prerequisites
-
-Connect the **Salesforce** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SALESFORCE_TOKEN` or `zero doctor check-connector --url https://your-instance.my.salesforce.com/services/data/v60.0/query --method GET`
+If requests fail, run `zero doctor check-connector --env-name SALESFORCE_TOKEN` or `zero doctor check-connector --url https://your-instance.my.salesforce.com/services/data/v60.0/query --method GET`
 
 ## Core APIs
 
@@ -32,8 +17,6 @@ curl -s "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/quer
 
 Docs: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_query.htm
 
----
-
 ### Search Contacts by Email
 
 Replace `<email>` with the email address to search for:
@@ -42,8 +25,6 @@ Replace `<email>` with the email address to search for:
 curl -s "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id,FirstName,LastName,Email+FROM+Contact+WHERE+Email=%27<email>%27+LIMIT+5" --header "Authorization: Bearer $SALESFORCE_TOKEN" | jq '[.records[] | {Id, FirstName, LastName, Email}]'
 ```
 
----
-
 ### Get Contact
 
 Replace `<contact-id>` with the Salesforce Contact ID (18-char string starting with `003`):
@@ -51,8 +32,6 @@ Replace `<contact-id>` with the Salesforce Contact ID (18-char string starting w
 ```bash
 curl -s "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/sobjects/Contact/<contact-id>" --header "Authorization: Bearer $SALESFORCE_TOKEN" | jq '{Id, FirstName, LastName, Email, Phone, AccountId}'
 ```
-
----
 
 ### Create Contact
 
@@ -73,8 +52,6 @@ Write to `/tmp/sf_request.json`:
 curl -s -X POST "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/sobjects/Contact/" --header "Authorization: Bearer $SALESFORCE_TOKEN" --header "Content-Type: application/json" -d @/tmp/sf_request.json | jq '{id, success}'
 ```
 
----
-
 ### Update Contact
 
 Replace `<contact-id>` with the Contact ID.
@@ -91,8 +68,6 @@ Write to `/tmp/sf_request.json`:
 ```bash
 curl -s -X PATCH "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/sobjects/Contact/<contact-id>" --header "Authorization: Bearer $SALESFORCE_TOKEN" --header "Content-Type: application/json" -d @/tmp/sf_request.json -w "\nHTTP Status: %{http_code}\n"
 ```
-
----
 
 ### Create Lead
 
@@ -113,15 +88,11 @@ Write to `/tmp/sf_request.json`:
 curl -s -X POST "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/sobjects/Lead/" --header "Authorization: Bearer $SALESFORCE_TOKEN" --header "Content-Type: application/json" -d @/tmp/sf_request.json | jq '{id, success}'
 ```
 
----
-
 ### Query Accounts
 
 ```bash
 curl -s "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/query?q=SELECT+Id,Name,Industry,AnnualRevenue+FROM+Account+LIMIT+20" --header "Authorization: Bearer $SALESFORCE_TOKEN" | jq '[.records[] | {Id, Name, Industry, AnnualRevenue}]'
 ```
-
----
 
 ### SOSL Full-Text Search
 
@@ -130,8 +101,6 @@ Search across multiple objects. Replace `<search-term>`:
 ```bash
 curl -s "https://$SALESFORCE_INSTANCE.my.salesforce.com/services/data/v60.0/search?q=FIND+%7B<search-term>%7D+IN+ALL+FIELDS+RETURNING+Contact(Id,Name,Email),Lead(Id,Name,Email)" --header "Authorization: Bearer $SALESFORCE_TOKEN" | jq '[.searchRecords[] | {Id, Name, type: .attributes.type}]'
 ```
-
----
 
 ## Guidelines
 

--- a/scrapeninja/SKILL.md
+++ b/scrapeninja/SKILL.md
@@ -4,33 +4,9 @@ description: ScrapeNinja API for web scraping. Use when user mentions "ScrapeNin
   "scrape", "web scraping", or data extraction.
 ---
 
-# ScrapeNinja
+## Troubleshooting
 
-High-performance web scraping API with Chrome TLS fingerprint, rotating proxies, smart retries, and optional JavaScript rendering.
-
-> Official docs: https://scrapeninja.net/docs/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Scrape websites with anti-bot protection (Cloudflare, Datadome)
-- Extract data without running a full browser (fast `/scrape` endpoint)
-- Render JavaScript-heavy pages (`/scrape-js` endpoint)
-- Use rotating proxies with geo selection (US, EU, Brazil, etc.)
-- Extract structured data with Cheerio extractors
-- Intercept AJAX requests
-- Take screenshots of pages
-
----
-
-## Prerequisites
-
-Connect the **ScrapeNinja** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SCRAPENINJA_TOKEN` or `zero doctor check-connector --url https://scrapeninja.p.rapidapi.com/scrape --method POST`
+If requests fail, run `zero doctor check-connector --env-name SCRAPENINJA_TOKEN` or `zero doctor check-connector --url https://scrapeninja.p.rapidapi.com/scrape --method POST`
 
 ## How to Use
 
@@ -209,8 +185,6 @@ Then run:
 curl -s -X POST "https://scrapeninja.p.rapidapi.com/scrape-js" --header "Content-Type: application/json" --header "X-RapidAPI-Key: $SCRAPENINJA_TOKEN" -d @/tmp/scrapeninja_request.json
 ```
 
----
-
 ## API Endpoints
 
 | Endpoint | Description |
@@ -218,8 +192,6 @@ curl -s -X POST "https://scrapeninja.p.rapidapi.com/scrape-js" --header "Content
 | `/scrape` | Fast non-JS scraping with Chrome TLS fingerprint |
 | `/scrape-js` | Full Chrome browser with JS rendering |
 | `/v2/scrape-js` | Enhanced JS rendering for protected sites (APIRoad only) |
-
----
 
 ## Request Parameters
 
@@ -249,8 +221,6 @@ curl -s -X POST "https://scrapeninja.p.rapidapi.com/scrape-js" --header "Content
 | `catchAjaxHeadersUrlMask` | string | - | URL pattern to intercept AJAX |
 | `viewport` | object | 1920x1080 | Custom viewport size |
 
----
-
 ## Response Format
 
 ```json
@@ -272,8 +242,6 @@ curl -s -X POST "https://scrapeninja.p.rapidapi.com/scrape-js" --header "Content
 }
 ```
 
----
-
 ## Guidelines
 
 1. **Start with `/scrape`**: Use the fast non-JS endpoint first, only switch to `/scrape-js` if needed
@@ -283,8 +251,6 @@ curl -s -X POST "https://scrapeninja.p.rapidapi.com/scrape-js" --header "Content
 5. **Blocked Sites**: For Cloudflare/Datadome protected sites, use `/v2/scrape-js` via APIRoad
 6. **Screenshots**: Set `screenshot: false` to speed up JS rendering
 7. **Rate Limits**: Check your plan limits on RapidAPI/APIRoad dashboard
-
----
 
 ## Tools
 

--- a/seedance/SKILL.md
+++ b/seedance/SKILL.md
@@ -3,29 +3,9 @@ name: seedance
 description: Seedance video generation API by ByteDance. Use when user mentions "Seedance", "ByteDance video AI", "text-to-video", "image-to-video", or wants to generate AI videos using Seedance models.
 ---
 
-# Seedance
+## Troubleshooting
 
-Generate AI videos from text prompts or images using ByteDance's Seedance model via the BytePlus ModelArk API. Supports text-to-video, image-to-video, and reference-to-video generation at up to 1080p.
-
-> Official docs: `https://docs.byteplus.com/en/docs/ModelArk/2291680`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Generate videos from text prompts** (text-to-video)
-- **Animate an image into a video** (image-to-video with first/last frame)
-- **Generate video with reference images, videos, or audio** (reference-to-video)
-
----
-
-## Prerequisites
-
-Connect the **Seedance** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SEEDANCE_TOKEN` or `zero doctor check-connector --url https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks --method POST`
+If requests fail, run `zero doctor check-connector --env-name SEEDANCE_TOKEN` or `zero doctor check-connector --url https://ark.ap-southeast.bytepluses.com/api/v3/contents/generations/tasks --method POST`
 
 ## How to Use
 
@@ -139,16 +119,12 @@ Replace `<video-url>` with the `content.video_url` from the completed task.
 curl -sL "<video-url>" -o /tmp/seedance_output.mp4
 ```
 
----
-
 ## Model Reference
 
 | Model ID | Tier | Max Resolution | Duration |
 |---|---|---|---|
 | `dreamina-seedance-2-0-260128` | Standard | 1080p | 4–15s or `-1` (smart) |
 | `dreamina-seedance-2-0-fast-260128` | Fast | 720p | 4–15s or `-1` (smart) |
-
----
 
 ## Key Parameters
 
@@ -171,8 +147,6 @@ curl -sL "<video-url>" -o /tmp/seedance_output.mp4
 | `reference_image` | Character/style reference (up to 9 images) |
 | `reference_video` | Video style reference (up to 3 videos, URL only — no Base64) |
 | `reference_audio` | Audio reference (up to 3 clips) |
-
----
 
 ## Guidelines
 

--- a/sentry/SKILL.md
+++ b/sentry/SKILL.md
@@ -4,32 +4,9 @@ description: Sentry API for error tracking. Use when user mentions "Sentry", "er
   tracking", "crash report", "exceptions", or asks about monitoring errors.
 ---
 
-# Sentry API
+## Troubleshooting
 
-Manage error tracking, issues, releases, monitors, and projects via the Sentry REST API.
-
-> Official docs: https://docs.sentry.io/api/
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- List, search, resolve, or ignore issues
-- View error events, stack traces, and event details
-- Manage releases and deployments
-- Configure monitors (cron monitoring)
-- Manage alert rules
-- View and manage projects and teams
-
----
-
-## Prerequisites
-
-Connect the **Sentry** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SENTRY_TOKEN` or `zero doctor check-connector --url https://sentry.io/api/0/organizations/ --method GET`
+If requests fail, run `zero doctor check-connector --env-name SENTRY_TOKEN` or `zero doctor check-connector --url https://sentry.io/api/0/organizations/ --method GET`
 
 ## Organizations
 
@@ -46,8 +23,6 @@ curl -s "https://sentry.io/api/0/organizations/" \
 curl -s "https://sentry.io/api/0/organizations/<org-slug>/" \
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
-
----
 
 ## Projects
 
@@ -80,8 +55,6 @@ curl -s -X PUT "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/" \
 curl -s -X DELETE "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/" \
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
-
----
 
 ## Issues
 
@@ -172,8 +145,6 @@ curl -s -X DELETE "https://sentry.io/api/0/organizations/<org-slug>/issues/<issu
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
 
----
-
 ## Events
 
 ### List Issue Events
@@ -196,8 +167,6 @@ curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/events/" \
 curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/events/<event-id>/" \
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
-
----
 
 ## Releases
 
@@ -247,8 +216,6 @@ curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/releases/<ve
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
 
----
-
 ## Monitors (Cron)
 
 ### List Monitors
@@ -288,8 +255,6 @@ curl -s -X DELETE "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/mo
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
 
----
-
 ## Alert Rules
 
 ### List Alert Rules
@@ -306,8 +271,6 @@ curl -s "https://sentry.io/api/0/organizations/<org-slug>/alert-rules/<rule-id>/
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
 
----
-
 ## Project Rules (Issue Alerts)
 
 ### List Project Rules
@@ -323,8 +286,6 @@ curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/rules/" \
 curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/rules/<rule-id>/" \
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
-
----
 
 ## Teams
 
@@ -349,8 +310,6 @@ curl -s "https://sentry.io/api/0/teams/<org-slug>/<team-slug>/projects/" \
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
 
----
-
 ## Members
 
 ### List Organization Members
@@ -359,8 +318,6 @@ curl -s "https://sentry.io/api/0/teams/<org-slug>/<team-slug>/projects/" \
 curl -s "https://sentry.io/api/0/organizations/<org-slug>/members/" \
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
-
----
 
 ## Environments
 
@@ -371,8 +328,6 @@ curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/environments
   --header "Authorization: Bearer $SENTRY_TOKEN"
 ```
 
----
-
 ## Issue Status Values
 
 | Status | Description |
@@ -382,8 +337,6 @@ curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/environments
 | `resolvedInNextRelease` | Auto-resolve on next release |
 | `ignored` | Ignored (won't alert) |
 
----
-
 ## Guidelines
 
 1. **Discover org slug first**: Call `GET /organizations/` to get your org slug before using other endpoints.
@@ -392,8 +345,6 @@ curl -s "https://sentry.io/api/0/projects/<org-slug>/<project-slug>/environments
 4. **Search syntax**: Issues support Sentry's query language: `is:unresolved`, `level:error`, `assigned:me`, `first-release:`, `error.type:`, etc.
 5. **Rate limits**: Back off on 429 responses.
 6. **Scopes**: Ensure token has required scopes (`project:read`, `event:read`, `org:read`, etc.).
-
----
 
 ## How to Look Up More API Details
 

--- a/serpapi/SKILL.md
+++ b/serpapi/SKILL.md
@@ -4,39 +4,15 @@ description: SerpApi for search engine results. Use when user mentions "SERP", "
   results", "Google scrape", or search API.
 ---
 
-# SerpApi
+## Troubleshooting
 
-Use SerpApi via direct `curl` calls to **scrape search engine results** from Google, Bing, YouTube, and more.
-
-> Official docs: `https://serpapi.com/search-api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Scrape Google search results** (organic, ads, knowledge graph)
-- **Search Google Images, News, Videos, Shopping**
-- **Get local business results** from Google Maps
-- **Scrape other search engines** (Bing, YouTube, DuckDuckGo, etc.)
-- **Monitor SERP rankings** for SEO analysis
-
----
-
-## Prerequisites
-
-Connect the **SerpApi** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SERPAPI_TOKEN` or `zero doctor check-connector --url https://serpapi.com/search --method GET`
+If requests fail, run `zero doctor check-connector --env-name SERPAPI_TOKEN` or `zero doctor check-connector --url https://serpapi.com/search --method GET`
 
 ## How to Use
 
 All examples below assume you have `SERPAPI_TOKEN` set.
 
 Base URL: `https://serpapi.com/search`
-
----
 
 ### 1. Basic Google Search
 
@@ -45,8 +21,6 @@ Search Google and get structured JSON results:
 ```bash
 curl -s "https://serpapi.com/search?engine=google&q=artificial+intelligence&api_key=$SERPAPI_TOKEN" | jq '.organic_results[:3] | .[] | {title, link, snippet}'
 ```
-
----
 
 ### 2. Search with Location
 
@@ -61,8 +35,6 @@ curl -s "https://serpapi.com/search?engine=google&q=best+coffee+shops&location=S
 - `gl`: Country code (us, uk, de, etc.)
 - `hl`: Language code (en, de, fr, etc.)
 
----
-
 ### 3. Google Image Search
 
 Search for images:
@@ -70,8 +42,6 @@ Search for images:
 ```bash
 curl -s "https://serpapi.com/search?engine=google_images&q=sunset+beach&api_key=$SERPAPI_TOKEN" | jq '.images_results[:3] | .[] | {title, original, thumbnail}'
 ```
-
----
 
 ### 4. Google News Search
 
@@ -81,8 +51,6 @@ Search news articles:
 curl -s "https://serpapi.com/search?engine=google_news&q=technology&api_key=$SERPAPI_TOKEN" | jq '.news_results[:3] | .[] | {title, link, source, date}'
 ```
 
----
-
 ### 5. Google Shopping Search
 
 Search products:
@@ -91,8 +59,6 @@ Search products:
 curl -s "https://serpapi.com/search?engine=google_shopping&q=wireless+headphones&api_key=$SERPAPI_TOKEN" | jq '.shopping_results[:3] | .[] | {title, price, source}'
 ```
 
----
-
 ### 6. YouTube Search
 
 Search YouTube videos:
@@ -100,8 +66,6 @@ Search YouTube videos:
 ```bash
 curl -s "https://serpapi.com/search?engine=youtube&search_query=python+tutorial&api_key=$SERPAPI_TOKEN" | jq '.video_results[:3] | .[] | {title, link, channel, views}'
 ```
-
----
 
 ### 7. Google Maps / Local Results
 
@@ -127,8 +91,6 @@ curl -s "https://serpapi.com/search?engine=google_maps&q=3PL&ll=@32.7767,-96.797
 **Parameters:**
 - `ll`: Latitude, longitude, and zoom level (e.g., `@40.7128,-74.0060,15z`)
 
----
-
 ### 8. Pagination
 
 Get more results using the `start` parameter:
@@ -141,8 +103,6 @@ curl -s "https://serpapi.com/search?engine=google&q=machine+learning&start=0&api
 curl -s "https://serpapi.com/search?engine=google&q=machine+learning&start=10&api_key=$SERPAPI_TOKEN" | jq '.organic_results | length'
 ```
 
----
-
 ### 9. Check Account Info
 
 Check your API usage and credits:
@@ -150,8 +110,6 @@ Check your API usage and credits:
 ```bash
 curl -s "https://serpapi.com/account?api_key=$SERPAPI_TOKEN" | jq '{plan_name, searches_per_month, this_month_usage}'
 ```
-
----
 
 ## Supported Engines
 
@@ -166,8 +124,6 @@ curl -s "https://serpapi.com/account?api_key=$SERPAPI_TOKEN" | jq '{plan_name, s
 | Bing | `engine=bing` | Bing web search |
 | DuckDuckGo | `engine=duckduckgo` | Privacy-focused search |
 
----
-
 ## Common Parameters
 
 | Parameter | Description |
@@ -181,8 +137,6 @@ curl -s "https://serpapi.com/account?api_key=$SERPAPI_TOKEN" | jq '{plan_name, s
 | `num` | Number of results (max 100) |
 | `safe` | Safe search (`active` or `off`) |
 | `device` | Device type (`desktop`, `mobile`, `tablet`) |
-
----
 
 ## Guidelines
 

--- a/shortio/SKILL.md
+++ b/shortio/SKILL.md
@@ -4,39 +4,15 @@ description: Short.io API for link shortening. Use when user mentions "Short.io"
   "link shortener", "short URL", or URL management.
 ---
 
-# Short.io
+## Troubleshooting
 
-Use Short.io via direct `curl` calls to **create and manage short links** on your branded domain.
-
-> Official docs: `https://developers.short.io/docs`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Create short links** from long URLs
-- **Customize link slugs** (paths) for branded URLs
-- **Track link clicks** and analytics
-- **Manage multiple links** (list, update, delete)
-- **Set link expiration** using TTL (time-to-live)
-
----
-
-## Prerequisites
-
-Connect the **Short.io** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SHORTIO_TOKEN` or `zero doctor check-connector --url https://api.short.io/links --method GET`
+If requests fail, run `zero doctor check-connector --env-name SHORTIO_TOKEN` or `zero doctor check-connector --url https://api.short.io/links --method GET`
 
 ## How to Use
 
 All examples below assume you have `SHORTIO_TOKEN` and `SHORTIO_DOMAIN` set.
 
 Base URL: `https://api.short.io`
-
----
 
 ### 1. Create a Short Link
 
@@ -56,8 +32,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.short.io/links" --header "Authorization: $SHORTIO_TOKEN" --header "Content-Type: application/json" --header "Accept: application/json" -d @/tmp/shortio_request.json | jq '{shortURL, originalURL, path, idString}'
 ```
-
----
 
 ### 2. Create with Custom Slug
 
@@ -79,8 +53,6 @@ Then run:
 curl -s -X POST "https://api.short.io/links" --header "Authorization: $SHORTIO_TOKEN" --header "Content-Type: application/json" --header "Accept: application/json" -d @/tmp/shortio_request.json | jq '{shortURL, originalURL, path, idString}'
 ```
 
----
-
 ### 3. Create with TTL (Expiration)
 
 Create a link that expires after a specified time (in ISO 8601 format):
@@ -101,8 +73,6 @@ Then run:
 curl -s -X POST "https://api.short.io/links" --header "Authorization: $SHORTIO_TOKEN" --header "Content-Type: application/json" --header "Accept: application/json" -d @/tmp/shortio_request.json | jq '{shortURL, originalURL, ttl}'
 ```
 
----
-
 ### 4. Get Link Info by Path
 
 Get details of a short link using domain and path:
@@ -110,8 +80,6 @@ Get details of a short link using domain and path:
 ```bash
 curl -s -X GET "https://api.short.io/links/expand?domain=$SHORTIO_DOMAIN&path=my-custom-slug" --header "Authorization: $SHORTIO_TOKEN" --header "Accept: application/json" | jq '{originalURL, shortURL, path, idString, createdAt, cloaking}'
 ```
-
----
 
 ### 5. Get Link Info by ID
 
@@ -123,8 +91,6 @@ LINK_ID="lnk_abc123xyz"
 curl -s -X GET "https://api.short.io/links/${LINK_ID}" --header "Authorization: $SHORTIO_TOKEN" --header "Accept: application/json" | jq '{originalURL, shortURL, path, idString, createdAt}'
 ```
 
----
-
 ### 6. List All Links
 
 Get a list of links for a domain (max 150 per request):
@@ -132,8 +98,6 @@ Get a list of links for a domain (max 150 per request):
 ```bash
 curl -s -X GET "https://api.short.io/api/links?domain_id=$SHORTIO_DOMAIN_ID&limit=20" --header "Authorization: $SHORTIO_TOKEN" --header "Accept: application/json" | jq '{count, links: [.links[] | {shortURL, originalURL, path, idString}]}'
 ```
-
----
 
 ### 7. Update a Link
 
@@ -158,8 +122,6 @@ Then run:
 curl -s -X POST "https://api.short.io/links/${LINK_ID}" --header "Authorization: $SHORTIO_TOKEN" --header "Content-Type: application/json" --header "Accept: application/json" -d @/tmp/shortio_request.json | jq '{shortURL, originalURL, path, idString}'
 ```
 
----
-
 ### 8. Delete a Link
 
 Delete a short link by ID:
@@ -170,8 +132,6 @@ LINK_ID="lnk_abc123xyz"
 curl -s -X DELETE "https://api.short.io/links/${LINK_ID}" --header "Authorization: $SHORTIO_TOKEN" --header "Accept: application/json" | jq '{success, idString}'
 ```
 
----
-
 ### 9. List Domains
 
 Get all domains associated with your account:
@@ -180,8 +140,6 @@ Get all domains associated with your account:
 curl -s -X GET "https://api.short.io/api/domains" --header "Authorization: $SHORTIO_TOKEN" --header "Accept: application/json" | jq '.[] | {id, hostname, state, linkType}'
 ```
 
----
-
 ### 10. Get Link Click Statistics
 
 Get click counts for specific links:
@@ -189,8 +147,6 @@ Get click counts for specific links:
 ```bash
 curl -s -X GET "https://api.short.io/domains/$SHORTIO_DOMAIN_ID/link_clicks?link_ids=${LINK_ID}" --header "Authorization: $SHORTIO_TOKEN" --header "Accept: application/json" | jq '{linkId: .linkId, clicks}'
 ```
-
----
 
 ## Create Link Parameters
 
@@ -207,8 +163,6 @@ curl -s -X GET "https://api.short.io/domains/$SHORTIO_DOMAIN_ID/link_clicks?link
 | `expiresAt` | string | No | Redirect URL when link expires |
 | `tags` | array | No | Tags for categorization |
 
----
-
 ## Response Fields
 
 | Field | Description |
@@ -222,8 +176,6 @@ curl -s -X GET "https://api.short.io/domains/$SHORTIO_DOMAIN_ID/link_clicks?link
 | `createdAt` | Creation timestamp |
 | `cloaking` | Whether cloaking is enabled |
 | `hasPassword` | Whether link is password protected |
-
----
 
 ## Guidelines
 

--- a/similarweb/SKILL.md
+++ b/similarweb/SKILL.md
@@ -4,25 +4,9 @@ description: Similarweb API for web analytics. Use when user mentions "Similarwe
   "website traffic", "competitor analysis", or market intelligence.
 ---
 
-# SimilarWeb API
+## Troubleshooting
 
-Analyze website traffic, engagement metrics, traffic sources, keywords, and competitive intelligence.
-
-> Official docs: `https://developers.similarweb.com/docs/getting-started`
-
-## When to Use
-
-- Analyze website traffic and engagement metrics (visits, bounce rate, pages per visit)
-- Break down traffic sources (search, social, referral, direct, display, mail)
-- Research organic and paid keywords driving traffic to a website
-- Find competitors and similar websites
-- Check API capabilities and remaining credits
-
-## Prerequisites
-
-Connect the **SimilarWeb** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SIMILARWEB_TOKEN` or `zero doctor check-connector --url https://api.similarweb.com/capabilities --method GET`
+If requests fail, run `zero doctor check-connector --env-name SIMILARWEB_TOKEN` or `zero doctor check-connector --url https://api.similarweb.com/capabilities --method GET`
 
 ## Core APIs
 

--- a/slack-webhook/SKILL.md
+++ b/slack-webhook/SKILL.md
@@ -4,20 +4,6 @@ description: Slack Webhook for posting messages. Use when user says "post to Sla
   "Slack webhook", or "send Slack notification".
 ---
 
-# Slack Incoming Webhook
-
-Send messages to a Slack channel using Incoming Webhooks. No OAuth or bot setup required.
-
-## When to Use
-
-- Send notifications to a specific channel
-- CI/CD notifications, alerts, status updates
-- Quick integration without full Slack app setup
-
-## Prerequisites
-
-Connect the **Slack Incoming Webhook** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Usage
 
 ### Simple Message

--- a/slack/SKILL.md
+++ b/slack/SKILL.md
@@ -5,35 +5,9 @@ description: Slack API for messages and channels. Use when user mentions "Slack"
   workspace.
 ---
 
-# Slack API
+## Troubleshooting
 
-Send messages, manage channels, search content, and interact with Slack workspaces via the Web API.
-
-> Official docs: https://docs.slack.dev/reference/methods
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Send, update, schedule, and delete messages
-- Read channel history and thread replies
-- Create, archive, and manage channels
-- Search messages, files, and content
-- Upload and manage files
-- List and manage users and user groups
-- Add and remove reactions, pins, and bookmarks
-- Manage reminders
-- View workspace and team info
-
----
-
-## Prerequisites
-
-Connect the **Slack** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SLACK_TOKEN` or `zero doctor check-connector --url https://slack.com/api/chat.postMessage --method POST`
+If requests fail, run `zero doctor check-connector --env-name SLACK_TOKEN` or `zero doctor check-connector --url https://slack.com/api/chat.postMessage --method POST`
 
 ## Messages
 
@@ -130,8 +104,6 @@ curl -s -X POST "https://slack.com/api/chat.postEphemeral" \
 curl -s "https://slack.com/api/chat.getPermalink?channel=<channel-id>&message_ts=<message-ts>" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
-
----
 
 ## Channels (Conversations)
 
@@ -286,8 +258,6 @@ curl -s -X POST "https://slack.com/api/conversations.open" \
 
 Returns a channel ID for the DM. Use multiple comma-separated user IDs for group DM.
 
----
-
 ## Users
 
 ### List Users
@@ -345,8 +315,6 @@ curl -s "https://slack.com/api/users.conversations?user=<user-id>&types=public_c
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
 
----
-
 ## Search
 
 ### Search Messages
@@ -371,8 +339,6 @@ curl -s "https://slack.com/api/search.files?query=presentation&count=20" \
 curl -s "https://slack.com/api/search.all?query=project%20update&count=20" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
-
----
 
 ## Files
 
@@ -431,8 +397,6 @@ curl -s -X POST "https://slack.com/api/files.delete" \
   -d "{\"file\": \"<file-id>\"}"
 ```
 
----
-
 ## Reactions
 
 ### Add Reaction
@@ -467,8 +431,6 @@ curl -s "https://slack.com/api/reactions.list?user=<user-id>&count=20" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
 
----
-
 ## Pins
 
 ### Pin a Message
@@ -495,8 +457,6 @@ curl -s -X POST "https://slack.com/api/pins.remove" \
 curl -s "https://slack.com/api/pins.list?channel=<channel-id>" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
-
----
 
 ## Bookmarks
 
@@ -526,8 +486,6 @@ curl -s -X POST "https://slack.com/api/bookmarks.remove" \
   --header "Content-Type: application/json" \
   -d "{\"channel_id\": \"<channel-id>\", \"bookmark_id\": \"<bookmark-id>\"}"
 ```
-
----
 
 ## User Groups
 
@@ -562,8 +520,6 @@ curl -s -X POST "https://slack.com/api/usergroups.users.update" \
 curl -s "https://slack.com/api/usergroups.users.list?usergroup=<usergroup-id>" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
-
----
 
 ## Reminders
 
@@ -603,8 +559,6 @@ curl -s -X POST "https://slack.com/api/reminders.delete" \
   -d "{\"reminder\": \"<reminder-id>\"}"
 ```
 
----
-
 ## Do Not Disturb
 
 ### Get DND Status
@@ -628,8 +582,6 @@ curl -s -X POST "https://slack.com/api/dnd.endDnd" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
 
----
-
 ## Emoji
 
 ### List Custom Emoji
@@ -638,8 +590,6 @@ curl -s -X POST "https://slack.com/api/dnd.endDnd" \
 curl -s "https://slack.com/api/emoji.list" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
-
----
 
 ## Team Info
 
@@ -657,8 +607,6 @@ curl -s "https://slack.com/api/team.profile.get" \
   --header "Authorization: Bearer $SLACK_TOKEN"
 ```
 
----
-
 ## Auth
 
 ### Test Token
@@ -669,8 +617,6 @@ curl -s -X POST "https://slack.com/api/auth.test" \
 ```
 
 Returns workspace, user, and bot info for the token. Useful for verifying connectivity and discovering the bot's user ID.
-
----
 
 ## Guidelines
 
@@ -685,8 +631,6 @@ Returns workspace, user, and bot info for the token. Useful for verifying connec
 9. **User IDs**: Users are identified by IDs like `U1234567890`. Use `users.lookupByEmail` to find a user by email.
 10. **File uploads**: The legacy `files.upload` still works but is deprecated. Prefer the two-step flow: `files.getUploadURLExternal` → upload → `files.completeUploadExternal`.
 
----
-
 ## Message Formatting
 
 | Syntax | Result |
@@ -700,8 +644,6 @@ Returns workspace, user, and bot info for the token. Useful for verifying connec
 | `<#C123>` | #channel link |
 | `<!here>` | @here |
 | `<!channel>` | @channel |
-
----
 
 ## Admin API (Enterprise Grid Only)
 
@@ -720,8 +662,6 @@ The `admin.*` methods (100+ endpoints) are only available on Slack Enterprise Gr
 - **admin.audit** — access audit logs
 
 > **Note:** These methods require Enterprise Grid admin tokens with `admin.*` scopes. They will return `missing_scope` or `not_allowed` errors on non-Enterprise workspaces. See docs for details.
-
----
 
 ## How to Look Up More API Details
 

--- a/spotify/SKILL.md
+++ b/spotify/SKILL.md
@@ -3,32 +3,9 @@ name: spotify
 description: Spotify Web API for music streaming. Use when user mentions "Spotify", "play music", "Spotify playlist", "top tracks", "now playing", "Spotify artist", or asks about music playback or library.
 ---
 
-# Spotify Web API
+## Troubleshooting
 
-Access Spotify's music catalog, manage playlists, control playback, and retrieve personalized listening data via the Spotify Web API.
-
-> Official docs: `https://developer.spotify.com/documentation/web-api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Search for tracks, albums, artists, or playlists
-- Get current user profile and listening stats
-- Retrieve the user's top tracks and artists
-- List and manage playlists
-- Control music playback (requires Spotify Premium)
-- Get currently playing track or recent listening history
-
----
-
-## Prerequisites
-
-Connect the **Spotify** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SPOTIFY_TOKEN` or `zero doctor check-connector --url https://api.spotify.com/v1/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name SPOTIFY_TOKEN` or `zero doctor check-connector --url https://api.spotify.com/v1/me --method GET`
 
 ## User Profile
 
@@ -37,8 +14,6 @@ Connect the **Spotify** connector at [app.vm0.ai/connectors](https://app.vm0.ai/
 ```bash
 curl -s "https://api.spotify.com/v1/me" --header "Authorization: Bearer $SPOTIFY_TOKEN" | jq '{id, display_name, email, product, followers: .followers.total}'
 ```
-
----
 
 ## Search
 
@@ -58,8 +33,6 @@ To search for playlists only:
 ```bash
 curl -s -G "https://api.spotify.com/v1/search" --header "Authorization: Bearer $SPOTIFY_TOKEN" --data-urlencode "q@/tmp/spotify_query.txt" --data-urlencode "type=playlist" -d "limit=5" | jq '[.playlists.items[]? | {id, name, owner: .owner.display_name, tracks: .tracks.total, uri}]'
 ```
-
----
 
 ## Personalized Data
 
@@ -88,8 +61,6 @@ Requires scope: `user-read-recently-played`.
 ```bash
 curl -s "https://api.spotify.com/v1/me/player/recently-played?limit=20" --header "Authorization: Bearer $SPOTIFY_TOKEN" | jq '[.items[] | {played_at, track: .track.name, artists: [.track.artists[].name], uri: .track.uri}]'
 ```
-
----
 
 ## Playlists
 
@@ -153,8 +124,6 @@ Replace `<playlist-id>` with the target playlist ID:
 ```bash
 curl -s -X POST "https://api.spotify.com/v1/playlists/<playlist-id>/tracks" --header "Authorization: Bearer $SPOTIFY_TOKEN" --header "Content-Type: application/json" -d @/tmp/spotify_add_tracks.json | jq '{snapshot_id}'
 ```
-
----
 
 ## Playback Control
 
@@ -233,8 +202,6 @@ Requires scope: `user-modify-playback-state`. Replace `<volume>` with a value be
 curl -s -X PUT "https://api.spotify.com/v1/me/player/volume?volume_percent=<volume>" --header "Authorization: Bearer $SPOTIFY_TOKEN"
 ```
 
----
-
 ## Albums & Artists
 
 ### Get Album
@@ -260,8 +227,6 @@ Replace `<artist-id>` with the Spotify artist ID:
 ```bash
 curl -s "https://api.spotify.com/v1/artists/<artist-id>/top-tracks" --header "Authorization: Bearer $SPOTIFY_TOKEN" | jq '[.tracks[] | {name, album: .album.name, popularity, uri}]'
 ```
-
----
 
 ## Guidelines
 

--- a/sql-cookbook/SKILL.md
+++ b/sql-cookbook/SKILL.md
@@ -3,14 +3,6 @@ name: sql-cookbook
 description: Craft and optimize SQL for any warehouse dialect — Snowflake, BigQuery, Databricks, Redshift, PostgreSQL. Covers window functions, CTEs, aggregations, joins, funnel queries, cohort retention, deduplication, dialect translation, slow query tuning, and cross-platform syntax differences.
 ---
 
-# SQL Cookbook
-
-Practical reference for building analytical SQL across every major data warehouse platform.
-
-## Prerequisites
-
-Connect the **SQL Cookbook** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Platform-Specific Syntax Guide
 
 ### PostgreSQL (Aurora, RDS, Supabase, Neon)
@@ -71,8 +63,6 @@ arr_col @> ARRAY['val']
 - Consider partial indexes for frequently used filter predicates
 - Deploy connection pooling when handling concurrent workloads
 
----
-
 ### Snowflake
 
 **Date and time functions:**
@@ -132,8 +122,6 @@ LATERAL FLATTEN(input => t.payload:items) elem
 - Reuse results via `RESULT_SCAN(LAST_QUERY_ID())` to skip re-execution
 - Use transient tables for ephemeral staging data
 
----
-
 ### BigQuery
 
 **Date and time functions:**
@@ -192,8 +180,6 @@ struct_col.field_name
 - Use `DECLARE` / `SET` for parameterized script logic
 - Run a dry-run estimate before executing expensive queries
 
----
-
 ### Redshift
 
 **Date and time functions:**
@@ -231,8 +217,6 @@ LISTAGG(col, ', ') WITHIN GROUP (ORDER BY col)
 - Watch for DS_BCAST and DS_DIST in plans (signs of costly cross-node shuffles)
 - Run `ANALYZE` and `VACUUM` on a regular cadence
 - Use late-binding views for flexibility when schemas evolve
-
----
 
 ### Databricks SQL
 
@@ -276,8 +260,6 @@ WHEN NOT MATCHED THEN INSERT *
 - Enable the Photon engine for compute-heavy workloads
 - Apply `CACHE TABLE` on datasets that are read repeatedly
 - Partition by low-cardinality date columns for efficient pruning
-
----
 
 ## Reusable Analytical Patterns
 

--- a/stats-methods/SKILL.md
+++ b/stats-methods/SKILL.md
@@ -3,14 +3,6 @@ name: stats-methods
 description: Apply statistical techniques to data — descriptive statistics, distributions, hypothesis testing, A/B test evaluation, outlier detection, trend analysis, correlation, forecasting, p-values, confidence intervals, significance testing, and avoiding common statistical pitfalls like Simpson's paradox and survivorship bias.
 ---
 
-# Statistical Methods
-
-A practitioner's guide to applying statistics in data analysis, from summarizing distributions through testing hypotheses and spotting analytical traps.
-
-## Prerequisites
-
-Connect the **Statistical Methods** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Summarizing Numeric Data
 
 ### Choosing a Center Metric

--- a/status-updates/SKILL.md
+++ b/status-updates/SKILL.md
@@ -3,14 +3,6 @@ name: status-updates
 description: Draft clear status updates, progress reports, and stakeholder communications for any audience — executives, engineering teams, cross-functional partners, or customers. Trigger on requests for weekly updates, monthly reports, launch announcements, project status emails, risk escalations, decision records (ADRs), meeting agendas, sprint retrospectives, or any structured team communication.
 ---
 
-# Status Updates
-
-Expert guidance for crafting project updates, managing stakeholder communications, documenting decisions, surfacing risks, and running productive meetings across product and engineering teams.
-
-## Prerequisites
-
-Connect the **Status Updates** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## Audience-Specific Update Formats
 
 ### Leadership / Executive Updates
@@ -177,21 +169,26 @@ Record significant decisions for institutional memory:
 # [Decision Title]
 
 ## Status
+
 [Proposed / Accepted / Deprecated / Superseded by ADR-XXX]
 
 ## Situation
+
 What circumstances necessitate this decision? What constraints and pressures exist?
 
 ## Resolution
+
 What was decided? State the choice clearly and unambiguously.
 
 ## Tradeoffs
+
 What follows from this decision?
 - Benefits gained
 - Downsides or compromises accepted
 - Future possibilities opened or closed
 
 ## Options Evaluated
+
 What alternatives were considered?
 For each: a brief description and the reason it was not chosen.
 ```

--- a/strapi/SKILL.md
+++ b/strapi/SKILL.md
@@ -7,30 +7,9 @@ vm0_env:
   - STRAPI_BASE_URL
 ---
 
-# Strapi CMS API
+## Troubleshooting
 
-Use the Strapi REST API via direct `curl` calls to **manage content types, entries, and media** on your Strapi instance.
-
-> Official docs: `https://docs.strapi.io/cms/api/rest`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage content entries** — create, read, update, delete entries in any content type
-- **Query and filter content** — search, sort, paginate, and filter entries
-- **Upload media** — upload files and images to the Strapi media library
-- **Discover schema** — find out what content types exist and their fields
-
----
-
-## Prerequisites
-
-Connect the **Strapi** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name STRAPI_TOKEN` or `zero doctor check-connector --url https://docs.strapi.io/cms/api/rest --method GET`
+If requests fail, run `zero doctor check-connector --env-name STRAPI_TOKEN` or `zero doctor check-connector --url https://docs.strapi.io/cms/api/rest --method GET`
 
 ## IMPORTANT: Discovery Workflow
 
@@ -61,8 +40,6 @@ If unsure, check the content type info from Step 1 — the `uid` follows the pat
 ### Step 3: Proceed with Operations
 
 Once you know the content types and their fields, proceed with the appropriate CRUD operations below.
-
----
 
 ## Collection Types (Multiple Entries)
 
@@ -156,8 +133,6 @@ curl -s -X DELETE "$STRAPI_BASE_URL/api/PLURAL_API_ID/DOCUMENT_ID" \
   --header "Authorization: Bearer $STRAPI_TOKEN" | jq .
 ```
 
----
-
 ## Single Types (One Entry)
 
 ### Get Single Type
@@ -192,8 +167,6 @@ curl -s -X PUT "$STRAPI_BASE_URL/api/SINGULAR_API_ID" \
   -d @/tmp/strapi_request.json | jq .
 ```
 
----
-
 ## Media Upload
 
 ### Upload a File
@@ -214,8 +187,6 @@ curl -s -X POST "$STRAPI_BASE_URL/api/upload" \
   -F "refId=DOCUMENT_ID" \
   -F "field=cover" | jq .
 ```
-
----
 
 ## Filtering Reference
 
@@ -248,8 +219,6 @@ curl -s "$STRAPI_BASE_URL/api/articles?filters[\$or][0][status][\$eq]=published&
   --header "Authorization: Bearer $STRAPI_TOKEN" | jq .
 ```
 
----
-
 ## Pagination
 
 ```bash
@@ -277,8 +246,6 @@ Response includes pagination metadata:
 }
 ```
 
----
-
 ## Guidelines
 
 1. **Always discover first**: Run the content type discovery endpoint before performing operations — never guess content type names or field names
@@ -289,8 +256,6 @@ Response includes pagination metadata:
 6. **API token scope**: The operations available depend on the token type (Full Access, Read-Only, or Custom permissions per content type)
 7. **Document IDs**: Strapi v5 uses document IDs (not numeric IDs) for CRUD operations
 8. **Sort syntax**: Use `sort=field:asc` or `sort=field:desc`. Multiple sorts: `sort[0]=field1:asc&sort[1]=field2:desc`
-
----
 
 ## API Reference
 

--- a/strava/SKILL.md
+++ b/strava/SKILL.md
@@ -4,36 +4,9 @@ description: Strava API for fitness activities. Use when user mentions "Strava",
   "cycling", "activity", or asks about fitness tracking.
 ---
 
-# Strava API
+## Troubleshooting
 
-Use the Strava API v3 via `curl` to access **athlete activities, segments, clubs, gear, and routes**. Create, update, and upload activities.
-
-> Official docs: https://developers.strava.com/docs/reference/
-
----
-
-## Prerequisites
-
-Connect the **Strava** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name STRAVA_TOKEN` or `zero doctor check-connector --url https://www.strava.com/api/v3/athlete --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- Get athlete profile and statistics
-- List, search, and filter activities
-- Create manual activities or upload activity files (GPX/FIT/TCX)
-- Update activity name, description, sport type, and other metadata
-- Access activity streams (GPS, heart rate, power data)
-- View segments, clubs, gear, and routes
-
----
-
-> **Placeholders:** Values in `<angle-brackets>` like `<activity-id>` are placeholders. Replace them with actual values when executing.
-
----
+If requests fail, run `zero doctor check-connector --env-name STRAVA_TOKEN` or `zero doctor check-connector --url https://www.strava.com/api/v3/athlete --method GET`
 
 ## Athlete
 
@@ -50,8 +23,6 @@ Replace `<athlete-id>` with the `id` from the athlete profile above:
 ```bash
 curl -s "https://www.strava.com/api/v3/athletes/<athlete-id>/stats" --header "Authorization: Bearer $STRAVA_TOKEN" | jq '{recent_run_totals, recent_ride_totals, ytd_run_totals, ytd_ride_totals, all_run_totals, all_ride_totals}'
 ```
-
----
 
 ## Activities
 
@@ -122,8 +93,6 @@ curl -s -X PUT "https://www.strava.com/api/v3/activities/<activity-id>" --header
 
 Updatable fields: `name`, `sport_type`, `description`, `gear_id` (set to `"none"` to remove), `trainer`, `commute`, `hide_from_home`.
 
----
-
 ## Uploads
 
 ### Upload Activity File (GPX/FIT/TCX)
@@ -143,8 +112,6 @@ curl -s "https://www.strava.com/api/v3/uploads/<upload-id>" --header "Authorizat
 ```
 
 When `activity_id` is populated, the upload is complete.
-
----
 
 ## Activity Details
 
@@ -174,8 +141,6 @@ curl -s "https://www.strava.com/api/v3/activities/<activity-id>/streams?keys=tim
 
 Available stream keys: `time`, `distance`, `latlng`, `altitude`, `velocity_smooth`, `heartrate`, `cadence`, `watts`, `temp`, `moving`, `grade_smooth`.
 
----
-
 ## Segments
 
 ### List Starred Segments
@@ -189,8 +154,6 @@ curl -s "https://www.strava.com/api/v3/segments/starred" --header "Authorization
 ```bash
 curl -s "https://www.strava.com/api/v3/segments/<segment-id>" --header "Authorization: Bearer $STRAVA_TOKEN" | jq '{id, name, activity_type, distance, average_grade, maximum_grade, elevation_high, elevation_low, city, country, effort_count, athlete_count}'
 ```
-
----
 
 ## Gear
 
@@ -207,8 +170,6 @@ Bike IDs start with `b`, shoe IDs start with `g`:
 ```bash
 curl -s "https://www.strava.com/api/v3/gear/<gear-id>" --header "Authorization: Bearer $STRAVA_TOKEN" | jq '{id, name, brand_name, model_name, distance, converted_distance}'
 ```
-
----
 
 ## Clubs
 
@@ -230,8 +191,6 @@ curl -s "https://www.strava.com/api/v3/clubs/<club-id>" --header "Authorization:
 curl -s "https://www.strava.com/api/v3/clubs/<club-id>/activities?per_page=20" --header "Authorization: Bearer $STRAVA_TOKEN" | jq '.[] | {name, sport_type, distance, moving_time, athlete: (.athlete.firstname + " " + .athlete.lastname)}'
 ```
 
----
-
 ## Routes
 
 ### Get Athlete Routes
@@ -239,8 +198,6 @@ curl -s "https://www.strava.com/api/v3/clubs/<club-id>/activities?per_page=20" -
 ```bash
 curl -s "https://www.strava.com/api/v3/athletes/<athlete-id>/routes?per_page=20" --header "Authorization: Bearer $STRAVA_TOKEN" | jq '.[] | {id, name, type, distance, elevation_gain, estimated_moving_time}'
 ```
-
----
 
 ## Guidelines
 
@@ -252,8 +209,6 @@ curl -s "https://www.strava.com/api/v3/athletes/<athlete-id>/routes?per_page=20"
 6. **Distance units**: All distances are in **meters**, speeds in **meters/second**
 7. **Time units**: All durations are in **seconds**
 8. **Sport type vs type**: Prefer `sport_type` over deprecated `type` field
-
----
 
 ## API Reference
 

--- a/streak/SKILL.md
+++ b/streak/SKILL.md
@@ -4,31 +4,9 @@ description: Streak CRM API for Gmail. Use when user mentions "Streak", "Gmail C
   "email CRM", or pipeline in Gmail.
 ---
 
-# Streak CRM
+## Troubleshooting
 
-Streak is a CRM built entirely inside Gmail. Use this skill to manage pipelines, boxes (deals), contacts, organizations, tasks, and email threads via the Streak API.
-
-> Official docs: `https://streak.readme.io/reference`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Manage sales pipelines and deal stages
-- Track leads, contacts, and organizations
-- Associate email threads with deals
-- Create tasks and comments on deals
-- Search across boxes, contacts, and organizations
-
----
-
-## Prerequisites
-
-Connect the **Streak CRM** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name STREAK_TOKEN` or `zero doctor check-connector --url https://api.streak.com/api/v1/users/me --method GET`
+If requests fail, run `zero doctor check-connector --env-name STREAK_TOKEN` or `zero doctor check-connector --url https://api.streak.com/api/v1/users/me --method GET`
 
 ## How to Use
 
@@ -36,15 +14,11 @@ Connect the **Streak CRM** connector at [app.vm0.ai/connectors](https://app.vm0.
 
 Streak uses HTTP Basic Auth with your API key as the username and no password. In curl, use `-u "$STREAK_TOKEN:"` (note the trailing colon).
 
----
-
 ### 1. Get Current User
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/users/me" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 2. List All Pipelines
 
@@ -54,15 +28,11 @@ Pipelines represent business processes (Sales, Hiring, Projects, etc.).
 curl -s -X GET "https://api.streak.com/api/v1/pipelines" -u "$STREAK_TOKEN:"
 ```
 
----
-
 ### 3. Get a Pipeline
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/pipelines/{pipelineKey}" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 4. Create a Pipeline
 
@@ -80,8 +50,6 @@ Then run:
 curl -s -X PUT "https://api.streak.com/api/v1/pipelines" -u "$STREAK_TOKEN:" --header "Content-Type: application/json" -d @/tmp/streak_request.json
 ```
 
----
-
 ### 5. List Boxes in Pipeline
 
 Boxes are the core data objects (deals, leads, projects) within a pipeline.
@@ -90,15 +58,11 @@ Boxes are the core data objects (deals, leads, projects) within a pipeline.
 curl -s -X GET "https://api.streak.com/api/v1/pipelines/{pipelineKey}/boxes" -u "$STREAK_TOKEN:"
 ```
 
----
-
 ### 6. Get a Box
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/boxes/{boxKey}" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 7. Create a Box
 
@@ -115,8 +79,6 @@ Then run:
 ```bash
 curl -s -X POST "https://api.streak.com/api/v1/pipelines/{pipelineKey}/boxes" -u "$STREAK_TOKEN:" --header "Content-Type: application/json" -d @/tmp/streak_request.json
 ```
-
----
 
 ### 8. Update a Box
 
@@ -135,15 +97,11 @@ Then run:
 curl -s -X POST "https://api.streak.com/api/v1/boxes/{boxKey}" -u "$STREAK_TOKEN:" --header "Content-Type: application/json" -d @/tmp/streak_request.json
 ```
 
----
-
 ### 9. List Stages in Pipeline
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/pipelines/{pipelineKey}/stages" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 10. List Fields in Pipeline
 
@@ -151,15 +109,11 @@ curl -s -X GET "https://api.streak.com/api/v1/pipelines/{pipelineKey}/stages" -u
 curl -s -X GET "https://api.streak.com/api/v1/pipelines/{pipelineKey}/fields" -u "$STREAK_TOKEN:"
 ```
 
----
-
 ### 11. Get a Contact
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/contacts/{contactKey}" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 12. Create a Contact
 
@@ -180,15 +134,11 @@ Then run:
 curl -s -X POST "https://api.streak.com/api/v1/contacts" -u "$STREAK_TOKEN:" --header "Content-Type: application/json" -d @/tmp/streak_request.json
 ```
 
----
-
 ### 13. Get an Organization
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/organizations/{organizationKey}" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 14. Search Boxes, Contacts, and Organizations
 
@@ -196,15 +146,11 @@ curl -s -X GET "https://api.streak.com/api/v1/organizations/{organizationKey}" -
 curl -s -X GET "https://api.streak.com/api/v1/search?query=acme" -u "$STREAK_TOKEN:"
 ```
 
----
-
 ### 15. Get Tasks in a Box
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/boxes/{boxKey}/tasks" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 16. Create a Task
 
@@ -223,15 +169,11 @@ Then run:
 curl -s -X POST "https://api.streak.com/api/v1/boxes/{boxKey}/tasks" -u "$STREAK_TOKEN:" --header "Content-Type: application/json" -d @/tmp/streak_request.json
 ```
 
----
-
 ### 17. Get Comments in a Box
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/boxes/{boxKey}/comments" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 18. Create a Comment
 
@@ -249,8 +191,6 @@ Then run:
 curl -s -X POST "https://api.streak.com/api/v1/boxes/{boxKey}/comments" -u "$STREAK_TOKEN:" --header "Content-Type: application/json" -d @/tmp/streak_request.json
 ```
 
----
-
 ### 19. Get Threads in a Box
 
 Email threads associated with a box.
@@ -259,23 +199,17 @@ Email threads associated with a box.
 curl -s -X GET "https://api.streak.com/api/v1/boxes/{boxKey}/threads" -u "$STREAK_TOKEN:"
 ```
 
----
-
 ### 20. Get Files in a Box
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/boxes/{boxKey}/files" -u "$STREAK_TOKEN:"
 ```
 
----
-
 ### 21. Get Meetings in a Box
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/boxes/{boxKey}/meetings" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ### 22. Create a Meeting Note
 
@@ -295,15 +229,11 @@ Then run:
 curl -s -X POST "https://api.streak.com/api/v1/boxes/{boxKey}/meetings" -u "$STREAK_TOKEN:" --header "Content-Type: application/json" -d @/tmp/streak_request.json
 ```
 
----
-
 ### 23. Get Box Timeline
 
 ```bash
 curl -s -X GET "https://api.streak.com/api/v1/boxes/{boxKey}/timeline" -u "$STREAK_TOKEN:"
 ```
-
----
 
 ## Guidelines
 

--- a/stripe/SKILL.md
+++ b/stripe/SKILL.md
@@ -4,26 +4,9 @@ description: Stripe API for payments. Use when user mentions "Stripe", "payment"
   "subscription", "billing", "invoice", or asks about payment processing.
 ---
 
-# Stripe API
+## Troubleshooting
 
-Manage payments, customers, subscriptions, and billing with the Stripe API.
-
-> Official docs: `https://docs.stripe.com/api`
-
-## Prerequisites
-
-Connect the **Stripe** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name STRIPE_TOKEN` or `zero doctor check-connector --url https://api.stripe.com/v1/account --method GET`
-
-## When to Use
-
-- Manage customers (create, update, list, delete)
-- Create products and prices for billing
-- Manage subscriptions and invoices
-- Create and track payment intents
-- View account balance and transactions
-- List charges and events
+If requests fail, run `zero doctor check-connector --env-name STRIPE_TOKEN` or `zero doctor check-connector --url https://api.stripe.com/v1/account --method GET`
 
 ## Important: Stripe Uses Form-Encoded Bodies
 
@@ -38,8 +21,6 @@ curl -s -u "$STRIPE_TOKEN:" "https://api.stripe.com/v1/account" | jq '{id, busin
 ```
 
 Docs: https://docs.stripe.com/api/accounts/retrieve
-
----
 
 ### List Customers
 
@@ -89,8 +70,6 @@ curl -s -u "$STRIPE_TOKEN:" -X DELETE "https://api.stripe.com/v1/customers/<cust
 
 Docs: https://docs.stripe.com/api/customers/delete
 
----
-
 ### List Products
 
 ```bash
@@ -119,8 +98,6 @@ curl -s -u "$STRIPE_TOKEN:" -X POST "https://api.stripe.com/v1/products" -d @/tm
 
 Docs: https://docs.stripe.com/api/products/create
 
----
-
 ### List Prices
 
 ```bash
@@ -142,8 +119,6 @@ curl -s -u "$STRIPE_TOKEN:" -X POST "https://api.stripe.com/v1/prices" -d @/tmp/
 ```
 
 Docs: https://docs.stripe.com/api/prices/create
-
----
 
 ### List Subscriptions
 
@@ -181,8 +156,6 @@ curl -s -u "$STRIPE_TOKEN:" -X DELETE "https://api.stripe.com/v1/subscriptions/<
 
 Docs: https://docs.stripe.com/api/subscriptions/cancel
 
----
-
 ### List Invoices
 
 ```bash
@@ -196,8 +169,6 @@ Docs: https://docs.stripe.com/api/invoices/list
 ```bash
 curl -s -u "$STRIPE_TOKEN:" "https://api.stripe.com/v1/invoices/<invoice-id>" | jq '{id, customer, status, amount_due, amount_paid}'
 ```
-
----
 
 ### List Payment Intents
 
@@ -227,8 +198,6 @@ Docs: https://docs.stripe.com/api/payment_intents/create
 curl -s -u "$STRIPE_TOKEN:" "https://api.stripe.com/v1/payment_intents/<payment-intent-id>" | jq '{id, amount, currency, status}'
 ```
 
----
-
 ### List Charges
 
 ```bash
@@ -242,8 +211,6 @@ Docs: https://docs.stripe.com/api/charges/list
 ```bash
 curl -s -u "$STRIPE_TOKEN:" "https://api.stripe.com/v1/charges/<charge-id>" | jq '{id, amount, currency, status, paid}'
 ```
-
----
 
 ### Get Balance
 
@@ -260,8 +227,6 @@ curl -s -u "$STRIPE_TOKEN:" "https://api.stripe.com/v1/balance_transactions?limi
 ```
 
 Docs: https://docs.stripe.com/api/balance_transactions/list
-
----
 
 ### List Events
 

--- a/supabase/SKILL.md
+++ b/supabase/SKILL.md
@@ -5,42 +5,15 @@ description: Supabase API for Postgres and auth. Use when user mentions "Supabas
   project.
 ---
 
-# Supabase REST API
+## Troubleshooting
 
-Use the Supabase REST API via direct `curl` calls to **perform database CRUD operations**.
-
-Supabase auto-generates a RESTful API from your PostgreSQL database schema using [PostgREST](https://postgrest.org/).
-
-> Official docs: `https://supabase.com/docs/guides/api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Read data** from Supabase tables with filtering and pagination
-- **Insert rows** into tables (single or bulk)
-- **Update rows** based on conditions
-- **Delete rows** from tables
-- **Upsert data** (insert or update)
-- **Query with complex filters** using PostgREST operators
-
----
-
-## Prerequisites
-
-Connect the **Supabase** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SUPABASE_PUBLISHABLE_KEY` or `zero doctor check-connector --url https://your-project.supabase.co/rest/v1/ --method GET`
+If requests fail, run `zero doctor check-connector --env-name SUPABASE_PUBLISHABLE_KEY` or `zero doctor check-connector --url https://your-project.supabase.co/rest/v1/ --method GET`
 
 ## How to Use
 
 Base URL: `${SUPABASE_URL}/rest/v1`
 
 All requests require the `apikey` header with your API key.
-
----
 
 ### 1. Read All Rows
 
@@ -50,8 +23,6 @@ Get all rows from a table:
 curl -s "$SUPABASE_URL/rest/v1/users?select=*" -H "apikey: $SUPABASE_PUBLISHABLE_KEY"
 ```
 
----
-
 ### 2. Select Specific Columns
 
 Get only specific columns:
@@ -59,8 +30,6 @@ Get only specific columns:
 ```bash
 curl -s "$SUPABASE_URL/rest/v1/users?select=id,name,email" -H "apikey: $SUPABASE_PUBLISHABLE_KEY"
 ```
-
----
 
 ### 3. Filter with Operators
 
@@ -99,8 +68,6 @@ curl -s "$SUPABASE_URL/rest/v1/users?age=gte.18&status=eq.active" -H "apikey: $S
 | `in` | In list | `?id=in.(1,2,3)` |
 | `is` | Is null/true/false | `?deleted_at=is.null` |
 
----
-
 ### 4. OR Conditions
 
 Use `or` for OR logic:
@@ -108,8 +75,6 @@ Use `or` for OR logic:
 ```bash
 curl -s "$SUPABASE_URL/rest/v1/users?or=(status.eq.active,status.eq.pending)" -H "apikey: $SUPABASE_PUBLISHABLE_KEY"
 ```
-
----
 
 ### 5. Ordering
 
@@ -133,8 +98,6 @@ curl -s "$SUPABASE_URL/rest/v1/users?order=created_at.desc" -H "apikey: $SUPABAS
 curl -s "$SUPABASE_URL/rest/v1/users?order=status.asc,created_at.desc" -H "apikey: $SUPABASE_PUBLISHABLE_KEY"
 ```
 
----
-
 ### 6. Pagination
 
 Use `limit` and `offset`.
@@ -151,8 +114,6 @@ curl -s "$SUPABASE_URL/rest/v1/users?limit=10" -H "apikey: $SUPABASE_PUBLISHABLE
 curl -s "$SUPABASE_URL/rest/v1/users?limit=10&offset=10" -H "apikey: $SUPABASE_PUBLISHABLE_KEY"
 ```
 
----
-
 ### 7. Get Row Count
 
 Use `Prefer: count=exact` header:
@@ -160,8 +121,6 @@ Use `Prefer: count=exact` header:
 ```bash
 curl -s "$SUPABASE_URL/rest/v1/users?select=*" -H "apikey: $SUPABASE_PUBLISHABLE_KEY" -H "Prefer: count=exact" -I | grep -i "content-range"
 ```
-
----
 
 ### 8. Insert Single Row
 
@@ -180,8 +139,6 @@ Then run:
 curl -s -X POST "$SUPABASE_URL/rest/v1/users" -H "apikey: $SUPABASE_TOKEN" -H "Content-Type: application/json" -H "Prefer: return=representation" -d @/tmp/supabase_request.json
 ```
 
----
-
 ### 9. Insert Multiple Rows
 
 Write to `/tmp/supabase_request.json`:
@@ -198,8 +155,6 @@ Then run:
 ```bash
 curl -s -X POST "$SUPABASE_URL/rest/v1/users" -H "apikey: $SUPABASE_TOKEN" -H "Content-Type: application/json" -H "Prefer: return=representation" -d @/tmp/supabase_request.json
 ```
-
----
 
 ### 10. Update Rows
 
@@ -218,8 +173,6 @@ Then run:
 ```bash
 curl -s -X PATCH "$SUPABASE_URL/rest/v1/users?id=eq.1" -H "apikey: $SUPABASE_TOKEN" -H "Content-Type: application/json" -H "Prefer: return=representation" -d @/tmp/supabase_request.json
 ```
-
----
 
 ### 11. Upsert (Insert or Update)
 
@@ -241,8 +194,6 @@ Then run:
 curl -s -X POST "$SUPABASE_URL/rest/v1/users" -H "apikey: $SUPABASE_TOKEN" -H "Content-Type: application/json" -H "Prefer: resolution=merge-duplicates,return=representation" -d @/tmp/supabase_request.json
 ```
 
----
-
 ### 12. Delete Rows
 
 Delete rows matching a filter:
@@ -250,8 +201,6 @@ Delete rows matching a filter:
 ```bash
 curl -s -X DELETE "$SUPABASE_URL/rest/v1/users?id=eq.1" -H "apikey: $SUPABASE_TOKEN" -H "Prefer: return=representation"
 ```
-
----
 
 ### 13. Query Related Tables
 
@@ -269,8 +218,6 @@ curl -s "$SUPABASE_URL/rest/v1/posts?select=*,author:users(*)" -H "apikey: $SUPA
 curl -s "$SUPABASE_URL/rest/v1/users?select=*,posts(*)" -H "apikey: $SUPABASE_PUBLISHABLE_KEY"
 ```
 
----
-
 ### 14. Full-Text Search
 
 Search text columns:
@@ -278,8 +225,6 @@ Search text columns:
 ```bash
 curl -s "$SUPABASE_URL/rest/v1/posts?title=fts.hello" -H "apikey: $SUPABASE_PUBLISHABLE_KEY"
 ```
-
----
 
 ### 15. Call RPC Functions
 
@@ -299,16 +244,12 @@ Then run:
 curl -s -X POST "$SUPABASE_URL/rest/v1/rpc/my_function" -H "apikey: $SUPABASE_TOKEN" -H "Content-Type: application/json" -d @/tmp/supabase_request.json
 ```
 
----
-
 ## Response Headers
 
 | Header | Description |
 |--------|-------------|
 | `Content-Range` | Row range and total count (e.g., `0-9/100`) |
 | `Preference-Applied` | Confirms applied preferences |
-
----
 
 ## Guidelines
 
@@ -319,8 +260,6 @@ curl -s -X POST "$SUPABASE_URL/rest/v1/rpc/my_function" -H "apikey: $SUPABASE_TO
 5. **Add indexes** on frequently filtered columns
 6. **Use `Prefer: return=representation`** to get inserted/updated rows back
 7. **Avoid full-table operations** without filters to prevent accidental data loss
-
----
 
 ## API Reference
 

--- a/supadata/SKILL.md
+++ b/supadata/SKILL.md
@@ -4,30 +4,9 @@ description: Supadata API for YouTube/web data. Use when user mentions "Supadata
   "YouTube data", "channel stats", or web scraping data.
 ---
 
-# Supadata API
+## Troubleshooting
 
-Use the Supadata API via direct `curl` calls to **extract video transcripts** and **scrape web content** for AI applications.
-
-> Official docs: `https://docs.supadata.ai/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Extract transcripts** from YouTube, TikTok, Instagram, X (Twitter), Facebook videos
-- **Scrape web pages** to markdown format for AI processing
-- **Get video/channel metadata** from social platforms
-- **Crawl websites** to extract content from multiple pages
-
----
-
-## Prerequisites
-
-Connect the **Supadata** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SUPADATA_TOKEN` or `zero doctor check-connector --url https://api.supadata.ai/v1/transcript --method POST`
+If requests fail, run `zero doctor check-connector --env-name SUPADATA_TOKEN` or `zero doctor check-connector --url https://api.supadata.ai/v1/transcript --method POST`
 
 ## How to Use
 
@@ -38,8 +17,6 @@ The base URL for the API is:
 - `https://api.supadata.ai/v1`
 
 Authentication uses the `x-api-key` header.
-
----
 
 ### 1. Get YouTube Video Transcript
 
@@ -62,8 +39,6 @@ curl -s "https://api.supadata.ai/v1/transcript" -H "x-api-key: $SUPADATA_TOKEN" 
 - `lang`: Preferred language (ISO 639-1 code, e.g., `en`, `zh`)
 - `mode`: `native` (existing only), `generate` (AI), `auto` (default)
 
----
-
 ### 2. Get Transcript with Timestamps
 
 Get transcript with timing information:
@@ -83,8 +58,6 @@ Response format:
 }
 ```
 
----
-
 ### 3. Get TikTok/Instagram/X Transcript
 
 Extract transcript from other platforms:
@@ -99,8 +72,6 @@ curl -s "https://api.supadata.ai/v1/transcript" -H "x-api-key: $SUPADATA_TOKEN" 
 
 Supported platforms: YouTube, TikTok, Instagram, X (Twitter), Facebook
 
----
-
 ### 4. Native Transcript Only (Save Credits)
 
 Fetch only existing transcripts without AI generation:
@@ -110,8 +81,6 @@ curl -s "https://api.supadata.ai/v1/transcript" -H "x-api-key: $SUPADATA_TOKEN" 
 ```
 
 Use `mode=native` to avoid AI generation costs (1 credit vs 2 credits/min).
-
----
 
 ### 5. Get YouTube Channel Metadata
 
@@ -123,8 +92,6 @@ curl -s "https://api.supadata.ai/v1/youtube/channel" -H "x-api-key: $SUPADATA_TO
 
 Accepts channel URL, channel ID, or handle (e.g., `@mkbhd`).
 
----
-
 ### 6. Get YouTube Video Metadata
 
 Get video information:
@@ -132,8 +99,6 @@ Get video information:
 ```bash
 curl -s "https://api.supadata.ai/v1/youtube/video" -H "x-api-key: $SUPADATA_TOKEN" -G --data-urlencode "url@/tmp/supadata_url.txt" | jq '{title, viewCount, likeCount, duration}
 ```
-
----
 
 ### 7. Get Social Media Metadata
 
@@ -145,8 +110,6 @@ curl -s "https://api.supadata.ai/v1/metadata" -H "x-api-key: $SUPADATA_TOKEN" -G
 
 Works with YouTube, TikTok, Instagram, X, Facebook posts.
 
----
-
 ### 8. Scrape Web Page to Markdown
 
 Extract web page content:
@@ -157,8 +120,6 @@ curl -s "https://api.supadata.ai/v1/web/scrape" -H "x-api-key: $SUPADATA_TOKEN" 
 
 Returns page content in Markdown format, ideal for AI processing.
 
----
-
 ### 9. Map Website Links
 
 Get all links from a website:
@@ -166,8 +127,6 @@ Get all links from a website:
 ```bash
 curl -s "https://api.supadata.ai/v1/web/map" -H "x-api-key: $SUPADATA_TOKEN" -G --data-urlencode "url@/tmp/supadata_url.txt" | jq '.urls[:10]'
 ```
-
----
 
 ### 10. Crawl Website (Async)
 
@@ -196,8 +155,6 @@ curl -s "https://api.supadata.ai/v1/web/crawl/<your-job-id>" -H "x-api-key: $SUP
 
 Status values: `queued`, `active`, `completed`, `failed`
 
----
-
 ### 11. Translate Transcript
 
 Translate a YouTube transcript to another language:
@@ -205,8 +162,6 @@ Translate a YouTube transcript to another language:
 ```bash
 curl -s "https://api.supadata.ai/v1/youtube/transcript/translate" -H "x-api-key: $SUPADATA_TOKEN" -G --data-urlencode "url@/tmp/supadata_url.txt" -d "lang=zh" -d "text=true"
 ```
-
----
 
 ## Response Handling
 
@@ -218,8 +173,6 @@ curl -s "https://api.supadata.ai/v1/youtube/transcript/translate" -H "x-api-key:
 ```
 
 Poll the job endpoint until status is `completed`.
-
----
 
 ## Guidelines
 

--- a/tavily/SKILL.md
+++ b/tavily/SKILL.md
@@ -4,30 +4,9 @@ description: Tavily API for AI search. Use when user mentions "Tavily", "AI sear
   "research", or asks for cited search results.
 ---
 
-# Tavily Search API
+## Troubleshooting
 
-Use Tavily's search API via direct `curl` calls to perform **live web search**, ideal for powering retrieval-augmented generation (RAG) for LLMs and agents.
-
-> Official documentation: `https://docs.tavily.com/`
-
----
-
-## When to Use
-
-Use this skill when you need:
-
-- **Fresh, up-to-date information** (news, trends, ongoing events)
-- **Search results with sources/links** to ground LLM or agent answers
-- **Research / desk research** inside automation workflows
-- A **reliable retrieval layer** for RAG, combined with skills like Notion or Firecrawl
-
----
-
-## Prerequisites
-
-Connect the **Tavily** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name TAVILY_TOKEN` or `zero doctor check-connector --url https://api.tavily.com/search --method POST`
+If requests fail, run `zero doctor check-connector --env-name TAVILY_TOKEN` or `zero doctor check-connector --url https://api.tavily.com/search --method POST`
 
 ## How to Use
 
@@ -37,8 +16,6 @@ The base endpoint for the Tavily search API is a `POST` request to:
 - `https://api.tavily.com/search`
 
 with a JSON body.
-
----
 
 ### 1. Basic Search
 
@@ -65,8 +42,6 @@ curl -s -X POST "https://api.tavily.com/search" --header "Content-Type: applicat
   - `"basic"` – faster, good for most use cases
   - `"advanced"` – deeper search and higher recall
 - `max_results`: Maximum number of results to return (e.g. 3 / 5 / 10)
-
----
 
 ### 2. Advanced Search
 
@@ -97,8 +72,6 @@ curl -s -X POST "https://api.tavily.com/search" --header "Content-Type: applicat
 - `exclude_domains`: Blacklist of domains to exclude
 - `include_raw_content`: Whether to include raw page content (HTML / raw text). Default is `false`.
 
----
-
 ### 3. Typical Response Structure (Example)
 
 Tavily returns a JSON object similar to:
@@ -122,8 +95,6 @@ In agents or automation flows you typically:
 - Use `answer` as a concise, ready-to-use summary
 - Iterate over `results` to extract `title` + `url` as references / citations
 
----
-
 ### 4. Using Tavily in n8n (HTTP Request Node)
 
 To integrate Tavily in n8n with the HTTP Request node:
@@ -144,8 +115,6 @@ To integrate Tavily in n8n with the HTTP Request node:
 ```
 
 This lets you pipe Tavily search results into downstream nodes such as LLMs, Notion, Slack notifications, etc.
-
----
 
 ## Guidelines
 

--- a/tldv/SKILL.md
+++ b/tldv/SKILL.md
@@ -4,33 +4,9 @@ description: tl;dv API for meeting recordings. Use when user mentions "tl;dv", "
   recording", "meeting summary", or asks about call analysis.
 ---
 
-# tl;dv API
+## Troubleshooting
 
-Access meeting recordings, transcripts, highlights, and AI-generated notes from tl;dv via the REST API.
-
-> Official docs: `https://doc.tldv.io/index.html`
-
----
-
-## Prerequisites
-
-Connect the **tl;dv** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name TLDV_TOKEN` or `zero doctor check-connector --url https://pasta.tldv.io/v1alpha1/health --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- List and retrieve meeting recordings from Zoom, Google Meet, or Microsoft Teams
-- Get structured transcripts with speaker identification and timestamps
-- Access AI-generated meeting highlights, topics, and summaries
-- Download meeting recordings
-- Import external meeting recordings into tl;dv
-
----
-
----
+If requests fail, run `zero doctor check-connector --env-name TLDV_TOKEN` or `zero doctor check-connector --url https://pasta.tldv.io/v1alpha1/health --method GET`
 
 ## How to Use
 
@@ -42,8 +18,6 @@ API version: `v1alpha1` (alpha — endpoints may change before stable v1 release
 
 Authentication uses the `x-api-key` header (not Bearer).
 
----
-
 ## Health Check
 
 ### Verify API Connectivity
@@ -51,8 +25,6 @@ Authentication uses the `x-api-key` header (not Bearer).
 ```bash
 curl -s "https://pasta.tldv.io/v1alpha1/health" --header "x-api-key: $TLDV_TOKEN" | jq .
 ```
-
----
 
 ## Meetings
 
@@ -102,8 +74,6 @@ Write to `/tmp/tldv_request.json`:
 curl -s -X POST "https://pasta.tldv.io/v1alpha1/meetings/import" --header "x-api-key: $TLDV_TOKEN" --header "Content-Type: application/json" -d @/tmp/tldv_request.json | jq .
 ```
 
----
-
 ## Transcripts
 
 ### Get Meeting Transcript
@@ -118,8 +88,6 @@ curl -s "https://pasta.tldv.io/v1alpha1/meetings/<meeting_id>/transcript" --head
 curl -s "https://pasta.tldv.io/v1alpha1/meetings/<meeting_id>/transcript" --header "x-api-key: $TLDV_TOKEN" | jq -r '.data[] | "\(.speaker): \(.text)"'
 ```
 
----
-
 ## Highlights / Notes
 
 ### Get Meeting Highlights
@@ -133,8 +101,6 @@ curl -s "https://pasta.tldv.io/v1alpha1/meetings/<meeting_id>/highlights" --head
 ```bash
 curl -s "https://pasta.tldv.io/v1alpha1/meetings/<meeting_id>/highlights" --header "x-api-key: $TLDV_TOKEN" | jq '[.data[] | .topic | select(. != null)] | unique_by(.title) | .[] | {title, summary}'
 ```
-
----
 
 ## Guidelines
 

--- a/todoist/SKILL.md
+++ b/todoist/SKILL.md
@@ -4,25 +4,9 @@ description: Todoist API for task management. Use when user mentions "Todoist", 
   tasks", "create todo", or asks about Todoist projects.
 ---
 
-# Todoist API
+## Troubleshooting
 
-Manage tasks, projects, sections, labels, and comments with the Todoist REST API v2.
-
-> Official docs: `https://developer.todoist.com/rest/v2`
-
-## Prerequisites
-
-Connect the **Todoist** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name TODOIST_TOKEN` or `zero doctor check-connector --url https://api.todoist.com/rest/v2/projects --method GET`
-
-## When to Use
-
-- Create, update, complete, and delete tasks
-- Organize tasks into projects and sections
-- Add labels and comments to tasks
-- List and filter tasks by project or label
-- Manage projects (create, update, delete)
+If requests fail, run `zero doctor check-connector --env-name TODOIST_TOKEN` or `zero doctor check-connector --url https://api.todoist.com/rest/v2/projects --method GET`
 
 ## Core APIs
 
@@ -34,8 +18,6 @@ curl -s "https://api.todoist.com/rest/v2/projects" --header "Authorization: Bear
 
 Docs: https://developer.todoist.com/rest/v2/#get-all-projects
 
----
-
 ### Get Project
 
 Replace `<project-id>` with the actual project ID:
@@ -43,8 +25,6 @@ Replace `<project-id>` with the actual project ID:
 ```bash
 curl -s "https://api.todoist.com/rest/v2/projects/<project-id>" --header "Authorization: Bearer $TODOIST_TOKEN" | jq '{id, name, comment_count, color, is_shared, is_favorite, url}'
 ```
-
----
 
 ### Create Project
 
@@ -61,8 +41,6 @@ curl -s -X POST "https://api.todoist.com/rest/v2/projects" --header "Authorizati
 ```
 
 Docs: https://developer.todoist.com/rest/v2/#create-a-new-project
-
----
 
 ### Update Project
 
@@ -81,8 +59,6 @@ Write to `/tmp/todoist_request.json`:
 curl -s -X POST "https://api.todoist.com/rest/v2/projects/<project-id>" --header "Authorization: Bearer $TODOIST_TOKEN" --header "Content-Type: application/json" -d @/tmp/todoist_request.json | jq '{id, name, color}'
 ```
 
----
-
 ### Delete Project
 
 Replace `<project-id>` with the actual project ID:
@@ -92,8 +68,6 @@ curl -s -X DELETE "https://api.todoist.com/rest/v2/projects/<project-id>" --head
 ```
 
 A `204` response means success.
-
----
 
 ### Get Active Tasks
 
@@ -111,8 +85,6 @@ Replace `<project-id>` with the actual project ID:
 curl -s "https://api.todoist.com/rest/v2/tasks?project_id=<project-id>" --header "Authorization: Bearer $TODOIST_TOKEN" | jq '.[] | {id, content, priority, due: .due.date}'
 ```
 
----
-
 ### Get Task
 
 Replace `<task-id>` with the actual task ID:
@@ -120,8 +92,6 @@ Replace `<task-id>` with the actual task ID:
 ```bash
 curl -s "https://api.todoist.com/rest/v2/tasks/<task-id>" --header "Authorization: Bearer $TODOIST_TOKEN" | jq '{id, content, description, project_id, section_id, priority, due, labels, url}'
 ```
-
----
 
 ### Create Task
 
@@ -144,8 +114,6 @@ curl -s -X POST "https://api.todoist.com/rest/v2/tasks" --header "Authorization:
 
 Docs: https://developer.todoist.com/rest/v2/#create-a-new-task
 
----
-
 ### Update Task
 
 Replace `<task-id>` with the actual task ID.
@@ -163,8 +131,6 @@ Write to `/tmp/todoist_request.json`:
 curl -s -X POST "https://api.todoist.com/rest/v2/tasks/<task-id>" --header "Authorization: Bearer $TODOIST_TOKEN" --header "Content-Type: application/json" -d @/tmp/todoist_request.json | jq '{id, content, priority}'
 ```
 
----
-
 ### Complete Task
 
 Replace `<task-id>` with the actual task ID:
@@ -177,8 +143,6 @@ A `204` response means success.
 
 Docs: https://developer.todoist.com/rest/v2/#close-a-task
 
----
-
 ### Reopen Task
 
 Replace `<task-id>` with the actual task ID:
@@ -187,8 +151,6 @@ Replace `<task-id>` with the actual task ID:
 curl -s -X POST "https://api.todoist.com/rest/v2/tasks/<task-id>/reopen" --header "Authorization: Bearer $TODOIST_TOKEN" -w "\nHTTP Status: %{http_code}\n"
 ```
 
----
-
 ### Delete Task
 
 Replace `<task-id>` with the actual task ID:
@@ -196,8 +158,6 @@ Replace `<task-id>` with the actual task ID:
 ```bash
 curl -s -X DELETE "https://api.todoist.com/rest/v2/tasks/<task-id>" --header "Authorization: Bearer $TODOIST_TOKEN" -w "\nHTTP Status: %{http_code}\n"
 ```
-
----
 
 ### Get Sections
 
@@ -213,8 +173,6 @@ Replace `<project-id>` with the actual project ID:
 curl -s "https://api.todoist.com/rest/v2/sections?project_id=<project-id>" --header "Authorization: Bearer $TODOIST_TOKEN" | jq '.[] | {id, name, order}'
 ```
 
----
-
 ### Create Section
 
 Write to `/tmp/todoist_request.json`:
@@ -229,8 +187,6 @@ Write to `/tmp/todoist_request.json`:
 ```bash
 curl -s -X POST "https://api.todoist.com/rest/v2/sections" --header "Authorization: Bearer $TODOIST_TOKEN" --header "Content-Type: application/json" -d @/tmp/todoist_request.json | jq '{id, name, project_id}'
 ```
-
----
 
 ### Get Labels
 
@@ -252,8 +208,6 @@ Write to `/tmp/todoist_request.json`:
 ```bash
 curl -s -X POST "https://api.todoist.com/rest/v2/labels" --header "Authorization: Bearer $TODOIST_TOKEN" --header "Content-Type: application/json" -d @/tmp/todoist_request.json | jq '{id, name, color}'
 ```
-
----
 
 ### Get Comments for Task
 
@@ -277,8 +231,6 @@ Write to `/tmp/todoist_request.json`:
 ```bash
 curl -s -X POST "https://api.todoist.com/rest/v2/comments" --header "Authorization: Bearer $TODOIST_TOKEN" --header "Content-Type: application/json" -d @/tmp/todoist_request.json | jq '{id, content, posted_at}'
 ```
-
----
 
 ## Guidelines
 

--- a/twenty/SKILL.md
+++ b/twenty/SKILL.md
@@ -4,32 +4,9 @@ description: Twenty CRM API for customer management. Use when user mentions "Twe
   "Twenty CRM", "open source CRM", or asks about Twenty.
 ---
 
-# Twenty CRM
+## Troubleshooting
 
-Open-source modern CRM platform. Manage people, companies, opportunities, notes, and tasks via REST or GraphQL API.
-
-> Official docs: https://docs.twenty.com/developers/api-and-webhooks/api
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Manage contacts (people) and companies
-- Track opportunities and deals
-- Create notes and tasks
-- Sync CRM data with other systems
-- Query CRM metadata and custom fields
-- Set up webhooks for CRM events
-
----
-
-## Prerequisites
-
-Connect the **Twenty CRM** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name TWENTY_TOKEN` or `zero doctor check-connector --url https://api.twenty.com/rest/companies --method GET`
+If requests fail, run `zero doctor check-connector --env-name TWENTY_TOKEN` or `zero doctor check-connector --url https://api.twenty.com/rest/companies --method GET`
 
 ## How to Use
 
@@ -206,8 +183,6 @@ Then run:
 curl -s -X POST "https://api.twenty.com/graphql" --header "Authorization: Bearer $TWENTY_TOKEN" --header "Content-Type: application/json" -d @/tmp/twenty_request.json | jq '.data.companies.edges'
 ```
 
----
-
 ## API Endpoints
 
 | Category | Endpoint | Description |
@@ -223,8 +198,6 @@ curl -s -X POST "https://api.twenty.com/graphql" --header "Authorization: Bearer
 | | `/rest/metadata/picklists` | Get dropdown field options |
 | **GraphQL** | `/graphql` | GraphQL endpoint |
 
----
-
 ## Query Parameters
 
 | Parameter | Description |
@@ -239,8 +212,6 @@ curl -s -X POST "https://api.twenty.com/graphql" --header "Authorization: Bearer
 ```bash
 curl -s -X GET "https://api.twenty.com/rest/companies?filter={\"name\":{\"like\":\"%Acme%\"}}" --header "Authorization: Bearer $TWENTY_TOKEN" | jq '.data.companies'
 ```
-
----
 
 ## Response Format
 
@@ -264,8 +235,6 @@ curl -s -X GET "https://api.twenty.com/rest/companies?filter={\"name\":{\"like\"
 }
 ```
 
----
-
 ## Guidelines
 
 1. **API Playground**: Test API calls at Settings → APIs & Webhooks in the Twenty app
@@ -274,8 +243,6 @@ curl -s -X GET "https://api.twenty.com/rest/companies?filter={\"name\":{\"like\"
 4. **REST**: Use REST for simple CRUD operations
 5. **Custom Objects**: Twenty supports custom objects; use metadata API to discover schema
 6. **Webhooks**: Set up webhooks at Settings → APIs & Webhooks for real-time events
-
----
 
 ## Resources
 

--- a/v0/SKILL.md
+++ b/v0/SKILL.md
@@ -3,35 +3,9 @@ name: v0
 description: v0 by Vercel AI app builder API. Use when user mentions "v0", "v0.dev", wants to generate UI components or full-stack apps with AI, or manage v0 projects, chats, and deployments programmatically.
 ---
 
-# v0 by Vercel API
-
-Generate React/Next.js UI components and full-stack apps from natural language prompts, iterate on generated code, manage projects, and track deployments — all via v0's REST API.
-
-> Official docs: `https://v0.app/docs/api/platform/overview`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Generate React/Next.js UI components or full-stack apps from a text prompt
-- Iterate on previously generated code by sending follow-up messages
-- List, create, or manage v0 projects programmatically
-- Check or list deployments of v0-generated apps
-- Use the `v0-1.0-md` model via an OpenAI-compatible chat completions endpoint
-
----
-
-## Prerequisites
-
-Connect the **v0 by Vercel** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 Base URL: `https://api.v0.dev/v1`
-
----
 
 ### 1. Generate App or UI from Prompt
 
@@ -57,8 +31,6 @@ The response includes:
 - `latestVersion.demoUrl` — live sandbox preview of the generated app
 - `latestVersion.files` — generated source files
 
----
-
 ### 2. Iterate — Send Follow-up Message
 
 Refine generated code by sending a follow-up to an existing chat. Replace `<chat-id>` with the ID from the previous response:
@@ -77,8 +49,6 @@ Then run:
 curl -s -X POST "https://api.v0.dev/v1/chats/<chat-id>/messages" --header "Authorization: Bearer $V0_TOKEN" --header "Content-Type: application/json" -d @/tmp/v0_request.json
 ```
 
----
-
 ### 3. Get Chat Details (Retrieve Generated Code)
 
 Fetch the full chat including generated files. Replace `<chat-id>` with the target chat ID:
@@ -89,15 +59,11 @@ curl -s "https://api.v0.dev/v1/chats/<chat-id>" --header "Authorization: Bearer 
 
 The `latestVersion.files` array contains the generated source code files.
 
----
-
 ### 4. List All Chats
 
 ```bash
 curl -s "https://api.v0.dev/v1/chats" --header "Authorization: Bearer $V0_TOKEN" | jq '.data[] | {id, name, webUrl}'
 ```
-
----
 
 ### 5. Create Project
 
@@ -121,23 +87,17 @@ curl -s -X POST "https://api.v0.dev/v1/projects" --header "Authorization: Bearer
 
 To create a chat within a project, add `"projectId": "<project-id>"` to the chat creation request.
 
----
-
 ### 6. List Projects
 
 ```bash
 curl -s "https://api.v0.dev/v1/projects" --header "Authorization: Bearer $V0_TOKEN" | jq '.data[] | {id, name, privacy}'
 ```
 
----
-
 ### 7. List Deployments
 
 ```bash
 curl -s "https://api.v0.dev/v1/deployments" --header "Authorization: Bearer $V0_TOKEN" | jq '.data[] | {id, webUrl, status}'
 ```
-
----
 
 ### 8. Chat Completions (OpenAI-compatible)
 
@@ -161,8 +121,6 @@ curl -s -X POST "https://api.v0.dev/v1/chat/completions" --header "Authorization
 ```
 
 **Context window:** 128,000 tokens input · 32,000 tokens output
-
----
 
 ## Guidelines
 

--- a/vercel/SKILL.md
+++ b/vercel/SKILL.md
@@ -4,33 +4,9 @@ description: Vercel API for deployments. Use when user mentions "Vercel", "verce
   "vercel.com", shares a Vercel link, "deploy", or asks about hosting.
 ---
 
-# Vercel API
+## Troubleshooting
 
-Manage projects, deployments, domains, environment variables, edge config, teams, and webhooks via the Vercel REST API.
-
-> Official docs: https://vercel.com/docs/rest-api
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- List and manage projects
-- Monitor, redeploy, promote, and cancel deployments
-- Manage domains and DNS records
-- Handle environment variables
-- Manage Edge Config stores
-- Configure teams and members
-- Manage webhooks and log drains
-
----
-
-## Prerequisites
-
-Connect the **Vercel** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name VERCEL_TOKEN` or `zero doctor check-connector --url https://api.vercel.com/v2/user --method GET`
+If requests fail, run `zero doctor check-connector --env-name VERCEL_TOKEN` or `zero doctor check-connector --url https://api.vercel.com/v2/user --method GET`
 
 ## User
 
@@ -47,8 +23,6 @@ curl -s "https://api.vercel.com/v2/user" \
 curl -s "https://api.vercel.com/v6/user/tokens" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
-
----
 
 ## Projects
 
@@ -110,8 +84,6 @@ curl -s -X POST "https://api.vercel.com/v1/projects/<project-id>/pause" \
 curl -s -X POST "https://api.vercel.com/v1/projects/<project-id>/unpause" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
-
----
 
 ## Deployments
 
@@ -193,8 +165,6 @@ curl -s "https://api.vercel.com/v2/deployments/<deployment-id>/aliases" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
 
----
-
 ## Domains
 
 ### List Domains
@@ -243,8 +213,6 @@ curl -s -X DELETE "https://api.vercel.com/v6/domains/<domain>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
 
----
-
 ## Project Domains
 
 ### List Project Domains
@@ -286,8 +254,6 @@ curl -s -X DELETE "https://api.vercel.com/v9/projects/<project-name>/domains/<do
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
 
----
-
 ## DNS Records
 
 ### List DNS Records
@@ -312,8 +278,6 @@ curl -s -X POST "https://api.vercel.com/v2/domains/<domain>/records" \
 curl -s -X DELETE "https://api.vercel.com/v2/domains/<domain>/records/<record-id>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
-
----
 
 ## Environment Variables
 
@@ -357,8 +321,6 @@ curl -s -X PATCH "https://api.vercel.com/v9/projects/<project-name>/env/<env-id>
 curl -s -X DELETE "https://api.vercel.com/v9/projects/<project-name>/env/<env-id>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
-
----
 
 ## Edge Config
 
@@ -416,8 +378,6 @@ curl -s "https://api.vercel.com/v1/edge-config/<edge-config-id>/item/<key>" \
 curl -s -X DELETE "https://api.vercel.com/v1/edge-config/<edge-config-id>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
-
----
 
 ## Teams
 
@@ -478,8 +438,6 @@ curl -s -X DELETE "https://api.vercel.com/v1/teams/<team-id>/members/<uid>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
 
----
-
 ## Webhooks
 
 ### List Webhooks
@@ -516,8 +474,6 @@ curl -s -X DELETE "https://api.vercel.com/v1/webhooks/<webhook-id>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
 
----
-
 ## Log Drains
 
 ### List Log Drains
@@ -544,8 +500,6 @@ curl -s -X POST "https://api.vercel.com/v1/log-drains" \
 curl -s -X DELETE "https://api.vercel.com/v1/log-drains/<id>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
-
----
 
 ## Aliases
 
@@ -579,8 +533,6 @@ curl -s -X DELETE "https://api.vercel.com/v2/aliases/<alias-id>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
 
----
-
 ## Certificates
 
 ### Get Certificate
@@ -606,8 +558,6 @@ curl -s -X DELETE "https://api.vercel.com/v8/certs/<cert-id>" \
   --header "Authorization: Bearer $VERCEL_TOKEN"
 ```
 
----
-
 ## Deployment States
 
 | State | Description |
@@ -618,8 +568,6 @@ curl -s -X DELETE "https://api.vercel.com/v8/certs/<cert-id>" \
 | `ERROR` | Build or deployment failed |
 | `CANCELED` | Deployment was canceled |
 
----
-
 ## Guidelines
 
 1. **Pagination**: Use `?limit=N&until=<timestamp>` for paginated results. The `until` value comes from the last item's timestamp.
@@ -629,8 +577,6 @@ curl -s -X DELETE "https://api.vercel.com/v8/certs/<cert-id>" \
 5. **Team scope**: For team resources, add `?teamId=<team-id>` query param or use team tokens.
 6. **Environment targets**: Env vars can target `production`, `preview`, `development`, or any combination.
 7. **Edge Config**: Use Edge Config for feature flags and runtime configuration that needs to be read at the edge with zero latency.
-
----
 
 ## How to Look Up More API Details
 

--- a/webflow/SKILL.md
+++ b/webflow/SKILL.md
@@ -4,40 +4,15 @@ description: Webflow API for CMS and sites. Use when user mentions "Webflow", "w
   "webflow.io", shares a Webflow link, "update Webflow", or asks about Webflow site.
 ---
 
-# Webflow API
+## Troubleshooting
 
-Manage Webflow sites, pages, CMS collections, items, assets, and forms via the REST API v2.
-
-> Official docs: `https://developers.webflow.com/data/reference/rest-introduction`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **List and inspect sites** in a Webflow workspace
-- **Read page metadata** and site structure
-- **Manage CMS collections** — list, create, delete collections and fields
-- **CRUD CMS items** — create, read, update, delete, and publish collection items
-- **List and manage assets** (images, files) on a site
-- **Retrieve form submissions** from Webflow forms
-
----
-
-## Prerequisites
-
-Connect the **Webflow** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name WEBFLOW_TOKEN` or `zero doctor check-connector --url https://api.webflow.com/v2/token/authorized_by --method GET`
+If requests fail, run `zero doctor check-connector --env-name WEBFLOW_TOKEN` or `zero doctor check-connector --url https://api.webflow.com/v2/token/authorized_by --method GET`
 
 ## How to Use
 
 All examples assume `WEBFLOW_TOKEN` is set.
 
 Base URL: `https://api.webflow.com/v2`
-
----
 
 ### 1. Get Authorized User
 
@@ -47,8 +22,6 @@ Get information about the authenticated user:
 curl -s "https://api.webflow.com/v2/token/authorized_by" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '{id, email, firstName, lastName}'
 ```
 
----
-
 ### 2. List Sites
 
 List all sites accessible to the authenticated user:
@@ -56,8 +29,6 @@ List all sites accessible to the authenticated user:
 ```bash
 curl -s "https://api.webflow.com/v2/sites" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '.sites[] | {id, displayName, shortName, lastPublished}'
 ```
-
----
 
 ### 3. Get Site Details
 
@@ -67,8 +38,6 @@ Retrieve details for a specific site. Replace `<site-id>` with an actual site ID
 curl -s "https://api.webflow.com/v2/sites/<site-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '{id, displayName, shortName, lastPublished, previewUrl}'
 ```
 
----
-
 ### 4. List Pages
 
 List all pages for a site. Replace `<site-id>` with your site ID.
@@ -77,8 +46,6 @@ List all pages for a site. Replace `<site-id>` with your site ID.
 curl -s "https://api.webflow.com/v2/sites/<site-id>/pages" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '.pages[] | {id, title, slug, createdOn, lastUpdated}'
 ```
 
----
-
 ### 5. Get Page Metadata
 
 Retrieve metadata for a specific page. Replace `<page-id>` with an actual page ID.
@@ -86,8 +53,6 @@ Retrieve metadata for a specific page. Replace `<page-id>` with an actual page I
 ```bash
 curl -s "https://api.webflow.com/v2/pages/<page-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '{id, title, slug, seo: {title: .seo.title, description: .seo.description}}'
 ```
-
----
 
 ### 6. Update Page Settings
 
@@ -110,8 +75,6 @@ Write to `/tmp/webflow_page_update.json`:
 curl -s -X PATCH "https://api.webflow.com/v2/pages/<page-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN" --header "Content-Type: application/json" -d @/tmp/webflow_page_update.json | jq '{id, title, slug}'
 ```
 
----
-
 ### 7. List Collections
 
 List all CMS collections for a site. Replace `<site-id>` with your site ID.
@@ -120,8 +83,6 @@ List all CMS collections for a site. Replace `<site-id>` with your site ID.
 curl -s "https://api.webflow.com/v2/sites/<site-id>/collections" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '.collections[] | {id, displayName, singularName, slug}'
 ```
 
----
-
 ### 8. Get Collection Details
 
 Retrieve schema and details for a specific collection, including field definitions. Replace `<collection-id>` with your collection ID.
@@ -129,8 +90,6 @@ Retrieve schema and details for a specific collection, including field definitio
 ```bash
 curl -s "https://api.webflow.com/v2/collections/<collection-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '{id, displayName, singularName, slug, fields: [.fields[] | {id, displayName, slug, type, isRequired}]}'
 ```
-
----
 
 ### 9. List Collection Items
 
@@ -146,8 +105,6 @@ Supports pagination with `offset` and `limit` query parameters:
 curl -s "https://api.webflow.com/v2/collections/<collection-id>/items?offset=0&limit=10" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '{pagination, items: [.items[] | {id, fieldData: .fieldData}]}'
 ```
 
----
-
 ### 10. Get Collection Item
 
 Get a single item by ID. Replace `<collection-id>` and `<item-id>`.
@@ -155,8 +112,6 @@ Get a single item by ID. Replace `<collection-id>` and `<item-id>`.
 ```bash
 curl -s "https://api.webflow.com/v2/collections/<collection-id>/items/<item-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '{id, fieldData}'
 ```
-
----
 
 ### 11. Create Collection Item
 
@@ -177,8 +132,6 @@ Write to `/tmp/webflow_item.json`:
 curl -s -X POST "https://api.webflow.com/v2/collections/<collection-id>/items" --header "Authorization: Bearer $WEBFLOW_TOKEN" --header "Content-Type: application/json" -d @/tmp/webflow_item.json | jq '{id, fieldData}'
 ```
 
----
-
 ### 12. Update Collection Item
 
 Update an existing item. Replace `<collection-id>` and `<item-id>`.
@@ -197,8 +150,6 @@ Write to `/tmp/webflow_item_update.json`:
 curl -s -X PATCH "https://api.webflow.com/v2/collections/<collection-id>/items/<item-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN" --header "Content-Type: application/json" -d @/tmp/webflow_item_update.json | jq '{id, fieldData}'
 ```
 
----
-
 ### 13. Delete Collection Item
 
 Delete an item from a collection. Replace `<collection-id>` and `<item-id>`.
@@ -206,8 +157,6 @@ Delete an item from a collection. Replace `<collection-id>` and `<item-id>`.
 ```bash
 curl -s -X DELETE "https://api.webflow.com/v2/collections/<collection-id>/items/<item-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN"
 ```
-
----
 
 ### 14. Publish Collection Items
 
@@ -225,8 +174,6 @@ Write to `/tmp/webflow_publish.json`:
 curl -s -X POST "https://api.webflow.com/v2/collections/<collection-id>/items/publish" --header "Authorization: Bearer $WEBFLOW_TOKEN" --header "Content-Type: application/json" -d @/tmp/webflow_publish.json | jq '{publishedItemIds}'
 ```
 
----
-
 ### 15. List Assets
 
 List all assets (images, files) for a site. Replace `<site-id>` with your site ID.
@@ -235,8 +182,6 @@ List all assets (images, files) for a site. Replace `<site-id>` with your site I
 curl -s "https://api.webflow.com/v2/sites/<site-id>/assets" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '.assets[] | {id, displayName, url, fileSize, contentType}'
 ```
 
----
-
 ### 16. Get Asset Details
 
 Get details for a specific asset. Replace `<asset-id>` with your asset ID.
@@ -244,8 +189,6 @@ Get details for a specific asset. Replace `<asset-id>` with your asset ID.
 ```bash
 curl -s "https://api.webflow.com/v2/assets/<asset-id>" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '{id, displayName, url, fileSize, contentType, createdOn}'
 ```
-
----
 
 ### 17. List Form Submissions
 
@@ -260,8 +203,6 @@ To find form IDs, list all forms for a site first:
 ```bash
 curl -s "https://api.webflow.com/v2/sites/<site-id>/forms" --header "Authorization: Bearer $WEBFLOW_TOKEN" | jq '.forms[] | {id, displayName, siteId}'
 ```
-
----
 
 ### 18. Publish Site
 
@@ -278,8 +219,6 @@ Write to `/tmp/webflow_publish_site.json`:
 ```bash
 curl -s -X POST "https://api.webflow.com/v2/sites/<site-id>/publish" --header "Authorization: Bearer $WEBFLOW_TOKEN" --header "Content-Type: application/json" -d @/tmp/webflow_publish_site.json
 ```
-
----
 
 ## Guidelines
 

--- a/wix/SKILL.md
+++ b/wix/SKILL.md
@@ -4,25 +4,9 @@ description: Wix API for website management. Use when user mentions "Wix", "wix.
   "wixsite.com", shares a Wix link, "Wix site", or asks about Wix CMS.
 ---
 
-# Wix API
+## Troubleshooting
 
-Manage contacts, blog posts, store products, and orders on a connected Wix site.
-
-> Official docs: `https://dev.wix.com/docs/rest`
-
-## When to Use
-
-- View and manage site contacts and CRM data
-- Create, read, and update blog posts
-- Query store products and inventory
-- View and manage orders
-- Get site information and stats
-
-## Prerequisites
-
-Connect the **Wix** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name WIX_TOKEN` or `zero doctor check-connector --url https://www.wixapis.com/apps/v1/instance --method GET`
+If requests fail, run `zero doctor check-connector --env-name WIX_TOKEN` or `zero doctor check-connector --url https://www.wixapis.com/apps/v1/instance --method GET`
 
 ## Core APIs
 

--- a/workflow-migration/SKILL.md
+++ b/workflow-migration/SKILL.md
@@ -3,15 +3,9 @@ name: workflow-migration
 description: VM0 migration helper for Claude Code workflows. Use when user says "migrate to VM0", "move to VM0", "convert skill to VM0", or asks about migrating local Claude Code workflows.
 ---
 
-# Local Claude Code Workflow to VM0 Migration
+## Troubleshooting
 
----
-
-## Prerequisites
-
-Connect the **Local Claude Code Workflow to VM0 Migration** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name NOTION_API_KEY`
+If requests fail, run `zero doctor check-connector --env-name NOTION_API_KEY`
 
 ## When to Use This Skill
 
@@ -21,8 +15,6 @@ Use when the user wants to:
 - "Run my local automation on VM0"
 - "Move my Claude Code setup to VM0 cloud"
 - "Deploy my local skill to VM0"
-
----
 
 ## How It Works
 
@@ -283,8 +275,6 @@ __pycache__
 reports/
 ```
 
----
-
 ## Complete Real Example: world-news-summary
 
 This is a real migration case showing exactly how to convert a local Claude Code skill to VM0.
@@ -486,8 +476,6 @@ vm0 logs
 - Completed in ~5 minutes
 - Cost: $1.51
 
----
-
 ## Migration Process
 
 When user asks to migrate their local workflow, follow these steps:
@@ -628,8 +616,6 @@ Next steps:
 - Monitor agent performance
 ```
 
----
-
 ## Tips for Good Migrations
 
 ### 1. Understand the Workflow First
@@ -670,8 +656,6 @@ Instead of raw API calls, use VM0 skills when available:
 - Include deployment instructions
 - Note any differences from local behavior
 
----
-
 ## Common Migration Patterns
 
 ### Pattern 1: Daily Data Sync
@@ -690,8 +674,6 @@ Instead of raw API calls, use VM0 skills when available:
 ### Pattern 4: Multi-service Integration
 **Local**: Skill that orchestrates multiple services (GitHub + Slack + Notion)
 **VM0**: Agent that uses multiple VM0 skills for each service
-
----
 
 ## Troubleshooting
 
@@ -721,8 +703,6 @@ Instead of raw API calls, use VM0 skills when available:
 ### Issue: "Agent behavior differs from local skill"
 **Solution**: Review AGENTS.md instructions - may need to preserve more details from original SKILL.md
 
----
-
 ## Key Differences: Local Skills vs VM0 Agents
 
 | Aspect | Local Claude Code Skills | VM0 Agents |
@@ -734,8 +714,6 @@ Instead of raw API calls, use VM0 skills when available:
 | **Secrets** | Local env vars or `.env` | VM0 secrets or `.env` (testing) |
 | **APIs** | Direct API calls | Can use VM0 skills |
 | **Execution** | `claude` CLI or IDE | `vm0 run` or `vm0 cook` |
-
----
 
 ## References
 

--- a/wrike/SKILL.md
+++ b/wrike/SKILL.md
@@ -4,33 +4,9 @@ description: Wrike API for project management. Use when user mentions "Wrike", "
   shares a Wrike link, "Wrike task", or asks about Wrike workspace.
 ---
 
-# Wrike API
+## Troubleshooting
 
-Manage tasks, folders, projects, spaces, comments, timelogs, and workflows in Wrike via the REST API v4.
-
-> Official docs: `https://developers.wrike.com/overview/`
-
----
-
-## Prerequisites
-
-Connect the **Wrike** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name WRIKE_TOKEN` or `zero doctor check-connector --url https://www.wrike.com/api/v4/spaces --method GET`
-
-## When to Use
-
-Use this skill when you need to:
-
-- List and manage spaces, folders, and projects
-- Create, update, delete, and search tasks
-- Add and manage comments on tasks and folders
-- Track time with timelogs
-- Query contacts and workflows
-
----
-
----
+If requests fail, run `zero doctor check-connector --env-name WRIKE_TOKEN` or `zero doctor check-connector --url https://www.wrike.com/api/v4/spaces --method GET`
 
 ## How to Use
 
@@ -39,8 +15,6 @@ All examples below assume you have `WRIKE_TOKEN` set.
 Base URL: `https://www.wrike.com/api/v4`
 
 Wrike uses alphanumeric IDs for all resources. The hierarchy is: Space > Folder/Project > Task. Projects are folders with additional properties (owners, start/end dates, status). All responses follow the format `{"kind": "...", "data": [...]}`.
-
----
 
 ## Spaces
 
@@ -75,8 +49,6 @@ curl -s -X POST "https://www.wrike.com/api/v4/spaces" --header "Authorization: B
 ```bash
 curl -s -X DELETE "https://www.wrike.com/api/v4/spaces/<space_id>" --header "Authorization: Bearer $WRIKE_TOKEN"
 ```
-
----
 
 ## Folders & Projects
 
@@ -157,8 +129,6 @@ curl -s -X PUT "https://www.wrike.com/api/v4/folders/<folder_id>" --header "Auth
 curl -s -X DELETE "https://www.wrike.com/api/v4/folders/<folder_id>" --header "Authorization: Bearer $WRIKE_TOKEN"
 ```
 
----
-
 ## Tasks
 
 ### List Tasks in a Folder
@@ -223,8 +193,6 @@ curl -s -X PUT "https://www.wrike.com/api/v4/tasks/<task_id>" --header "Authoriz
 curl -s -X DELETE "https://www.wrike.com/api/v4/tasks/<task_id>" --header "Authorization: Bearer $WRIKE_TOKEN"
 ```
 
----
-
 ## Comments
 
 ### List Comments on a Task
@@ -273,8 +241,6 @@ curl -s -X PUT "https://www.wrike.com/api/v4/comments/<comment_id>" --header "Au
 curl -s -X DELETE "https://www.wrike.com/api/v4/comments/<comment_id>" --header "Authorization: Bearer $WRIKE_TOKEN"
 ```
 
----
-
 ## Contacts
 
 ### List All Contacts
@@ -288,8 +254,6 @@ curl -s "https://www.wrike.com/api/v4/contacts" --header "Authorization: Bearer 
 ```bash
 curl -s "https://www.wrike.com/api/v4/contacts/<contact_id>" --header "Authorization: Bearer $WRIKE_TOKEN" | jq '.data[0]'
 ```
-
----
 
 ## Timelogs
 
@@ -321,8 +285,6 @@ curl -s -X POST "https://www.wrike.com/api/v4/tasks/<task_id>/timelogs" --header
 curl -s -X DELETE "https://www.wrike.com/api/v4/timelogs/<timelog_id>" --header "Authorization: Bearer $WRIKE_TOKEN"
 ```
 
----
-
 ## Workflows
 
 ### List Workflows
@@ -330,8 +292,6 @@ curl -s -X DELETE "https://www.wrike.com/api/v4/timelogs/<timelog_id>" --header 
 ```bash
 curl -s "https://www.wrike.com/api/v4/workflows" --header "Authorization: Bearer $WRIKE_TOKEN" | jq '.data[] | {id, name, customStatuses}'
 ```
-
----
 
 ## Guidelines
 

--- a/x/SKILL.md
+++ b/x/SKILL.md
@@ -5,30 +5,6 @@ description: X (Twitter) API for tweets and profiles. Use when user mentions "X"
   social media posts.
 ---
 
-# X (Twitter) API
-
-Use `xurl` CLI to **read tweets, search posts, view user profiles, timelines, and social graphs**.
-
-> xurl docs: `https://github.com/xdevplatform/xurl`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **View user profiles** - look up users by username or ID
-- **Read tweets** - get tweet details by ID or URL
-- **Browse timelines** - get a user's tweets or mentions
-- **Search posts** - find recent tweets matching a query
-- **Explore social graphs** - list followers and following
-
----
-
-## Prerequisites
-
-Connect the **X (Twitter)** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
 ## How to Use
 
 ### 1. Get Authenticated User Profile
@@ -36,8 +12,6 @@ Connect the **X (Twitter)** connector at [app.vm0.ai/connectors](https://app.vm0
 ```bash
 xurl whoami
 ```
-
----
 
 ### 2. Look Up User by Username
 
@@ -47,8 +21,6 @@ xurl whoami
 xurl user elonmusk
 ```
 
----
-
 ### 3. Look Up User by ID
 
 > **Note:** Replace `12345` with the actual user ID. You can obtain user IDs from other endpoint responses.
@@ -56,8 +28,6 @@ xurl user elonmusk
 ```bash
 xurl /2/users/12345?user.fields=id,name,username,description,public_metrics,created_at
 ```
-
----
 
 ### 4. Look Up Multiple Users
 
@@ -69,8 +39,6 @@ Get profiles for multiple users at once (up to 100):
 xurl '/2/users?ids=12345,67890&user.fields=id,name,username,description,public_metrics'
 ```
 
----
-
 ### 5. Get a Tweet by ID
 
 > **Note:** Replace `1234567890` with the actual tweet ID. Full URLs like `https://x.com/user/status/1234567890` also work.
@@ -78,8 +46,6 @@ xurl '/2/users?ids=12345,67890&user.fields=id,name,username,description,public_m
 ```bash
 xurl read 1234567890
 ```
-
----
 
 ### 6. Get Multiple Tweets
 
@@ -90,8 +56,6 @@ Get details for multiple tweets at once (up to 100):
 ```bash
 xurl '/2/tweets?ids=1234567890,0987654321&tweet.fields=created_at,public_metrics,author_id,text&expansions=author_id&user.fields=name,username'
 ```
-
----
 
 ### 7. Get User's Tweets (Timeline)
 
@@ -113,15 +77,11 @@ xurl '/2/users/USER_ID/tweets?max_results=10&tweet.fields=created_at,public_metr
 - `pagination_token` - For paginating results
 - `exclude` - Comma-separated: `retweets`, `replies`
 
----
-
 ### 8. Get User's Mentions
 
 ```bash
 xurl mentions -n 10
 ```
-
----
 
 ### 9. Search Recent Tweets
 
@@ -144,8 +104,6 @@ Common search operators:
 - `lang:en` - Filter by language
 - `conversation_id:123` - Tweets in a conversation thread
 
----
-
 ### 10. Get User's Followers
 
 > **Note:** Replace `elonmusk` with the actual username.
@@ -154,8 +112,6 @@ Common search operators:
 xurl followers --of elonmusk -n 20
 ```
 
----
-
 ### 11. Get User's Following
 
 > **Note:** Replace `elonmusk` with the actual username.
@@ -163,8 +119,6 @@ xurl followers --of elonmusk -n 20
 ```bash
 xurl following --of elonmusk -n 20
 ```
-
----
 
 ## Pagination
 
@@ -177,8 +131,6 @@ xurl '/2/tweets/search/recent?query=example&max_results=10' | jq .meta
 ```
 
 Use the returned `next_token` value as `pagination_token` in the next request to get more results.
-
----
 
 ## Common user.fields
 
@@ -208,8 +160,6 @@ Use the returned `next_token` value as `pagination_token` in the next request to
 | `lang` | Detected language |
 | `referenced_tweets` | Retweet/quote/reply references |
 | `entities` | URLs, hashtags, mentions, cashtags |
-
----
 
 ## Guidelines
 

--- a/xero/SKILL.md
+++ b/xero/SKILL.md
@@ -4,37 +4,9 @@ description: Xero API for accounting. Use when user mentions "Xero", "accounting
   "invoices", "bookkeeping", or asks about financial management.
 ---
 
-# Xero Accounting API
+## Troubleshooting
 
-Manage accounting data including invoices, contacts, bank transactions, payments, accounts, financial reports, fixed assets, projects, and files via Xero's REST API.
-
-> Official docs: https://developer.xero.com/documentation/api/accounting/overview
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- Manage invoices, quotes, credit notes, and purchase orders
-- Manage contacts and contact groups
-- View and create bank transactions and transfers
-- Manage payments and batch payments
-- View chart of accounts and organisation settings
-- View financial reports (P&L, balance sheet, trial balance, aged reports, etc.)
-- View and manage budgets
-- Manage inventory items
-- View and create fixed assets (read + create only, no update/delete)
-- Manage projects, tasks, and time entries
-- Upload and organise files
-
----
-
-## Prerequisites
-
-Connect the **Xero** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name XERO_TOKEN` or `zero doctor check-connector --url https://api.xero.com/Connections --method GET`
+If requests fail, run `zero doctor check-connector --env-name XERO_TOKEN` or `zero doctor check-connector --url https://api.xero.com/Connections --method GET`
 
 ## Step 1: Get Tenant ID (Required First)
 
@@ -61,8 +33,6 @@ Response returns an array of connected orgs. Use the `tenantId` from the first (
 
 Store the `tenantId` and use it as the `xero-tenant-id` header in all subsequent requests.
 
----
-
 ## Organisation
 
 ### Get Organisation Info
@@ -84,8 +54,6 @@ curl -s "https://api.xero.com/api.xro/2.0/Organisation/Actions" \
 ```
 
 Returns array of `{Name, Status}` where Status is "ALLOWED" or "NOT-ALLOWED". Useful to check what operations are available.
-
----
 
 ## Contacts
 
@@ -159,8 +127,6 @@ curl -s -X POST "https://api.xero.com/api.xro/2.0/Contacts/<contact-id>" \
 
 Contacts cannot be deleted — only archived. Use `includeArchived=true` in list requests to see archived contacts.
 
----
-
 ## Contact Groups
 
 ### List Contact Groups
@@ -208,8 +174,6 @@ curl -s -X POST "https://api.xero.com/api.xro/2.0/ContactGroups/<group-id>" \
   --header "Content-Type: application/json" \
   -d "{\"Status\": \"DELETED\"}"
 ```
-
----
 
 ## Invoices
 
@@ -347,8 +311,6 @@ curl -s -X POST "https://api.xero.com/api.xro/2.0/Invoices/<invoice-id>/Email" \
   -d "{}"
 ```
 
----
-
 ## Credit Notes
 
 ### List Credit Notes
@@ -382,8 +344,6 @@ curl -s -X PUT "https://api.xero.com/api.xro/2.0/CreditNotes/<credit-note-id>/Al
   --header "Content-Type: application/json" \
   -d "{\"Allocations\": [{\"Amount\": 100.00, \"Invoice\": {\"InvoiceID\": \"<invoice-id>\"}}]}"
 ```
-
----
 
 ## Quotes
 
@@ -419,8 +379,6 @@ curl -s -X POST "https://api.xero.com/api.xro/2.0/Quotes/<quote-id>" \
   -d "{\"QuoteID\": \"<quote-id>\", \"Contact\": {\"ContactID\": \"<contact-id>\"}, \"Date\": \"2026-03-05\", \"Status\": \"SENT\"}"
 ```
 
----
-
 ## Purchase Orders
 
 ### List Purchase Orders
@@ -454,8 +412,6 @@ curl -s -X POST "https://api.xero.com/api.xro/2.0/PurchaseOrders/<po-id>" \
   --header "Content-Type: application/json" \
   -d "{\"PurchaseOrderID\": \"<po-id>\", \"Status\": \"AUTHORISED\"}"
 ```
-
----
 
 ## Payments
 
@@ -503,8 +459,6 @@ curl -s -X POST "https://api.xero.com/api.xro/2.0/Payments/<payment-id>" \
   -d "{\"PaymentID\": \"<payment-id>\", \"Status\": \"DELETED\"}"
 ```
 
----
-
 ## Batch Payments
 
 ### List Batch Payments
@@ -514,8 +468,6 @@ curl -s "https://api.xero.com/api.xro/2.0/BatchPayments" \
   --header "Authorization: Bearer $XERO_TOKEN" \
   --header "xero-tenant-id: <tenant-id>"
 ```
-
----
 
 ## Bank Transactions
 
@@ -567,8 +519,6 @@ curl -s -X POST "https://api.xero.com/api.xro/2.0/BankTransactions/<transaction-
   -d "{\"BankTransactionID\": \"<transaction-id>\", \"Status\": \"DELETED\"}"
 ```
 
----
-
 ## Bank Transfers
 
 ### List Bank Transfers
@@ -588,8 +538,6 @@ curl -s -X PUT "https://api.xero.com/api.xro/2.0/BankTransfers" \
   --header "Content-Type: application/json" \
   -d "{\"BankTransfers\": [{\"FromBankAccount\": {\"Code\": \"090\"}, \"ToBankAccount\": {\"Code\": \"091\"}, \"Amount\": 500.00}]}"
 ```
-
----
 
 ## Accounts (Chart of Accounts)
 
@@ -649,8 +597,6 @@ curl -s -X DELETE "https://api.xero.com/api.xro/2.0/Accounts/<account-id>" \
   --header "xero-tenant-id: <tenant-id>"
 ```
 
----
-
 ## Manual Journals
 
 ### List Manual Journals
@@ -672,8 +618,6 @@ curl -s -X PUT "https://api.xero.com/api.xro/2.0/ManualJournals" \
   --header "Content-Type: application/json" \
   -d "{\"Narration\": \"Year-end adjustment\", \"Date\": \"2026-03-05\", \"JournalLines\": [{\"LineAmount\": 100.00, \"AccountCode\": \"200\", \"Description\": \"Revenue adjustment\"}, {\"LineAmount\": -100.00, \"AccountCode\": \"400\", \"Description\": \"Expense adjustment\"}]}"
 ```
-
----
 
 ## Items
 
@@ -714,8 +658,6 @@ curl -s -X DELETE "https://api.xero.com/api.xro/2.0/Items/<item-id>" \
   --header "Authorization: Bearer $XERO_TOKEN" \
   --header "xero-tenant-id: <tenant-id>"
 ```
-
----
 
 ## Reports
 
@@ -809,8 +751,6 @@ curl -s "https://api.xero.com/api.xro/2.0/Reports/BudgetSummary?date=2026-03-05"
   --header "xero-tenant-id: <tenant-id>"
 ```
 
----
-
 ## Budgets
 
 ### List Budgets
@@ -829,8 +769,6 @@ curl -s "https://api.xero.com/api.xro/2.0/Budgets/<budget-id>?DateFrom=2026-01-0
   --header "xero-tenant-id: <tenant-id>"
 ```
 
----
-
 ## Currencies
 
 ### List Currencies
@@ -843,8 +781,6 @@ curl -s "https://api.xero.com/api.xro/2.0/Currencies" \
 
 Adding currencies requires a plan that supports multi-currency. See docs: `https://r.jina.ai/https://developer.xero.com/documentation/api/accounting/currencies`
 
----
-
 ## Tax Rates
 
 ### List Tax Rates
@@ -854,8 +790,6 @@ curl -s "https://api.xero.com/api.xro/2.0/TaxRates" \
   --header "Authorization: Bearer $XERO_TOKEN" \
   --header "xero-tenant-id: <tenant-id>"
 ```
-
----
 
 ## Tracking Categories
 
@@ -887,8 +821,6 @@ curl -s -X PUT "https://api.xero.com/api.xro/2.0/TrackingCategories/<category-id
   -d "{\"Name\": \"North\"}"
 ```
 
----
-
 ## Branding Themes
 
 ### List Branding Themes
@@ -899,8 +831,6 @@ curl -s "https://api.xero.com/api.xro/2.0/BrandingThemes" \
   --header "xero-tenant-id: <tenant-id>"
 ```
 
----
-
 ## Users
 
 ### List Users
@@ -910,8 +840,6 @@ curl -s "https://api.xero.com/api.xro/2.0/Users" \
   --header "Authorization: Bearer $XERO_TOKEN" \
   --header "xero-tenant-id: <tenant-id>"
 ```
-
----
 
 ## Attachments
 
@@ -930,8 +858,6 @@ curl -s -X PUT "https://api.xero.com/api.xro/2.0/Invoices/<invoice-id>/Attachmen
 Use PUT to create a new attachment (fails if filename exists), POST to overwrite an existing one.
 
 Attachments work on: Invoices, CreditNotes, BankTransactions, Contacts, Accounts, ManualJournals, PurchaseOrders, Receipts, RepeatingInvoices. Replace the entity path accordingly.
-
----
 
 ## Fixed Assets (Assets API)
 
@@ -1002,8 +928,6 @@ curl -s "https://api.xero.com/assets.xro/1.0/Settings" \
 ```
 
 Returns: `assetNumberPrefix`, `assetNumberSequence`, `assetStartDate`, `optInForTax`.
-
----
 
 ## Projects API
 
@@ -1153,8 +1077,6 @@ curl -s -X DELETE "https://api.xero.com/projects.xro/2.0/Projects/<project-id>/T
 
 INVOICED entries cannot be deleted.
 
----
-
 ## Files API
 
 Base URL: `https://api.xero.com/files.xro/1.0` (different from accounting API).
@@ -1252,8 +1174,6 @@ curl -s "https://api.xero.com/files.xro/1.0/Inbox" \
   --header "xero-tenant-id: <tenant-id>"
 ```
 
----
-
 ## Guidelines
 
 1. **Tenant ID Required**: Always call `/Connections` first to get the `tenantId`, then include it as `xero-tenant-id` header in every API call.
@@ -1273,8 +1193,6 @@ curl -s "https://api.xero.com/files.xro/1.0/Inbox" \
 15. **LineItemID on Updates**: Always include `LineItemID` when updating line items, or they get deleted and recreated.
 16. **100k Record Limit**: GET requests returning >100,000 records return a 400 error. Use filters and pagination.
 17. **Different Base URLs**: Accounting API uses `api.xro/2.0`, Assets API uses `assets.xro/1.0`, Projects API uses `projects.xro/2.0`, Files API uses `files.xro/1.0`.
-
----
 
 ## How to Look Up More API Details
 

--- a/youtube/SKILL.md
+++ b/youtube/SKILL.md
@@ -5,46 +5,19 @@ description: YouTube API for videos and channels. Use when user mentions "YouTub
   content.
 ---
 
-# YouTube Data API
+## Troubleshooting
 
-Use the YouTube Data API v3 via direct `curl` calls to **search videos, retrieve video details, get channel information, list playlist items, and fetch comments**.
-
-> Official docs: `https://developers.google.com/youtube/v3`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Search videos** by keywords or filters
-- **Get video details** (title, description, statistics, duration)
-- **Get channel info** (subscriber count, video count, description)
-- **List playlist items** (videos in a playlist)
-- **Fetch comments** on videos
-- **Get trending videos** by region
-
----
-
-## Prerequisites
-
-Connect the **YouTube** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name YOUTUBE_TOKEN` or `zero doctor check-connector --url https://www.googleapis.com/youtube/v3/search --method GET`
+If requests fail, run `zero doctor check-connector --env-name YOUTUBE_TOKEN` or `zero doctor check-connector --url https://www.googleapis.com/youtube/v3/search --method GET`
 
 ## How to Use
 
 Base URL: `https://www.googleapis.com/youtube/v3`
-
----
 
 ### 1. Search Videos
 
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/search?part=snippet&q=kubernetes+tutorial&type=video&maxResults=5&key=$YOUTUBE_TOKEN" | jq '.items[] | {videoId: .id.videoId, title: .snippet.title, channel: .snippet.channelTitle}'
 ```
-
----
 
 ### 2. Search with Filters
 
@@ -54,8 +27,6 @@ Search for videos uploaded this year, ordered by view count:
 curl -s "https://www.googleapis.com/youtube/v3/search?part=snippet&q=react+hooks&type=video&order=viewCount&publishedAfter=2024-01-01T00:00:00Z&maxResults=10&key=$YOUTUBE_TOKEN" | jq '.items[] | {videoId: .id.videoId, title: .snippet.title}'
 ```
 
----
-
 ### 3. Get Video Details
 
 Replace `<your-video-id>` with an actual video ID:
@@ -63,8 +34,6 @@ Replace `<your-video-id>` with an actual video ID:
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics,contentDetails&id=<your-video-id>&key=$YOUTUBE_TOKEN" | jq '.items[0] | {title: .snippet.title, views: .statistics.viewCount, likes: .statistics.likeCount, duration: .contentDetails.duration}'
 ```
-
----
 
 ### 4. Get Multiple Videos
 
@@ -74,15 +43,11 @@ Replace `<your-video-id-1>`, `<your-video-id-2>`, `<your-video-id-3>` with actua
 curl -s "https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics&id=<your-video-id-1>,<your-video-id-2>,<your-video-id-3>&key=$YOUTUBE_TOKEN" | jq '.items[] | {id: .id, title: .snippet.title, views: .statistics.viewCount}'
 ```
 
----
-
 ### 5. Get Trending Videos
 
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics&chart=mostPopular&regionCode=US&maxResults=10&key=$YOUTUBE_TOKEN" | jq '.items[] | {title: .snippet.title, channel: .snippet.channelTitle, views: .statistics.viewCount}'
 ```
-
----
 
 ### 6. Get Channel by ID
 
@@ -92,23 +57,17 @@ Replace `<your-channel-id>` with an actual channel ID:
 curl -s "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics&id=<your-channel-id>&key=$YOUTUBE_TOKEN" | jq '.items[0] | {title: .snippet.title, subscribers: .statistics.subscriberCount, videos: .statistics.videoCount}'
 ```
 
----
-
 ### 7. Get Channel by Handle
 
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics&forHandle=@GoogleDevelopers&key=$YOUTUBE_TOKEN" | jq '.items[0] | {id: .id, title: .snippet.title, subscribers: .statistics.subscriberCount}'
 ```
 
----
-
 ### 8. Get Channel by Username
 
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics&forUsername=GoogleDevelopers&key=$YOUTUBE_TOKEN" | jq '.items[0] | {id: .id, title: .snippet.title, description: .snippet.description}'
 ```
-
----
 
 ### 9. List Playlist Items
 
@@ -118,8 +77,6 @@ Replace `<your-playlist-id>` with an actual playlist ID:
 curl -s "https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&playlistId=<your-playlist-id>&maxResults=20&key=$YOUTUBE_TOKEN" | jq '.items[] | {position: .snippet.position, title: .snippet.title, videoId: .snippet.resourceId.videoId}'
 ```
 
----
-
 ### 10. Get Channel Uploads Playlist
 
 First get the channel's uploads playlist ID, then list videos. Replace `<your-channel-id>` with an actual channel ID:
@@ -127,8 +84,6 @@ First get the channel's uploads playlist ID, then list videos. Replace `<your-ch
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/channels?part=contentDetails&id=<your-channel-id>&key=$YOUTUBE_TOKEN" | jq -r '.items[0].contentDetails.relatedPlaylists.uploads'
 ```
-
----
 
 ### 11. Get Video Comments
 
@@ -138,8 +93,6 @@ Replace `<your-video-id>` with an actual video ID:
 curl -s "https://www.googleapis.com/youtube/v3/commentThreads?part=snippet&videoId=<your-video-id>&maxResults=20&order=relevance&key=$YOUTUBE_TOKEN" | jq '.items[] | {author: .snippet.topLevelComment.snippet.authorDisplayName, text: .snippet.topLevelComment.snippet.textDisplay, likes: .snippet.topLevelComment.snippet.likeCount}'
 ```
 
----
-
 ### 12. Search Comments
 
 Replace `<your-video-id>` with an actual video ID:
@@ -148,15 +101,11 @@ Replace `<your-video-id>` with an actual video ID:
 curl -s "https://www.googleapis.com/youtube/v3/commentThreads?part=snippet&videoId=<your-video-id>&searchTerms=great+video&maxResults=10&key=$YOUTUBE_TOKEN" | jq '.items[] | {author: .snippet.topLevelComment.snippet.authorDisplayName, text: .snippet.topLevelComment.snippet.textDisplay}'
 ```
 
----
-
 ### 13. Get Video Categories
 
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/videoCategories?part=snippet&regionCode=US&key=$YOUTUBE_TOKEN" | jq '.items[] | {id: .id, title: .snippet.title}'
 ```
-
----
 
 ### 14. Search Videos by Category
 
@@ -166,8 +115,6 @@ curl -s "https://www.googleapis.com/youtube/v3/search?part=snippet&type=video&vi
 
 Note: Category 28 = Science & Technology
 
----
-
 ### 15. Get Playlists from Channel
 
 Replace `<your-channel-id>` with an actual channel ID:
@@ -175,8 +122,6 @@ Replace `<your-channel-id>` with an actual channel ID:
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/playlists?part=snippet&channelId=<your-channel-id>&maxResults=20&key=$YOUTUBE_TOKEN" | jq '.items[] | {id: .id, title: .snippet.title, description: .snippet.description}'
 ```
-
----
 
 ## Common Video Categories
 
@@ -193,8 +138,6 @@ curl -s "https://www.googleapis.com/youtube/v3/playlists?part=snippet&channelId=
 | 27 | Education |
 | 28 | Science & Technology |
 
----
-
 ## Part Parameter Options
 
 ### Videos
@@ -210,8 +153,6 @@ curl -s "https://www.googleapis.com/youtube/v3/playlists?part=snippet&channelId=
 - `contentDetails` - Related playlists (uploads, likes)
 - `brandingSettings` - Channel customization
 
----
-
 ## Pagination
 
 Use `nextPageToken` from response to get more results. Replace `<your-next-page-token>` with the actual token from the previous response:
@@ -219,8 +160,6 @@ Use `nextPageToken` from response to get more results. Replace `<your-next-page-
 ```bash
 curl -s "https://www.googleapis.com/youtube/v3/search?part=snippet&q=python&type=video&maxResults=50&pageToken=<your-next-page-token>&key=$YOUTUBE_TOKEN" | jq '.items[] | {title: .snippet.title}'
 ```
-
----
 
 ## Guidelines
 

--- a/zapier/SKILL.md
+++ b/zapier/SKILL.md
@@ -4,36 +4,13 @@ description: Zapier API for workflow automation. Use when user mentions "Zapier"
   "zap", "automation", or asks about connecting apps.
 ---
 
-# Zapier AI Actions API
+## Troubleshooting
 
-Use the Zapier AI Actions API via direct `curl` calls to **execute pre-configured actions across 6000+ apps** using natural language instructions. AI Actions removes the complexity of building integrations by providing a single universal API that handles authentication, API calls, and edge cases for supported apps.
-
-> Official docs: `https://actions.zapier.com/docs/using-the-api`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Execute automated actions** across apps like Gmail, Slack, Google Sheets, Salesforce, and thousands more
-- **Trigger workflows** using natural language instructions without building direct integrations
-- **Preview action results** before executing them
-- **List and manage configured AI actions** available to your account
-
----
-
-## Prerequisites
-
-Connect the **Zapier** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ZAPIER_TOKEN` or `zero doctor check-connector --url https://actions.zapier.com/api/v2/check/ --method GET`
+If requests fail, run `zero doctor check-connector --env-name ZAPIER_TOKEN` or `zero doctor check-connector --url https://actions.zapier.com/api/v2/check/ --method GET`
 
 ## How to Use
 
 All examples below assume you have `ZAPIER_TOKEN` set. Authentication uses the `x-api-key` header.
-
----
 
 ### 1. Check API Key
 
@@ -43,8 +20,6 @@ Verify that your API key is valid.
 curl -s "https://actions.zapier.com/api/v2/check/" --header "x-api-key: $ZAPIER_TOKEN" | jq .
 ```
 
----
-
 ### 2. List Exposed Actions
 
 Retrieve all actions you have configured and exposed in your Zapier AI Actions dashboard.
@@ -53,8 +28,6 @@ Retrieve all actions you have configured and exposed in your Zapier AI Actions d
 curl -s "https://actions.zapier.com/api/v1/exposed/" --header "x-api-key: $ZAPIER_TOKEN" | jq '.results[] | {id, description, params}'
 ```
 
----
-
 ### 3. Execute an AI Action
 
 Execute a configured action using natural language instructions. Replace `ACTION_ID` with the action ID from the list above.
@@ -62,8 +35,6 @@ Execute a configured action using natural language instructions. Replace `ACTION
 ```bash
 curl -s -X POST "https://actions.zapier.com/api/v2/ai-actions/ACTION_ID/execute/" --header "Content-Type: application/json" --header "x-api-key: $ZAPIER_TOKEN" -d '{"instructions": "Send a message saying hello to the #general channel"}' | jq .
 ```
-
----
 
 ### 4. Execute with Parameter Hints
 
@@ -93,8 +64,6 @@ Then run:
 curl -s -X POST "https://actions.zapier.com/api/v2/ai-actions/ACTION_ID/execute/" --header "Content-Type: application/json" --header "x-api-key: $ZAPIER_TOKEN" -d @/tmp/zapier_request.json | jq .
 ```
 
----
-
 ### 5. Preview an Action (Dry Run)
 
 Preview what the action would do without actually executing it. Add `preview_only=true` as a query parameter.
@@ -103,8 +72,6 @@ Preview what the action would do without actually executing it. Add `preview_onl
 curl -s -X POST "https://actions.zapier.com/api/v2/ai-actions/ACTION_ID/execute/?preview_only=true" --header "Content-Type: application/json" --header "x-api-key: $ZAPIER_TOKEN" -d '{"instructions": "Create a new row in the Sales spreadsheet with name John and amount 500"}' | jq .
 ```
 
----
-
 ### 6. Execute a V1 Exposed Action
 
 Execute an action using the V1 endpoint. Replace `ACTION_ID` with the exposed action ID.
@@ -112,8 +79,6 @@ Execute an action using the V1 endpoint. Replace `ACTION_ID` with the exposed ac
 ```bash
 curl -s -X POST "https://actions.zapier.com/api/v1/dynamic/exposed/ACTION_ID/execute/" --header "Content-Type: application/json" --header "x-api-key: $ZAPIER_TOKEN" -d '{"instructions": "Send a Slack message to #dev saying deployment complete"}' | jq .
 ```
-
----
 
 ## Guidelines
 

--- a/zapsign/SKILL.md
+++ b/zapsign/SKILL.md
@@ -4,37 +4,13 @@ description: ZapSign API for e-signatures. Use when user mentions "ZapSign", "e-
   "sign document", or Brazilian e-signature.
 ---
 
-# ZapSign
+## Troubleshooting
 
-Use ZapSign via direct `curl` calls to **create and manage electronic signatures** with legal validity.
-
-> Official docs: `https://docs.zapsign.com.br/english`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Create documents** for electronic signature (PDF, DOCX, or Markdown)
-- **Add signers** to documents with various authentication methods
-- **Track signing status** and get signed documents
-- **Send automatic notifications** via email or WhatsApp
-- **Collect biometric verification** (selfie, document photo, facial recognition)
-
----
-
-## Prerequisites
-
-Connect the **ZapSign** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ZAPSIGN_TOKEN` or `zero doctor check-connector --url https://sandbox.api.zapsign.com.br/api/v1/docs/ --method GET`
+If requests fail, run `zero doctor check-connector --env-name ZAPSIGN_TOKEN` or `zero doctor check-connector --url https://sandbox.api.zapsign.com.br/api/v1/docs/ --method GET`
 
 ## How to Use
 
 All examples use the **sandbox** environment. For production, replace `sandbox.api.zapsign.com.br` with `api.zapsign.com.br`.
-
----
 
 ### 1. Create Document from PDF URL
 
@@ -63,8 +39,6 @@ Then run:
 ```bash
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, status, sign_url: .signers[0].sign_url}'
 ```
-
----
 
 ### 2. Create Document from Base64
 
@@ -96,8 +70,6 @@ Then run:
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, status, signers}'
 ```
 
----
-
 ### 3. Create Document from Markdown
 
 Create a document directly from Markdown text (great for AI integrations):
@@ -122,8 +94,6 @@ Then run:
 ```bash
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, status, original_file}'
 ```
-
----
 
 ### 4. Create Document with Multiple Signers
 
@@ -159,8 +129,6 @@ Then run:
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, status, signature_order_active}'
 ```
 
----
-
 ### 5. Create Document with Expiration
 
 Create a document with a deadline for signing:
@@ -187,8 +155,6 @@ Then run:
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, status, date_limit_to_sign}'
 ```
 
----
-
 ### 6. Get Document Details
 
 Retrieve document status and signer information. Replace `<your-document-token>` with the actual document token:
@@ -196,8 +162,6 @@ Retrieve document status and signer information. Replace `<your-document-token>`
 ```bash
 curl -s -X GET "https://sandbox.api.zapsign.com.br/api/v1/docs/<your-document-token>/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" | jq '{name, status, original_file, signed_file, signers: [.signers[] | {name, status, signed_at}]}'
 ```
-
----
 
 ### 7. Add Signer to Existing Document
 
@@ -219,8 +183,6 @@ Then run:
 ```bash
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/<your-document-token>/add-signer/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, sign_url, status}'
 ```
-
----
 
 ### 8. Create Document with WhatsApp Notification
 
@@ -250,8 +212,6 @@ Then run:
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, status, signers}'
 ```
 
----
-
 ### 9. Create Document with Biometric Verification
 
 Require facial recognition during signing:
@@ -279,8 +239,6 @@ Then run:
 curl -s -X POST "https://sandbox.api.zapsign.com.br/api/v1/docs/" -H "Authorization: Bearer $ZAPSIGN_TOKEN" -H "Content-Type: application/json" -d @/tmp/zapsign_request.json | jq '{token, status, signers: [.signers[] | {name, selfie_validation_type}]}'
 ```
 
----
-
 ### 10. Delete a Document
 
 Delete a document. Replace `<your-document-token>` with the actual document token:
@@ -288,8 +246,6 @@ Delete a document. Replace `<your-document-token>` with the actual document toke
 ```bash
 curl -s -X DELETE "https://sandbox.api.zapsign.com.br/api/v1/docs/<your-document-token>/" -H "Authorization: Bearer $ZAPSIGN_TOKEN"
 ```
-
----
 
 ## Authentication Modes
 
@@ -303,8 +259,6 @@ curl -s -X DELETE "https://sandbox.api.zapsign.com.br/api/v1/docs/<your-document
 | `tokenWhatsapp` | WhatsApp verification token | $0.10 |
 | `assinaturaTela-tokenWhatsapp` | Signature + WhatsApp token | $0.10 |
 
----
-
 ## Biometric Validation Types
 
 | Type | Description | Cost |
@@ -312,8 +266,6 @@ curl -s -X DELETE "https://sandbox.api.zapsign.com.br/api/v1/docs/<your-document
 | `liveness-document-match` | Face + document match | $0.50 |
 | `identity-verification` | Full identity verification (CO, MX, CL, PE) | $1.00 |
 | `identity-verification-global` | Global identity verification | $0.90 |
-
----
 
 ## Document Status
 
@@ -330,8 +282,6 @@ curl -s -X DELETE "https://sandbox.api.zapsign.com.br/api/v1/docs/<your-document
 | `link-opened` | Signer opened the link |
 | `signed` | Signer completed signing |
 
----
-
 ## Response Fields
 
 | Field | Description |
@@ -343,8 +293,6 @@ curl -s -X DELETE "https://sandbox.api.zapsign.com.br/api/v1/docs/<your-document
 | `signers[].token` | Signer unique identifier |
 | `signers[].sign_url` | Direct signing link for signer |
 | `signers[].signed_at` | Timestamp when signer signed |
-
----
 
 ## Guidelines
 

--- a/zendesk/SKILL.md
+++ b/zendesk/SKILL.md
@@ -4,34 +4,9 @@ description: Zendesk API for customer support. Use when user mentions "Zendesk",
   ticket", "customer service", or help desk.
 ---
 
-# Zendesk API
+## Troubleshooting
 
-Manage customer support tickets, users, organizations, and support operations via the Zendesk Support REST API.
-
-> Official docs: `https://developer.zendesk.com/api-reference/`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Manage tickets** - Create, update, search, and close support tickets
-- **Handle users** - Create end-users, agents, and manage user profiles
-- **Organize accounts** - Manage organizations and their members
-- **Support groups** - Create and manage agent groups for ticket routing
-- **Search data** - Find tickets, users, and organizations with powerful search
-- **Bulk operations** - Create or update multiple resources at once
-- **Automate support** - Build integrations and automate workflows
-- **Track metrics** - Access ticket data for reporting and analytics
-
----
-
-## Prerequisites
-
-Connect the **Zendesk** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ZENDESK_API_TOKEN` or `zero doctor check-connector --url https://your-subdomain.zendesk.com/api/v2/tickets.json --method GET`
+If requests fail, run `zero doctor check-connector --env-name ZENDESK_API_TOKEN` or `zero doctor check-connector --url https://your-subdomain.zendesk.com/api/v2/tickets.json --method GET`
 
 ## How to Use
 
@@ -45,8 +20,6 @@ All examples assume environment variables are set.
 ```
 
 **Note**: The `-u` flag automatically handles Base64 encoding for you.
-
----
 
 ## Core APIs
 
@@ -64,8 +37,6 @@ With pagination:
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets.json?page=1&per_page=50" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN"
 ```
 
----
-
 ### 2. Get Ticket
 
 Retrieve a specific ticket:
@@ -75,8 +46,6 @@ TICKET_ID="123"
 
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/${TICKET_ID}.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN"
 ```
-
----
 
 ### 3. Create Ticket
 
@@ -126,8 +95,6 @@ Then run:
 ```bash
 curl -s -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
-
----
 
 ### 4. Update Ticket
 
@@ -183,8 +150,6 @@ sed -i '' "s/ASSIGNEE_ID_PLACEHOLDER/${ASSIGNEE_ID}/" /tmp/zendesk_request.json
 curl -s -X PUT "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/${TICKET_ID}.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
 
----
-
 ### 5. Delete Ticket
 
 Permanently delete a ticket:
@@ -194,8 +159,6 @@ TICKET_ID="123"
 
 curl -s -X DELETE "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/${TICKET_ID}.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN"
 ```
-
----
 
 ### 6. Create Multiple Tickets
 
@@ -228,8 +191,6 @@ Then run:
 curl -s -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/create_many.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
 
----
-
 ### 7. List Users
 
 Get all users:
@@ -238,8 +199,6 @@ Get all users:
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/users.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" | jq '.users[] | {id, name, email, role}
 ```
 
----
-
 ### 8. Get Current User
 
 Get authenticated user details:
@@ -247,8 +206,6 @@ Get authenticated user details:
 ```bash
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/users/me.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN"
 ```
-
----
 
 ### 9. Create User
 
@@ -292,8 +249,6 @@ Then run:
 curl -s -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/users.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
 
----
-
 ### 10. Update User
 
 Update user information:
@@ -319,8 +274,6 @@ Then run:
 curl -s -X PUT "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/users/${USER_ID}.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
 
----
-
 ### 11. Search Users
 
 Search for users by query:
@@ -329,8 +282,6 @@ Search for users by query:
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/users/search.json?query=john" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" | jq '.users[] | {id, name, email}
 ```
 
----
-
 ### 12. List Organizations
 
 Get all organizations:
@@ -338,8 +289,6 @@ Get all organizations:
 ```bash
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/organizations.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" | jq '.organizations[] | {id, name, domain_names}
 ```
-
----
 
 ### 13. Create Organization
 
@@ -362,8 +311,6 @@ Then run:
 ```bash
 curl -s -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/organizations.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
-
----
 
 ### 14. Update Organization
 
@@ -390,8 +337,6 @@ Then run:
 curl -s -X PUT "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/organizations/${ORG_ID}.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
 
----
-
 ### 15. List Groups
 
 Get all agent groups:
@@ -399,8 +344,6 @@ Get all agent groups:
 ```bash
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/groups.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" | jq '.groups[] | {id, name}
 ```
-
----
 
 ### 16. Create Group
 
@@ -421,8 +364,6 @@ Then run:
 ```bash
 curl -s -X POST "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/groups.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
-
----
 
 ### 17. Search API
 
@@ -456,8 +397,6 @@ Search users by email domain:
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/search.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -G --data-urlencode "query@/tmp/zendesk_query.txt" | jq '.results[]
 ```
 
----
-
 ### 18. Get Ticket Comments
 
 List all comments on a ticket:
@@ -467,8 +406,6 @@ TICKET_ID="123"
 
 curl -s "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/${TICKET_ID}/comments.json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" | jq '.comments[] | {id, body, author_id, public}
 ```
-
----
 
 ### 19. Assign Ticket to Group
 
@@ -497,8 +434,6 @@ sed -i '' "s/GROUP_ID_PLACEHOLDER/${GROUP_ID}/" /tmp/zendesk_request.json
 curl -s -X PUT "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/${TICKET_ID}.json" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
 
----
-
 ### 20. Bulk Update Tickets
 
 Update multiple tickets at once:
@@ -518,8 +453,6 @@ Then run:
 ```bash
 curl -s -X PUT "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/update_many.json?ids=123,124,125" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
-
----
 
 ## Common Workflows
 
@@ -593,8 +526,6 @@ Then run:
 curl -s -X PUT "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets/update_many.json?ids=${OLD_TICKETS}" -H "Content-Type: application/json" -u "$ZENDESK_EMAIL/token:$ZENDESK_API_TOKEN" -d @/tmp/zendesk_request.json
 ```
 
----
-
 ## Search Query Syntax
 
 ### Ticket Search Operators
@@ -622,8 +553,6 @@ Use spaces for AND logic:
 ```bash
 query=type:ticket status:open priority:high
 ```
-
----
 
 ## Rate Limits
 
@@ -656,8 +585,6 @@ curl "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets.json" \
   --retry 3 --retry-delay 5
 ```
 
----
-
 ## Guidelines
 
 1. **Enable API token access first**: In Admin Center, ensure Token Access is enabled before using tokens
@@ -675,8 +602,6 @@ curl "https://$ZENDESK_SUBDOMAIN.zendesk.com/api/v2/tickets.json" \
 13. **Ticket types**: problem, incident, question, task
 14. **Authentication format**: email/token:api_token (curl -u handles encoding)
 15. **New workspaces**: Fresh Zendesk accounts come with sample tickets for testing
-
----
 
 ## API Reference
 

--- a/zeptomail/SKILL.md
+++ b/zeptomail/SKILL.md
@@ -4,39 +4,13 @@ description: ZeptoMail API for transactional email. Use when user mentions "Zept
   "transactional email", "send email", or Zoho email.
 ---
 
-# Zoho ZeptoMail
+## Troubleshooting
 
-Use the ZeptoMail API via `curl` to send **transactional emails** like password resets, OTPs, welcome emails, and order confirmations.
-
-> Official docs: `https://www.zoho.com/zeptomail/help/api-home.html`
-
----
-
-## When to Use
-
-Use this skill when you need to:
-
-- **Send transactional emails** (password resets, OTPs, confirmations)
-- **Send templated emails** with dynamic merge fields
-- **Batch send** to multiple recipients (up to 500)
-- **Track email opens and clicks**
-- **Send emails with attachments** or inline images
-
-**Note:** ZeptoMail is for transactional emails only. For marketing/bulk emails, use Zoho Campaigns instead.
-
----
-
-## Prerequisites
-
-Connect the **Zoho ZeptoMail** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
-
-> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name ZEPTOMAIL_TOKEN` or `zero doctor check-connector --url https://api.zeptomail.com/v1.1/email --method POST`
+If requests fail, run `zero doctor check-connector --env-name ZEPTOMAIL_TOKEN` or `zero doctor check-connector --url https://api.zeptomail.com/v1.1/email --method POST`
 
 ## How to Use
 
 Base URL: `https://api.zeptomail.com/v1.1`
-
----
 
 ### 1. Send Basic Email
 
@@ -67,8 +41,6 @@ Then run:
 curl -s "https://api.zeptomail.com/v1.1/email" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
 
----
-
 ### 2. Send Plain Text Email
 
 Write to `/tmp/zeptomail_request.json`:
@@ -97,8 +69,6 @@ Then run:
 ```bash
 curl -s "https://api.zeptomail.com/v1.1/email" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
-
----
 
 ### 3. Send Email with Tracking
 
@@ -133,8 +103,6 @@ Then run:
 ```bash
 curl -s "https://api.zeptomail.com/v1.1/email" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
-
----
 
 ### 4. Send to Multiple Recipients (CC/BCC)
 
@@ -187,8 +155,6 @@ Then run:
 curl -s "https://api.zeptomail.com/v1.1/email" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
 
----
-
 ### 5. Send Email with Attachment (Base64)
 
 ```bash
@@ -229,8 +195,6 @@ Then run:
 ```bash
 curl -s "https://api.zeptomail.com/v1.1/email" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
-
----
 
 ### 6. Send Email with Inline Image
 
@@ -274,8 +238,6 @@ Then run:
 curl -s "https://api.zeptomail.com/v1.1/email" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
 
----
-
 ### 7. Send Templated Email
 
 Use pre-defined templates with merge fields:
@@ -316,8 +278,6 @@ Template example (in ZeptoMail dashboard):
 <p>Hi {{user_name}},</p>
 <p>Your order #{{order_id}} totaling {{total}} has been shipped!</p>
 ```
-
----
 
 ### 8. Batch Send (Multiple Recipients)
 
@@ -364,8 +324,6 @@ Then run:
 curl -s "https://api.zeptomail.com/v1.1/email/batch" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
 
----
-
 ### 9. Batch Send with Template
 
 Write to `/tmp/zeptomail_request.json`:
@@ -408,8 +366,6 @@ Then run:
 curl -s "https://api.zeptomail.com/v1.1/email/template/batch" -X POST --header "Authorization: Zoho-enczapikey $ZEPTOMAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/zeptomail_request.json
 ```
 
----
-
 ## Response Format
 
 ### Success Response
@@ -447,8 +403,6 @@ curl -s "https://api.zeptomail.com/v1.1/email/template/batch" -X POST --header "
 }
 ```
 
----
-
 ## Common Error Codes
 
 | Code | Description |
@@ -458,8 +412,6 @@ curl -s "https://api.zeptomail.com/v1.1/email/template/batch" -X POST --header "
 | TM_103 | Domain not verified |
 | TM_104 | Rate limit exceeded |
 | EM_104 | Success |
-
----
 
 ## Guidelines
 


### PR DESCRIPTION
## Summary

All SKILL.md files have been stripped to their essential contents. Each file now contains, in order:

1. Frontmatter block (`---` ... `---`)
2. `## Troubleshooting` section as the first section (for connector skills — omitted for skills without a Troubleshooting blockquote, such as `brand-guidelines`, `analysis-qa`, `copywriting`)
3. All remaining example/usage content (endpoint tables, curl examples, parameter references, model tables, permission scopes, etc.)

## What was removed

- H1 title lines (e.g. `# Apollo Skill`, `# HubSpot`, `# Resend Email API`)
- Intro description paragraphs beneath the H1
- `> Official docs:` / `> Docs:` lines
- Floating `---` horizontal separators
- `## When to Use` sections (heading + bullet list)
- `## Prerequisites` sections — the "Connect the X connector" line is gone; the `> **Troubleshooting:**` blockquote that used to live inside Prerequisites has been promoted to a dedicated `## Troubleshooting` section at the top of the file

## Stats

173 SKILL.md files updated across the repository.

## Test plan

- [x] Frontmatter preserved exactly as on `main`
- [x] `## Troubleshooting` appears as first section for connector skills
- [x] Non-connector skills (brand-guidelines, analysis-qa, copywriting, etc.) correctly start with their first content section — no empty Troubleshooting heading
- [x] All `## Authentication` / `## Environment Variables` / `## Key Endpoints` / `## Common Workflows` / `## Guidelines` sections preserved with their code blocks, tables, and examples intact
- [x] No leftover `---` separators or excessive blank lines

Generated with [Claude Code](https://claude.com/claude-code)