### PR TITLE
feat: add remote-agent skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -667,6 +667,15 @@
       ]
     },
     {
+      "name": "remote-agent",
+      "description": "VM0 remote-agent CLI for delegating work to a linked local Codex or Claude host. Use this skill to list remote-agent hosts and submit jobs with npx -p @vm0/cli zero remote-agent.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./remote-agent"
+      ]
+    },
+    {
       "name": "reportei",
       "description": "Reportei marketing report generation API via curl. Use this skill to manage clients, reports, templates, integrations and webhooks for automated marketing analytics.",
       "source": "./",

--- a/remote-agent/SKILL.md
+++ b/remote-agent/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: remote-agent
+description: VM0 remote-agent CLI for delegating work to an already linked local
+  Codex or Claude host. Use when an agent should list remote-agent hosts or run
+  tasks through `npx -p @vm0/cli zero remote-agent`.
+---
+
+# VM0 Remote Agent
+
+Remote-agent lets this agent submit a prompt to an already linked machine running Codex or Claude Code. Use this skill when the current sandbox is not the right execution environment: for example, the task needs a user's local repo, local credentials, a long-running local agent CLI, or a specific workstation that has been registered as a remote-agent host.
+
+Use the `zero remote-agent` entry point for agent-side operations:
+
+```bash
+npx -y -p @vm0/cli zero remote-agent <command>
+```
+
+The `-y` flag avoids npm's package-install prompt. Omit it only when an interactive install prompt is desired.
+
+## Prerequisites
+
+Authentication is required. The CLI reads tokens in this order: `ZERO_TOKEN`, `VM0_TOKEN`, then the local `~/.vm0/config.json` created by `vm0 auth login`.
+
+If no token is available in the environment, authenticate with:
+
+```bash
+npx -y -p @vm0/cli vm0 auth login
+```
+
+`zero remote-agent` can list hosts and submit jobs only. It does not start or delete hosts. If there is no online host, ask the user or host operator to start one on the intended machine:
+
+```bash
+npx -y -p @vm0/cli vm0 remote-agent start \
+  --name "<host-name>" \
+  --workdir "<absolute-workdir>" \
+  --backend codex \
+  --permission-mode workspace-write
+```
+
+Host setup options are intentionally on the `vm0 remote-agent` command, not `zero remote-agent`.
+
+Supported host backends are `codex` and `claude-code`. Codex permission modes are `default`, `read-only`, `workspace-write`, `danger-full-access`, and `bypassPermissions`. Claude Code permission modes are `default`, `acceptEdits`, `auto`, `dontAsk`, `plan`, and `bypassPermissions`.
+
+## List Hosts
+
+Always list hosts before targeting a specific host:
+
+```bash
+npx -y -p @vm0/cli zero remote-agent list
+```
+
+The output columns are `HOST ID`, `STATUS`, `BACKENDS`, `LAST SEEN`, and `NAME`. Use only hosts with `STATUS` = `online`.
+
+Important: `run --host` takes the host `NAME`, not the host id. If multiple hosts have the same name, the run will fail as ambiguous.
+
+## Run a Job
+
+Run on any online host:
+
+```bash
+npx -y -p @vm0/cli zero remote-agent run "Check the repo status and summarize the current branch."
+```
+
+Run on a named host:
+
+```bash
+npx -y -p @vm0/cli zero remote-agent run \
+  --host "<host-name>" \
+  --timeout 3600 \
+  "In /path/to/repo, run the tests for package X and report failures with file paths."
+```
+
+`--timeout` is seconds and defaults to `7200`. The command queues the job, polls until it finishes or times out, prints the remote output, and exits non-zero if the remote job fails.
+
+For multiline prompts, pass one shell argument:
+
+```bash
+prompt=$(cat <<'EOF'
+Task: inspect the current checkout and find why the build is failing.
+
+Expected output:
+- concise root cause
+- exact commands run
+- changed files, if any
+- remaining risks
+EOF
+)
+
+npx -y -p @vm0/cli zero remote-agent run --host "<host-name>" --timeout 7200 "$prompt"
+```
+
+## Prompting Guidelines
+
+- Include the exact task, expected output, and any relevant repo paths or branches.
+- State whether the remote agent may edit files, run tests, install dependencies, or only inspect.
+- Do not assume the remote host has the same files as the current sandbox. Include enough context for the host's configured `--workdir`.
+- Keep prompts below 60,000 characters.
+- Ask for concise output. Remote job output keeps only the latest output up to the CLI limit, so request summaries plus file paths or commands rather than large logs.
+- Treat remote-agent as execution on another machine. Do not send secrets or private data unless the task requires it and the user authorized it.
+
+## Troubleshooting
+
+- `Not authenticated`: set `ZERO_TOKEN` or `VM0_TOKEN`, or run `npx -y -p @vm0/cli vm0 auth login`.
+- `Remote agent is not enabled`: the account or token lacks remote-agent access.
+- `No linked remote-agent host found`: no host has been registered; ask the operator to start one with `vm0 remote-agent start`.
+- `No online remote-agent host`: the host daemon stopped or its heartbeat is stale. Hosts are treated as closed after roughly 90 seconds without a heartbeat.
+- `Remote-agent host not found`: rerun `list` and use the exact host `NAME`.
+- `Multiple remote-agent hosts have this name`: `zero remote-agent run --host` cannot select by id; use a unique host name.
+- `Remote-agent job timed out`: rerun with a larger `--timeout` or ask the remote agent to split the work.

--- a/remote-agent/SKILL.md
+++ b/remote-agent/SKILL.md
@@ -7,49 +7,31 @@ description: VM0 remote-agent CLI for delegating work to an already linked local
 
 # VM0 Remote Agent
 
-Remote-agent lets this agent submit a prompt to an already linked machine running Codex or Claude Code. Use this skill when the current sandbox is not the right execution environment: for example, the task needs a user's local repo, local credentials, a long-running local agent CLI, or a specific workstation that has been registered as a remote-agent host.
+Remote-agent lets this agent submit a natural-language job to a remote-agent host that is already available in VM0. The host runs Codex or Claude Code in its configured environment, then returns the result to the current agent.
 
-Use the `zero remote-agent` entry point for agent-side operations:
+Use it when the current sandbox is not the right execution environment, such as when the task needs a user's local repo, local files, local tools, or a specific workstation.
 
 ```bash
 npx -y -p @vm0/cli zero remote-agent <command>
 ```
 
-The `-y` flag avoids npm's package-install prompt. Omit it only when an interactive install prompt is desired.
-
-## Prerequisites
-
-Authentication is required. The CLI reads tokens in this order: `ZERO_TOKEN`, `VM0_TOKEN`, then the local `~/.vm0/config.json` created by `vm0 auth login`.
-
-If no token is available in the environment, authenticate with:
-
-```bash
-npx -y -p @vm0/cli vm0 auth login
-```
-
-`zero remote-agent` can list hosts and submit jobs only. It does not start or delete hosts. If there is no online host, ask the user or host operator to start one on the intended machine:
-
-```bash
-npx -y -p @vm0/cli vm0 remote-agent start \
-  --name "<host-name>" \
-  --workdir "<absolute-workdir>" \
-  --backend codex \
-  --permission-mode workspace-write
-```
-
-Host setup options are intentionally on the `vm0 remote-agent` command, not `zero remote-agent`.
-
-Supported host backends are `codex` and `claude-code`. Codex permission modes are `default`, `read-only`, `workspace-write`, `danger-full-access`, and `bypassPermissions`. Claude Code permission modes are `default`, `acceptEdits`, `auto`, `dontAsk`, `plan`, and `bypassPermissions`.
+`-y` avoids npm's install prompt. Use `npx -p @vm0/cli ...` without `-y` only when an interactive prompt is acceptable.
 
 ## List Hosts
 
-Always list hosts before targeting a specific host:
+List remote-agent hosts before choosing where to run a job:
 
 ```bash
 npx -y -p @vm0/cli zero remote-agent list
 ```
 
-The output columns are `HOST ID`, `STATUS`, `BACKENDS`, `LAST SEEN`, and `NAME`. Use only hosts with `STATUS` = `online`.
+The output columns are:
+
+- `HOST ID`: host identifier shown for reference
+- `STATUS`: `online` hosts can accept jobs; `closed` hosts cannot
+- `BACKENDS`: supported agent backend, such as `codex` or `claude-code`
+- `LAST SEEN`: how recently the host checked in
+- `NAME`: the host name used by `run --host`
 
 Important: `run --host` takes the host `NAME`, not the host id. If multiple hosts have the same name, the run will fail as ambiguous.
 
@@ -61,7 +43,7 @@ Run on any online host:
 npx -y -p @vm0/cli zero remote-agent run "Check the repo status and summarize the current branch."
 ```
 
-Run on a named host:
+Run on a specific host by name:
 
 ```bash
 npx -y -p @vm0/cli zero remote-agent run \
@@ -70,7 +52,12 @@ npx -y -p @vm0/cli zero remote-agent run \
   "In /path/to/repo, run the tests for package X and report failures with file paths."
 ```
 
-`--timeout` is seconds and defaults to `7200`. The command queues the job, polls until it finishes or times out, prints the remote output, and exits non-zero if the remote job fails.
+Options:
+
+- `--host <name>`: send the job to a named host from `zero remote-agent list`
+- `--timeout <seconds>`: maximum time to wait; defaults to `7200`
+
+The command queues the job, polls until it finishes or times out, prints the remote output, and exits non-zero if the remote job fails.
 
 For multiline prompts, pass one shell argument:
 
@@ -93,17 +80,7 @@ npx -y -p @vm0/cli zero remote-agent run --host "<host-name>" --timeout 7200 "$p
 
 - Include the exact task, expected output, and any relevant repo paths or branches.
 - State whether the remote agent may edit files, run tests, install dependencies, or only inspect.
-- Do not assume the remote host has the same files as the current sandbox. Include enough context for the host's configured `--workdir`.
+- Do not assume the remote host has the same files as the current sandbox. Include enough context for the host's configured working directory.
 - Keep prompts below 60,000 characters.
 - Ask for concise output. Remote job output keeps only the latest output up to the CLI limit, so request summaries plus file paths or commands rather than large logs.
 - Treat remote-agent as execution on another machine. Do not send secrets or private data unless the task requires it and the user authorized it.
-
-## Troubleshooting
-
-- `Not authenticated`: set `ZERO_TOKEN` or `VM0_TOKEN`, or run `npx -y -p @vm0/cli vm0 auth login`.
-- `Remote agent is not enabled`: the account or token lacks remote-agent access.
-- `No linked remote-agent host found`: no host has been registered; ask the operator to start one with `vm0 remote-agent start`.
-- `No online remote-agent host`: the host daemon stopped or its heartbeat is stale. Hosts are treated as closed after roughly 90 seconds without a heartbeat.
-- `Remote-agent host not found`: rerun `list` and use the exact host `NAME`.
-- `Multiple remote-agent hosts have this name`: `zero remote-agent run --host` cannot select by id; use a unique host name.
-- `Remote-agent job timed out`: rerun with a larger `--timeout` or ask the remote agent to split the work.


### PR DESCRIPTION
## Summary
- add a remote-agent skill for using `npx -p @vm0/cli zero remote-agent`
- document list/run usage, host prerequisites, auth, and common failure modes
- register the skill in the marketplace

## Validation
- validated SKILL.md frontmatter
- validated marketplace JSON
- ran `git diff --check`
- checked `zero remote-agent` CLI help output