### PR TITLE
chore: remove deprecated vm0_env frontmatter field

### DIFF
--- a/docs/skill-template.md
+++ b/docs/skill-template.md
@@ -37,9 +37,6 @@ Create `<skill-name>/SKILL.md` in the project root with the following structure:
 ---
 name: <skill-name>
 description: <One-line description of what this skill does>
-vm0_env:
-  - ENV_VAR_1
-  - ENV_VAR_2
 ---
 
 # <Skill Name>

--- a/manus/SKILL.md
+++ b/manus/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: manus
 description: Manus API for AI agent task execution. Use when user mentions "Manus", "run an agent task", "AI agent", or needs to automate multi-step research, analysis, or content tasks via Manus.
-vm0_env:
-  - MANUS_TOKEN
 ---
 
 ## Troubleshooting

--- a/plain/SKILL.md
+++ b/plain/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: plain
 description: Plain.com GraphQL API for customer support. Use when user mentions "Plain", "Plain.com", "support threads", or managing customers in Plain.
-vm0_env:
-  - PLAIN_TOKEN
 ---
 
 ## Troubleshooting

--- a/strapi/SKILL.md
+++ b/strapi/SKILL.md
@@ -2,9 +2,6 @@
 name: strapi
 description: Strapi CMS REST API for headless content management. Use when user mentions
   "Strapi", "CMS", "content types", "entries", or managing headless CMS content.
-vm0_env:
-  - STRAPI_TOKEN
-  - STRAPI_BASE_URL
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

vm0 no longer reads the `vm0_env` frontmatter field — connectors drive all environment injection. Removing it from:

- `docs/skill-template.md` — so new skills don't carry it forward
- `manus/SKILL.md`, `plain/SKILL.md`, `strapi/SKILL.md` — the only 3 SKILL.md files that still had it

## Test plan

- [x] All 3 SKILL.md files still have valid frontmatter (just `name` + `description`)
- [x] Template shows the correct minimal frontmatter format

🤖 Generated with [Claude Code](https://claude.com/claude-code)