### PR TITLE
feat: add 6 API-token connector skills (sendgrid, twilio, browserstack, testrail, servicenow, altium-365)

### DIFF
--- a/altium-365/SKILL.md
+++ b/altium-365/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: altium-365
+description: Altium 365 Requirements and Systems Portal REST API for PCB requirements management. Use when user mentions "Altium 365", "Altium", "PCB", "EDA", "Requirements Portal", or "Systems Portal".
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name ALTIUM365_TOKEN` or `zero doctor check-connector --url $ALTIUM365_WORKSPACE_URL/rest/projects --method GET`
+
+## How to Use
+
+All examples assume `ALTIUM365_TOKEN` (Personal User Token) and `ALTIUM365_WORKSPACE_URL` (e.g. `https://acme.365.altium.com`) are set. Altium 365 uses Bearer authentication on the Requirements & Systems Portal REST API.
+
+Base URL: `$ALTIUM365_WORKSPACE_URL/rest`
+
+The workspace URL is specific to your Altium 365 deployment — find it in the address bar of the Requirements & Systems Portal. User tokens are valid for three months from creation.
+
+### 1. Verify the Token
+
+Pull the project list as a connectivity sanity check:
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects?limit=1" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json"
+```
+
+A `401 Unauthorized` typically means the token has expired or never had Portal access; a `404` usually means the workspace URL is wrong.
+
+### 2. List Projects
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects?limit=50" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" | jq '.items[] | {id, name, description}'
+```
+
+### 3. Get a Specific Project
+
+Replace `<project-id>` with an `id` from the list response:
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json"
+```
+
+### 4. List Requirements in a Project
+
+Requirements are the core unit — each represents a system or component requirement that traces through design and verification.
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/requirements?limit=100" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" | jq '.items[] | {id, name, status, priority}'
+```
+
+### 5. Create a Requirement
+
+Write to `/tmp/altium365_request.json`:
+
+```json
+{
+  "name": "REQ-PWR-001 — System operates from 12V ± 5% input",
+  "description": "Board must regulate cleanly from 11.4V to 12.6V input.",
+  "priority": "high",
+  "status": "draft"
+}
+```
+
+```bash
+curl -s -X POST "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/requirements" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/altium365_request.json
+```
+
+### 6. Update a Requirement
+
+Write to `/tmp/altium365_request.json` with only the changed fields (replace `<requirement-id>`):
+
+```json
+{ "status": "approved", "priority": "critical" }
+```
+
+```bash
+curl -s -X PATCH "$ALTIUM365_WORKSPACE_URL/rest/requirements/<requirement-id>" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/altium365_request.json
+```
+
+### 7. Delete a Requirement
+
+```bash
+curl -s -X DELETE "$ALTIUM365_WORKSPACE_URL/rest/requirements/<requirement-id>" --header "Authorization: Bearer $ALTIUM365_TOKEN"
+```
+
+### 8. List Components in a Project
+
+Components map requirements onto subsystems / blocks in the system design:
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/components" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" | jq '.items[] | {id, name, parent_id}'
+```
+
+### 9. Create a Component
+
+Write to `/tmp/altium365_request.json`:
+
+```json
+{
+  "name": "Power Subsystem",
+  "description": "12V → 3.3V / 5V regulation and protection",
+  "parent_id": "<parent-component-id>"
+}
+```
+
+```bash
+curl -s -X POST "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/components" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/altium365_request.json
+```
+
+### 10. Link a Requirement to a Component (Trace)
+
+Write to `/tmp/altium365_request.json`:
+
+```json
+{ "requirement_id": "<requirement-id>", "component_id": "<component-id>" }
+```
+
+```bash
+curl -s -X POST "$ALTIUM365_WORKSPACE_URL/rest/traces" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/altium365_request.json
+```
+
+### 11. List Verification Tests
+
+Verification tests close the loop on each requirement:
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/tests" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" | jq '.items[] | {id, name, status, last_run_at}'
+```
+
+### 12. Record a Test Result
+
+Write to `/tmp/altium365_request.json`:
+
+```json
+{
+  "test_id": "<test-id>",
+  "result": "passed",
+  "notes": "Verified at 11.4V, 12.0V, 12.6V — all within ±2% target rail.",
+  "ran_at": "2026-05-12T14:00:00Z"
+}
+```
+
+```bash
+curl -s -X POST "$ALTIUM365_WORKSPACE_URL/rest/tests/<test-id>/results" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/altium365_request.json
+```
+
+### 13. Export Requirements as JSON
+
+The list endpoint is itself the export — pull all pages with a large `limit`:
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/requirements?limit=1000" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Accept: application/json" > /tmp/altium365_requirements.json
+```
+
+For >1000 items, paginate with the `cursor` field returned in the response.
+
+## Common Workflows
+
+### Bulk-approve all "review" requirements in a project
+
+```bash
+# 1. Find candidate IDs
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/requirements?status=review&limit=200" --header "Authorization: Bearer $ALTIUM365_TOKEN" | jq -r '.items[].id'
+
+# 2. For each <requirement-id>, PATCH status to approved
+# Write /tmp/altium365_request.json: { "status": "approved" }
+curl -s -X PATCH "$ALTIUM365_WORKSPACE_URL/rest/requirements/<requirement-id>" --header "Authorization: Bearer $ALTIUM365_TOKEN" --header "Content-Type: application/json" -d @/tmp/altium365_request.json
+```
+
+### Find requirements without any trace links
+
+```bash
+curl -s "$ALTIUM365_WORKSPACE_URL/rest/projects/<project-id>/requirements?has_traces=false&limit=200" --header "Authorization: Bearer $ALTIUM365_TOKEN" | jq '.items[] | {id, name, status}'
+```
+
+## Guidelines
+
+1. The base host is workspace-specific — every team has their own subdomain on `*.365.altium.com`. There is no single global API host.
+2. User tokens are minted in **Altium 365 → Settings → User Tokens** and expire after **three months** — surface 401s as "token expired, please reconnect," not as bad credentials.
+3. This is the **Requirements & Systems Portal** REST API. Other Altium 365 surfaces (Workspace, Manufacturing Portal, ConcordPro) use OAuth and are not covered here.
+4. IDs are UUIDs / opaque strings — store them as-is.
+5. Pagination uses a `cursor` field plus `limit` (default 50, max 1000). The response includes `next_cursor` when more pages exist.
+6. PATCH is the safe verb for partial updates. PUT replaces the entire resource and any omitted field becomes `null`.
+7. Dates are ISO 8601 with `Z` suffix; localize on the client side.
+8. Trace links are uni-directional (`requirement → component`, `requirement → test`). Listing inbound traces for a component or test uses the parent resource's `/traces` subpath.
+9. Token security: scope tokens to the smallest set of projects the integration needs — Altium 365 supports per-project ACLs on tokens.
+
+## API Reference
+
+- REST / Python API overview: https://www.altium.com/documentation/altium-365/requirements-systems-portal/rest-python-api-documentation
+- Authentication: https://www.altium.com/documentation/altium-365/requirements-systems-portal/rest-python-api-authentication
+- Projects, requirements, components: see the same docs index
+- Altium 365 platform docs: https://www.altium.com/documentation/altium-365

--- a/browserstack/SKILL.md
+++ b/browserstack/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: browserstack
+description: BrowserStack API for cross-browser and device testing. Use when user mentions "BrowserStack", "cross-browser testing", "Selenium grid", "App Live", "Automate", "App Automate", or "real device testing".
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name BROWSERSTACK_USERNAME` or `zero doctor check-connector --url https://api.browserstack.com/automate/plan.json --method GET`
+
+## How to Use
+
+All examples assume `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` are set. BrowserStack uses HTTP Basic auth — username and access key are passed via `-u`.
+
+Hosts by product:
+- Live / general account: `https://api.browserstack.com`
+- Automate (Selenium): `https://api.browserstack.com/automate`
+- App Automate (Appium): `https://api-cloud.browserstack.com/app-automate`
+- Screenshots: `https://www.browserstack.com/screenshots`
+
+Pass credentials with `-u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY"`.
+
+### 1. Verify the Credentials
+
+```bash
+curl -s "https://api.browserstack.com/automate/plan.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY"
+```
+
+Returns the plan name and current parallel-session usage. If you see `401`, the credentials are wrong.
+
+### 2. List Available Browsers (Automate)
+
+Returns every OS / browser / version combo that Automate supports:
+
+```bash
+curl -s "https://api.browserstack.com/automate/browsers.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq '.[] | {os, os_version, browser, browser_version}'
+```
+
+### 3. List Recent Automate Builds
+
+```bash
+curl -s "https://api.browserstack.com/automate/builds.json?limit=10" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq '.[] | .automation_build | {hashed_id, name, status, duration}'
+```
+
+### 4. List Sessions Within a Build
+
+Replace `<build-id>` with a `hashed_id` from step 3:
+
+```bash
+curl -s "https://api.browserstack.com/automate/builds/<build-id>/sessions.json?limit=20" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq '.[] | .automation_session | {hashed_id, name, status, browser, browser_version, os, duration}'
+```
+
+### 5. Fetch a Single Session
+
+```bash
+curl -s "https://api.browserstack.com/automate/sessions/<session-id>.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY"
+```
+
+The response includes `browser_url` (the BrowserStack dashboard URL), `logs`, `video_url`, and `selenium_logs_url`.
+
+### 6. Update Session Status
+
+Mark a session passed or failed and attach a reason (typical end-of-test hook):
+
+Write to `/tmp/browserstack_request.json`:
+
+```json
+{ "status": "passed", "reason": "All assertions passed" }
+```
+
+```bash
+curl -s -X PUT "https://api.browserstack.com/automate/sessions/<session-id>.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" --header "Content-Type: application/json" -d @/tmp/browserstack_request.json
+```
+
+### 7. Download a Session Video
+
+The video URL is exposed in the session response (step 5). Once you have it, download with the same credentials:
+
+```bash
+curl -s "<session-video-url>" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" -o /tmp/session_video.mp4
+```
+
+### 8. Delete a Session
+
+```bash
+curl -s -X DELETE "https://api.browserstack.com/automate/sessions/<session-id>.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY"
+```
+
+### 9. List App Automate Builds
+
+```bash
+curl -s "https://api-cloud.browserstack.com/app-automate/builds.json?limit=10" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq '.[] | .automation_build | {hashed_id, name, status}'
+```
+
+### 10. Upload an App for App Automate
+
+Uploads an `.apk` or `.ipa`. Returns an `app_url` (e.g. `bs://abc123`) to pass in your Appium capabilities:
+
+```bash
+curl -s -X POST "https://api-cloud.browserstack.com/app-automate/upload" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" -F "file=@/path/to/app.apk"
+```
+
+### 11. List Uploaded Apps
+
+```bash
+curl -s "https://api-cloud.browserstack.com/app-automate/recent_apps" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq '.[] | {app_name, app_url, uploaded_at}'
+```
+
+### 12. Generate Screenshots Across Browsers
+
+Write to `/tmp/browserstack_request.json`:
+
+```json
+{
+  "url": "https://example.com",
+  "tunnel": false,
+  "callback_url": "",
+  "win_res": "1280x1024",
+  "mac_res": "1920x1080",
+  "browsers": [
+    { "os": "Windows", "os_version": "11", "browser": "chrome", "browser_version": "latest" },
+    { "os": "OS X", "os_version": "Sonoma", "browser": "safari", "browser_version": "17.0" }
+  ]
+}
+```
+
+```bash
+curl -s -X POST "https://www.browserstack.com/screenshots" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" --header "Content-Type: application/json" -d @/tmp/browserstack_request.json
+```
+
+Poll the returned job ID until each browser's `state` is `done`:
+
+```bash
+curl -s "https://www.browserstack.com/screenshots/<job-id>.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq '.screenshots[] | {browser, state, image_url}'
+```
+
+### 13. Get Console / Network / Appium Logs for a Session
+
+```bash
+curl -s "https://api.browserstack.com/automate/sessions/<session-id>/consolelogs" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY"
+curl -s "https://api.browserstack.com/automate/sessions/<session-id>/networklogs" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY"
+curl -s "https://api-cloud.browserstack.com/app-automate/sessions/<session-id>/appiumlogs" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY"
+```
+
+## Common Workflows
+
+### Mark every running session as failed (incident cleanup)
+
+```bash
+# 1. Find sessions still in "running" state in the most recent build
+curl -s "https://api.browserstack.com/automate/builds.json?limit=1" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq -r '.[0].automation_build.hashed_id'
+# Then for each <build-id>:
+curl -s "https://api.browserstack.com/automate/builds/<build-id>/sessions.json?status=running" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq -r '.[].automation_session.hashed_id'
+
+# 2. For each session ID, mark it failed
+# Write to /tmp/browserstack_request.json: { "status": "failed", "reason": "Incident cleanup" }
+curl -s -X PUT "https://api.browserstack.com/automate/sessions/<session-id>.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" --header "Content-Type: application/json" -d @/tmp/browserstack_request.json
+```
+
+### Check parallel-session capacity before launching
+
+```bash
+curl -s "https://api.browserstack.com/automate/plan.json" -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" | jq '{parallel_sessions_running, parallel_sessions_max_allowed}'
+```
+
+## Guidelines
+
+1. Automate (Selenium/web) lives at `api.browserstack.com`; App Automate (mobile Appium) lives at `api-cloud.browserstack.com`. The screenshots service has its own host. Don't cross the streams.
+2. Authentication is the same across all three — Basic auth with username + access key.
+3. Session and build IDs are `hashed_id` strings — they look opaque, not numeric.
+4. Builds list endpoints return wrapping objects (`{automation_build: {...}}`) — drill into them with jq.
+5. App uploads (step 10) take `multipart/form-data`. Don't `--data-urlencode`.
+6. Video and log URLs are short-lived signed URLs; download them in the same job once you have the session record.
+7. Parallel-session limits are billed per-plan — calling `plan.json` before launching avoids `403 Parallel limit exceeded` errors.
+8. Pagination: most list endpoints use `limit` and `offset` (max `limit=100` on most).
+9. Screenshots API is asynchronous — submit, get a job ID, poll until each browser entry has `state: "done"`.
+
+## API Reference
+
+- Automate REST: https://www.browserstack.com/automate/rest-api
+- App Automate REST: https://www.browserstack.com/app-automate/rest-api
+- Screenshots: https://www.browserstack.com/screenshots/api
+- Capabilities builder: https://www.browserstack.com/automate/capabilities
+- Authentication: https://www.browserstack.com/docs/automate/selenium/getting-started/api-authentication

--- a/sendgrid/SKILL.md
+++ b/sendgrid/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: sendgrid
+description: Twilio SendGrid API for transactional and marketing email. Use when user mentions "SendGrid", "send email", "transactional email", "email marketing", "email API", or "Twilio SendGrid".
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name SENDGRID_TOKEN` or `zero doctor check-connector --url https://api.sendgrid.com/v3/scopes --method GET`
+
+## How to Use
+
+All examples assume `SENDGRID_TOKEN` is set. SendGrid uses Bearer authentication on all v3 endpoints.
+
+Base URL: `https://api.sendgrid.com/v3`
+
+### 1. Verify the API Key
+
+Returns the scopes attached to the current key. Useful for sanity-checking the connection.
+
+```bash
+curl -s "https://api.sendgrid.com/v3/scopes" --header "Authorization: Bearer $SENDGRID_TOKEN"
+```
+
+### 2. Send a Single Transactional Email
+
+Write to `/tmp/sendgrid_request.json`:
+
+```json
+{
+  "personalizations": [
+    {
+      "to": [{ "email": "recipient@example.com", "name": "Recipient" }],
+      "subject": "Hello from vm0"
+    }
+  ],
+  "from": { "email": "noreply@your-verified-domain.com", "name": "vm0" },
+  "content": [
+    { "type": "text/plain", "value": "This is a plain-text body." },
+    { "type": "text/html", "value": "<p>This is an <strong>HTML</strong> body.</p>" }
+  ]
+}
+```
+
+Then send. A successful call returns `202 Accepted` with an empty body:
+
+```bash
+curl -s -X POST "https://api.sendgrid.com/v3/mail/send" --header "Authorization: Bearer $SENDGRID_TOKEN" --header "Content-Type: application/json" -d @/tmp/sendgrid_request.json
+```
+
+### 3. Send to Multiple Recipients with Personalization
+
+Each `personalizations[]` entry produces a separate email. Substitution data is per-recipient.
+
+Write to `/tmp/sendgrid_request.json`:
+
+```json
+{
+  "personalizations": [
+    { "to": [{ "email": "alice@example.com" }], "dynamic_template_data": { "first_name": "Alice" } },
+    { "to": [{ "email": "bob@example.com" }], "dynamic_template_data": { "first_name": "Bob" } }
+  ],
+  "from": { "email": "noreply@your-verified-domain.com" },
+  "template_id": "<your-template-id>"
+}
+```
+
+```bash
+curl -s -X POST "https://api.sendgrid.com/v3/mail/send" --header "Authorization: Bearer $SENDGRID_TOKEN" --header "Content-Type: application/json" -d @/tmp/sendgrid_request.json
+```
+
+### 4. List Dynamic Templates
+
+```bash
+curl -s "https://api.sendgrid.com/v3/templates?generations=dynamic&page_size=100" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq '.result[] | {id, name, generation}'
+```
+
+### 5. Get a Single Template (with all versions)
+
+Replace `<template-id>` with an ID from the list above:
+
+```bash
+curl -s "https://api.sendgrid.com/v3/templates/<template-id>" --header "Authorization: Bearer $SENDGRID_TOKEN"
+```
+
+### 6. List Suppressions (Bounces, Blocks, Spam Reports)
+
+Recent bounces:
+
+```bash
+curl -s "https://api.sendgrid.com/v3/suppression/bounces" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq '.[] | {email, reason, created}'
+```
+
+Other suppression lists follow the same shape — replace the path segment:
+- `/v3/suppression/blocks`
+- `/v3/suppression/spam_reports`
+- `/v3/suppression/invalid_emails`
+- `/v3/asm/suppressions/global` (global unsubscribes)
+
+### 7. Remove an Address from a Suppression List
+
+Replace `<email>` with the address to release. Returns `204 No Content` on success:
+
+```bash
+curl -s -X DELETE "https://api.sendgrid.com/v3/suppression/bounces/<email>" --header "Authorization: Bearer $SENDGRID_TOKEN"
+```
+
+### 8. List Verified Senders
+
+Senders must be verified before they can appear in the `from` field.
+
+```bash
+curl -s "https://api.sendgrid.com/v3/verified_senders" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq '.results[] | {id, from_email, verified}'
+```
+
+### 9. Marketing Campaigns — List Contacts
+
+Marketing Campaigns uses a separate path under `/v3/marketing`:
+
+```bash
+curl -s "https://api.sendgrid.com/v3/marketing/contacts" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq '.result[] | {id, email, first_name, last_name}'
+```
+
+### 10. Add or Update a Contact
+
+Upsert is asynchronous and returns a `job_id`. Write to `/tmp/sendgrid_request.json`:
+
+```json
+{
+  "contacts": [
+    { "email": "newcontact@example.com", "first_name": "Pat", "last_name": "Sample" }
+  ]
+}
+```
+
+```bash
+curl -s -X PUT "https://api.sendgrid.com/v3/marketing/contacts" --header "Authorization: Bearer $SENDGRID_TOKEN" --header "Content-Type: application/json" -d @/tmp/sendgrid_request.json
+```
+
+### 11. List Marketing Lists
+
+```bash
+curl -s "https://api.sendgrid.com/v3/marketing/lists" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq '.result[] | {id, name, contact_count}'
+```
+
+### 12. Get Email Activity Stats
+
+Aggregate stats by day for a date range:
+
+```bash
+curl -s "https://api.sendgrid.com/v3/stats?start_date=2026-04-01&end_date=2026-05-01&aggregated_by=day" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq '.[] | {date, stats: .stats[0].metrics}'
+```
+
+Aggregate by week or month by setting `aggregated_by=week` or `aggregated_by=month`.
+
+## Common Workflows
+
+### Send a templated email to a single recipient
+
+```bash
+# 1. Find the template you want to use
+curl -s "https://api.sendgrid.com/v3/templates?generations=dynamic" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq '.result[] | {id, name}'
+
+# 2. Build the request with the template ID and per-recipient data
+# Write to /tmp/sendgrid_request.json
+# {
+#   "personalizations": [{ "to": [{"email": "user@example.com"}], "dynamic_template_data": {"name": "Pat"} }],
+#   "from": { "email": "noreply@your-domain.com" },
+#   "template_id": "d-abcdef0123456789"
+# }
+curl -s -X POST "https://api.sendgrid.com/v3/mail/send" --header "Authorization: Bearer $SENDGRID_TOKEN" --header "Content-Type: application/json" -d @/tmp/sendgrid_request.json
+```
+
+### Audit recent bounces
+
+```bash
+curl -s "https://api.sendgrid.com/v3/suppression/bounces?start_time=1714521600" --header "Authorization: Bearer $SENDGRID_TOKEN" | jq 'group_by(.reason) | map({reason: .[0].reason, count: length})'
+```
+
+`start_time` is a Unix epoch timestamp.
+
+## Guidelines
+
+1. The `from.email` must be a verified sender or part of a verified sending domain — unverified senders return `403`.
+2. `Authorization: Bearer $SENDGRID_TOKEN` is the only supported auth scheme on v3.
+3. `/v3/mail/send` returns `202 Accepted` with an empty body on success — no message ID is returned in the body; use the `X-Message-Id` response header for tracking.
+4. Marketing Campaigns endpoints live under `/v3/marketing/` and use a different rate-limit pool than `/v3/mail/send`.
+5. Contact upserts are asynchronous — you get a `job_id`, then poll `/v3/marketing/contacts/imports/<job_id>` for status.
+6. Dates accept ISO 8601 (`2026-04-18`) or Unix epoch depending on the endpoint — check the docs per call.
+7. Pagination uses `page_size` and `page_token`; `Link` response header carries the cursor for the next page.
+8. Rate limits vary by endpoint (e.g., `/v3/mail/send` allows ~600 requests per minute on most plans) — watch `X-RateLimit-Remaining` and `X-RateLimit-Reset`.
+
+## API Reference
+
+- API reference: https://www.twilio.com/docs/sendgrid/api-reference
+- Mail Send v3: https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send
+- Marketing Campaigns: https://www.twilio.com/docs/sendgrid/api-reference/marketing-campaigns-contacts
+- Suppressions: https://www.twilio.com/docs/sendgrid/api-reference/suppressions-bounces
+- Stats: https://www.twilio.com/docs/sendgrid/api-reference/stats

--- a/servicenow/SKILL.md
+++ b/servicenow/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: servicenow
+description: ServiceNow Table API for ITSM, incidents, change requests, and CMDB. Use when user mentions "ServiceNow", "incident", "change request", "ITSM", "CMDB", "Now Platform", or "service catalog".
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name SERVICENOW_USERNAME` or `zero doctor check-connector --url https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident?sysparm_limit=1 --method GET`
+
+## How to Use
+
+All examples assume `SERVICENOW_USERNAME`, `SERVICENOW_PASSWORD`, and `SERVICENOW_INSTANCE` (the subdomain before `.service-now.com`) are set. ServiceNow uses HTTP Basic auth — username and password on every request.
+
+Base URL: `https://$SERVICENOW_INSTANCE.service-now.com/api/now/`
+
+Pass credentials with `-u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD"`.
+
+The Table API (`/api/now/table/<table>`) is the workhorse — almost every record type (incident, change_request, problem, cmdb_ci, sys_user, etc.) is reachable through it.
+
+### 1. Verify the Credentials
+
+Fetch one incident to confirm the connection. `sysparm_limit=1` keeps the response small:
+
+```bash
+curl -s "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident?sysparm_limit=1" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json"
+```
+
+A `401` means bad credentials; a `403` means the user lacks the required role (typically `itil` for incidents).
+
+### 2. List Incidents
+
+`sysparm_query` accepts ServiceNow's encoded query string (filters joined with `^`):
+
+```bash
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --data-urlencode "sysparm_query=active=true^priority=1" --data-urlencode "sysparm_fields=number,short_description,priority,state,assigned_to.name,sys_id" --data-urlencode "sysparm_limit=25"
+```
+
+Common encoded-query operators: `=`, `!=`, `>`, `<`, `LIKE`, `STARTSWITH`, `IN`, `^OR`, `^EQ`, `ORDERBY`, `ORDERBYDESC`.
+
+### 3. Get a Single Incident
+
+Replace `<sys-id>` with the 32-character `sys_id` from a list response:
+
+```bash
+curl -s "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident/<sys-id>?sysparm_display_value=true" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json"
+```
+
+`sysparm_display_value=true` returns human-readable labels instead of raw IDs.
+
+### 4. Create an Incident
+
+Write to `/tmp/servicenow_request.json`:
+
+```json
+{
+  "short_description": "App login intermittently fails for SSO users",
+  "description": "Users from acme.com see a 502 about 1/20 logins since 09:00 UTC.",
+  "category": "software",
+  "impact": "2",
+  "urgency": "2",
+  "caller_id": "<sys-user-sys-id>"
+}
+```
+
+```bash
+curl -s -X POST "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/servicenow_request.json
+```
+
+`priority` is auto-calculated from `impact` × `urgency`.
+
+### 5. Update an Incident
+
+Write to `/tmp/servicenow_request.json` with only the fields to change, then run (replace `<sys-id>`):
+
+```json
+{
+  "state": "6",
+  "close_code": "Solved (Permanently)",
+  "close_notes": "Reinstated session affinity in load balancer."
+}
+```
+
+```bash
+curl -s -X PATCH "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident/<sys-id>" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/servicenow_request.json
+```
+
+Common incident `state` values: `1` New, `2` In Progress, `3` On Hold, `6` Resolved, `7` Closed, `8` Canceled.
+
+### 6. Delete a Record (admin only)
+
+Use sparingly — most workflows resolve / cancel rather than delete:
+
+```bash
+curl -s -X DELETE "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident/<sys-id>" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD"
+```
+
+### 7. List Change Requests
+
+```bash
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/change_request" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --data-urlencode "sysparm_query=state!=closed^ORDERBYDESCsys_created_on" --data-urlencode "sysparm_fields=number,short_description,state,risk,assignment_group.name,sys_id" --data-urlencode "sysparm_limit=25"
+```
+
+### 8. Create a Standard Change
+
+Write to `/tmp/servicenow_request.json`:
+
+```json
+{
+  "short_description": "Restart prod-app-3 after kernel patch",
+  "description": "Maintenance window 2026-05-20 02:00–04:00 UTC.",
+  "type": "standard",
+  "category": "Software",
+  "risk": "3",
+  "impact": "3"
+}
+```
+
+```bash
+curl -s -X POST "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/change_request" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/servicenow_request.json
+```
+
+### 9. Look Up a User by Email
+
+```bash
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/sys_user" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --data-urlencode "sysparm_query=email=user@example.com" --data-urlencode "sysparm_fields=sys_id,name,email,user_name,department.name"
+```
+
+The returned `sys_id` is what you pass for `caller_id`, `assigned_to`, etc.
+
+### 10. Query CMDB Configuration Items
+
+```bash
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/cmdb_ci" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --data-urlencode "sysparm_query=nameLIKEprod-app" --data-urlencode "sysparm_fields=name,sys_class_name,operational_status,sys_id" --data-urlencode "sysparm_limit=20"
+```
+
+### 11. Add a Work Note (Journal Field)
+
+`work_notes` is internal-only; `comments` is customer-visible. Update either via PATCH:
+
+Write to `/tmp/servicenow_request.json`:
+
+```json
+{ "work_notes": "Engaged on-call DBA, awaiting query plan." }
+```
+
+```bash
+curl -s -X PATCH "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident/<sys-id>" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --header "Content-Type: application/json" -d @/tmp/servicenow_request.json
+```
+
+### 12. List Attachments on a Record
+
+```bash
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/attachment" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --data-urlencode "sysparm_query=table_name=incident^table_sys_id=<sys-id>"
+```
+
+### 13. Upload an Attachment
+
+Replace `<table>` (e.g. `incident`) and `<sys-id>`. `--data-binary` sends the file bytes raw; `Content-Type` should match the file:
+
+```bash
+curl -s -X POST "https://$SERVICENOW_INSTANCE.service-now.com/api/now/attachment/file?table_name=<table>&table_sys_id=<sys-id>&file_name=report.pdf" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --header "Content-Type: application/pdf" --data-binary @/path/to/report.pdf
+```
+
+### 14. List the Tables You Can Query
+
+```bash
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/sys_db_object" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --data-urlencode "sysparm_query=super_class.name=task" --data-urlencode "sysparm_fields=name,label"
+```
+
+### 15. Aggregate / Count (Aggregate API)
+
+Counts open P1 incidents per assignment group:
+
+```bash
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/stats/incident" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Accept: application/json" --data-urlencode "sysparm_query=active=true^priority=1" --data-urlencode "sysparm_group_by=assignment_group" --data-urlencode "sysparm_count=true"
+```
+
+## Common Workflows
+
+### Auto-create an incident from an alert
+
+```bash
+# 1. Look up the caller's sys_id by email
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/sys_user" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --data-urlencode "sysparm_query=email=alerts@example.com" --data-urlencode "sysparm_fields=sys_id" | jq -r '.result[0].sys_id'
+
+# 2. Build /tmp/servicenow_request.json with caller_id set, then POST
+curl -s -X POST "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Content-Type: application/json" -d @/tmp/servicenow_request.json
+```
+
+### Close every On-Hold incident older than 60 days
+
+```bash
+# 1. Query candidates (replace 2026-03-15 with cutoff)
+curl -s -G "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --data-urlencode "sysparm_query=state=3^sys_updated_on<2026-03-15 00:00:00" --data-urlencode "sysparm_fields=sys_id,number" | jq -r '.result[].sys_id'
+
+# 2. For each <sys-id>, PATCH to state=7 (Closed) with close fields populated
+# Write /tmp/servicenow_request.json: {"state":"7","close_code":"Closed/Resolved by Caller","close_notes":"Auto-closed after 60 days stale"}
+curl -s -X PATCH "https://$SERVICENOW_INSTANCE.service-now.com/api/now/table/incident/<sys-id>" -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" --header "Content-Type: application/json" -d @/tmp/servicenow_request.json
+```
+
+## Guidelines
+
+1. Every record has a 32-character hex `sys_id` — it's the immutable primary key, distinct from human-readable numbers like `INC0010001`.
+2. Encoded-query syntax (`sysparm_query=state=2^active=true^ORimpact=1`) is the only filter language for the Table API. Reference: ServiceNow's "Encoded Query Strings" docs.
+3. `sysparm_display_value=true` returns labels (e.g. `Critical`) instead of internal values (`1`). For writes, always send internal values.
+4. Reference fields can be dot-walked in `sysparm_fields` (e.g. `assigned_to.name`, `caller_id.email`) — saves an extra round trip.
+5. Pagination: `sysparm_limit` (default 10000, but practical max ~1000), `sysparm_offset`. Response headers include `X-Total-Count` and `Link` for the next page.
+6. The user must have the right role on each table — `itil` for incident/problem/change, `cmdb_read` for CMDB, `admin` for sys_user_role assignment, etc. `403` errors usually mean missing roles, not bad creds.
+7. PATCH is the right verb for partial updates; PUT replaces the entire record (often loses data unless every field is sent).
+8. Attachments live in the `sys_attachment` table; uploads use `application/binary` semantics — see step 13.
+9. Aggregate / stats endpoints (`/api/now/stats/<table>`) avoid pulling thousands of rows for counts.
+10. Rate limit: instance-specific, but the default is ~600 requests/min per user; expect throttling at scale. Response code `429` returns `Retry-After`.
+
+## API Reference
+
+- Table API: https://developer.servicenow.com/dev.do#!/reference/api/rome/rest/c_TableAPI
+- Aggregate API: https://developer.servicenow.com/dev.do#!/reference/api/rome/rest/c_AggregateAPI
+- Attachment API: https://developer.servicenow.com/dev.do#!/reference/api/rome/rest/c_AttachmentAPI
+- Encoded query strings: https://docs.servicenow.com/bundle/rome-platform-user-interface/page/use/common-ui-elements/reference/r_OpAvailableFiltersQueries.html
+- Authentication options: https://docs.servicenow.com/bundle/rome-application-development/page/integrate/inbound-rest/concept/c_InboundRESTBasicAuth.html

--- a/testrail/SKILL.md
+++ b/testrail/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: testrail
+description: TestRail API for QA test case management. Use when user mentions "TestRail", "test cases", "test runs", "test results", "test plans", "QA management", or "Gurock TestRail".
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name TESTRAIL_TOKEN` or `zero doctor check-connector --url https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_projects --method GET`
+
+## How to Use
+
+All examples assume `TESTRAIL_EMAIL`, `TESTRAIL_TOKEN` (API key), and `TESTRAIL_INSTANCE` (the subdomain before `.testrail.io`) are set. TestRail uses HTTP Basic auth — email as username, API key as password.
+
+Base URL: `https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/`
+
+Pass credentials with `-u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN"`. Self-hosted instances use a different domain; set `TESTRAIL_INSTANCE` appropriately if your team runs TestRail Server.
+
+### 1. List Projects
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_projects" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.projects[] | {id, name, suite_mode, is_completed}'
+```
+
+`suite_mode`: `1` = single suite, `2` = single suite + baselines, `3` = multiple suites.
+
+### 2. Get a Single Project
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_project/<project-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN"
+```
+
+### 3. List Test Suites in a Project
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_suites/<project-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.[] | {id, name, description}'
+```
+
+### 4. List Sections in a Suite
+
+Sections organize cases into a tree. Replace `<project-id>` and `<suite-id>`:
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_sections/<project-id>&suite_id=<suite-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.sections[] | {id, name, parent_id, depth}'
+```
+
+### 5. List Test Cases
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_cases/<project-id>&suite_id=<suite-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.cases[] | {id, title, priority_id, type_id, section_id}'
+```
+
+Filter by section or other criteria:
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_cases/<project-id>&suite_id=<suite-id>&section_id=<section-id>&priority_id=4" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN"
+```
+
+### 6. Get a Specific Test Case
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_case/<case-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN"
+```
+
+### 7. Create a Test Case
+
+Write to `/tmp/testrail_request.json`:
+
+```json
+{
+  "title": "User can log in with valid credentials",
+  "type_id": 1,
+  "priority_id": 4,
+  "custom_steps": "1. Open login page\n2. Enter valid credentials\n3. Click Login",
+  "custom_expected": "User lands on dashboard"
+}
+```
+
+Replace `<section-id>` with the destination section ID:
+
+```bash
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/add_case/<section-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/testrail_request.json
+```
+
+### 8. Update a Test Case
+
+Write to `/tmp/testrail_request.json` with only the fields you want to change, then run (replace `<case-id>`):
+
+```bash
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/update_case/<case-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/testrail_request.json
+```
+
+### 9. List Test Runs
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_runs/<project-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.runs[] | {id, name, suite_id, is_completed, passed_count, failed_count}'
+```
+
+### 10. Create a Test Run
+
+A run binds cases to a planned execution. Write to `/tmp/testrail_request.json`:
+
+```json
+{
+  "suite_id": <suite-id>,
+  "name": "Sprint 42 — Regression",
+  "include_all": false,
+  "case_ids": [<case-id>, <case-id>]
+}
+```
+
+Set `include_all` to `true` to include every case in the suite; otherwise list specific `case_ids`. Replace `<project-id>`:
+
+```bash
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/add_run/<project-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/testrail_request.json
+```
+
+### 11. List Tests in a Run
+
+`tests` are case-in-run instances and have IDs distinct from the underlying case IDs:
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_tests/<run-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.tests[] | {id, case_id, title, status_id}'
+```
+
+### 12. Add a Result for a Test
+
+Write to `/tmp/testrail_request.json`:
+
+```json
+{
+  "status_id": 1,
+  "comment": "Verified on Chrome 124 and Firefox 125.",
+  "elapsed": "3m 20s",
+  "version": "1.2.3"
+}
+```
+
+Status IDs: `1` Passed, `2` Blocked, `3` Untested, `4` Retest, `5` Failed (defaults — your instance may have custom statuses).
+
+```bash
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/add_result/<test-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/testrail_request.json
+```
+
+### 13. Bulk-Add Results by Case ID
+
+Useful for posting CI results in one call. Write to `/tmp/testrail_request.json`:
+
+```json
+{
+  "results": [
+    { "case_id": 101, "status_id": 1, "comment": "Passed" },
+    { "case_id": 102, "status_id": 5, "comment": "Failed — see attached log" }
+  ]
+}
+```
+
+```bash
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/add_results_for_cases/<run-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/testrail_request.json
+```
+
+### 14. Close a Test Run
+
+Archives the run and prevents further result entry:
+
+```bash
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/close_run/<run-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN"
+```
+
+### 15. List Milestones
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_milestones/<project-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.milestones[] | {id, name, due_on, is_completed}'
+```
+
+### 16. List Users
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_users" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.[] | {id, name, email, role_id, is_active}'
+```
+
+## Common Workflows
+
+### Post CI results for a sprint run
+
+```bash
+# 1. Find (or create) the run for this sprint
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_runs/<project-id>&is_completed=0" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.runs[] | {id, name}'
+
+# 2. Bulk-post results by case_id (see step 13)
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/add_results_for_cases/<run-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" --header "Content-Type: application/json" -d @/tmp/testrail_request.json
+
+# 3. Close the run when sprint completes
+curl -s -X POST "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/close_run/<run-id>" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN"
+```
+
+### Find failing tests in the latest run
+
+```bash
+curl -s "https://$TESTRAIL_INSTANCE.testrail.io/index.php?/api/v2/get_tests/<run-id>&status_id=5" -u "$TESTRAIL_EMAIL:$TESTRAIL_TOKEN" | jq '.tests[] | {case_id, title, refs}'
+```
+
+## Guidelines
+
+1. URLs use TestRail's quirky `index.php?/api/v2/<endpoint>/<id>` query-string style — extra parameters use `&key=value`, never `?key=value` (the `?` is already consumed by `/api/v2/...`).
+2. Authentication is HTTP Basic: email as username, API key as password. Generate the key in **My Settings → API Keys** (admin must have **Enable API** turned on for the instance).
+3. `case_ids` belong to the suite; `test_id` belongs to a specific run — don't confuse them when adding results.
+4. Bulk endpoints (e.g. `add_results_for_cases`) succeed atomically — if any record fails validation, the entire batch is rejected.
+5. Pagination: list endpoints with many records return a `_links` object with `next`/`prev` and use `offset` + `limit` query params (default limit 250, max 250 from v6.7+).
+6. Status, priority, and type IDs differ if your instance was customized — pull `/get_statuses`, `/get_priorities`, `/get_case_types` first if you're not sure.
+7. Custom fields are exposed as `custom_<system_name>` keys (e.g., `custom_steps`, `custom_expected`).
+8. Self-hosted TestRail Server uses a different host than `testrail.io` — change `TESTRAIL_INSTANCE` to your full host (still go through `index.php?/api/v2/`).
+9. Rate limit: TestRail Cloud enforces 180 requests per minute per user by default. `429` responses include a `Retry-After` header.
+
+## API Reference
+
+- API overview: https://support.testrail.com/hc/en-us/articles/7077083596436-Introduction-to-the-TestRail-API
+- Cases: https://support.testrail.com/hc/en-us/articles/7077295410732-Cases
+- Runs: https://support.testrail.com/hc/en-us/articles/7077874763156-Runs
+- Tests: https://support.testrail.com/hc/en-us/articles/7077874763156-Tests
+- Results: https://support.testrail.com/hc/en-us/articles/7077819312404-Results
+- Authentication: https://support.testrail.com/hc/en-us/articles/7077039051284-Accessing-the-TestRail-API

--- a/twilio/SKILL.md
+++ b/twilio/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: twilio
+description: Twilio API for SMS, voice, WhatsApp, and Verify. Use when user mentions "Twilio", "send SMS", "voice call", "WhatsApp message", "phone number lookup", or "Verify OTP".
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name TWILIO_ACCOUNT_SID` or `zero doctor check-connector --url https://api.twilio.com/2010-04-01/Accounts.json --method GET`
+
+## How to Use
+
+All examples assume `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` are set. Twilio uses HTTP Basic auth — the Account SID is the username, the Auth Token is the password.
+
+Base URL: `https://api.twilio.com/2010-04-01` (core REST API). Product subdomains for newer services: `verify.twilio.com`, `messaging.twilio.com`, `lookups.twilio.com`, `serverless.twilio.com`, `studio.twilio.com`.
+
+Pass credentials to curl with `-u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN"`.
+
+### 1. Verify the Credentials
+
+Fetch the account record — a quick sanity check that the SID/token pair is valid:
+
+```bash
+curl -s "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" | jq '{sid, friendly_name, status, type}'
+```
+
+### 2. Send an SMS
+
+`From` must be a number you own (purchased through Twilio) or a Messaging Service SID. Body is plain text. Returns the message resource including `sid` and initial `status`:
+
+```bash
+curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=+14155552671" --data-urlencode "From=+14155550100" --data-urlencode "Body=Hello from vm0"
+```
+
+### 3. Send a WhatsApp Message
+
+Prefix WhatsApp numbers with `whatsapp:`. Use Twilio's sandbox or an approved sender:
+
+```bash
+curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=whatsapp:+14155552671" --data-urlencode "From=whatsapp:+14155238886" --data-urlencode "Body=Hi via WhatsApp"
+```
+
+### 4. Send an MMS (with media)
+
+Pass one or more `MediaUrl` values. Each URL must be publicly reachable:
+
+```bash
+curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=+14155552671" --data-urlencode "From=+14155550100" --data-urlencode "Body=See attached" --data-urlencode "MediaUrl=https://example.com/photo.jpg"
+```
+
+### 5. List Recent Messages
+
+```bash
+curl -s "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json?PageSize=20" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" | jq '.messages[] | {sid, from, to, status, body, date_sent}'
+```
+
+Filter by recipient or date:
+
+```bash
+curl -s -G "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=+14155552671" --data-urlencode "DateSent>=2026-04-01"
+```
+
+### 6. Fetch a Specific Message (by SID)
+
+Replace `<message-sid>` (always starts with `SM`) with a value returned from the send/list endpoints:
+
+```bash
+curl -s "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages/<message-sid>.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN"
+```
+
+### 7. Make an Outbound Voice Call
+
+The `Url` returns TwiML that drives the call. For a quick test, point it at the Twilio demo TwiML hosted on Twimlets:
+
+```bash
+curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Calls.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=+14155552671" --data-urlencode "From=+14155550100" --data-urlencode "Url=http://demo.twilio.com/docs/voice.xml"
+```
+
+### 8. List Recent Calls
+
+```bash
+curl -s "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Calls.json?PageSize=20" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" | jq '.calls[] | {sid, from, to, status, duration, start_time}'
+```
+
+### 9. List Phone Numbers You Own
+
+```bash
+curl -s "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/IncomingPhoneNumbers.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" | jq '.incoming_phone_numbers[] | {sid, phone_number, friendly_name, capabilities}'
+```
+
+### 10. Search for Available Numbers to Buy
+
+Find a US local number with SMS + MMS capability:
+
+```bash
+curl -s "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/AvailablePhoneNumbers/US/Local.json?SmsEnabled=true&MmsEnabled=true&PageSize=10" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" | jq '.available_phone_numbers[] | {phone_number, locality, region}'
+```
+
+### 11. Look Up a Phone Number (Lookups v2)
+
+Returns carrier, line type, country, and validity. Replace `<phone-number>` with an E.164-formatted number:
+
+```bash
+curl -s "https://lookups.twilio.com/v2/PhoneNumbers/<phone-number>?Fields=line_type_intelligence" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN"
+```
+
+### 12. Create a Verify Service (Verify v2 — OTP / 2FA)
+
+```bash
+curl -s -X POST "https://verify.twilio.com/v2/Services" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "FriendlyName=vm0 OTP"
+```
+
+The response includes a service SID (`VAxxxxxxxx...`) used in subsequent verifications.
+
+### 13. Send a Verification Code
+
+Replace `<verify-service-sid>` with the SID from step 12. Channel is `sms`, `call`, `whatsapp`, or `email`:
+
+```bash
+curl -s -X POST "https://verify.twilio.com/v2/Services/<verify-service-sid>/Verifications" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=+14155552671" --data-urlencode "Channel=sms"
+```
+
+### 14. Check a Verification Code
+
+```bash
+curl -s -X POST "https://verify.twilio.com/v2/Services/<verify-service-sid>/VerificationCheck" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=+14155552671" --data-urlencode "Code=123456"
+```
+
+`status` will be `approved`, `pending`, or `canceled`.
+
+## Common Workflows
+
+### Send an SMS and poll for delivery
+
+```bash
+# 1. Send and capture the message SID
+curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "To=+14155552671" --data-urlencode "From=+14155550100" --data-urlencode "Body=Order #1234 ready" | jq -r '.sid'
+
+# 2. Poll status until delivered, failed, or undelivered (replace <message-sid>)
+curl -s "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/Messages/<message-sid>.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" | jq '{status, error_code, error_message}'
+```
+
+### Buy a number from a search result
+
+```bash
+# 1. Search (see step 10) and copy a phone_number
+# 2. Purchase it
+curl -s -X POST "https://api.twilio.com/2010-04-01/Accounts/$TWILIO_ACCOUNT_SID/IncomingPhoneNumbers.json" -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" --data-urlencode "PhoneNumber=<phone-number>"
+```
+
+## Guidelines
+
+1. The Account SID always starts with `AC` and is 34 characters; Auth Tokens are 32 hex characters.
+2. All form fields use `--data-urlencode` — Twilio rejects `application/json` on the classic `api.twilio.com` endpoints; payloads are `application/x-www-form-urlencoded`.
+3. Phone numbers must be E.164 format (`+14155552671`). For WhatsApp, prefix with `whatsapp:`.
+4. Newer products (Verify, Lookups, Messaging, Studio, Serverless) use product subdomains, not the `2010-04-01` REST root.
+5. SMS status flows through `queued → sending → sent → delivered` (or `failed` / `undelivered`). Use webhook callbacks or poll the message resource — there's no list-of-deliveries stream.
+6. Trial accounts can only send to verified numbers and Twilio prepends a trial header to every SMS.
+7. Pagination uses `PageSize` (max 1000) and either `Page` or the `next_page_uri` field in the response.
+8. Rate limits are account-wide and product-specific; expect ~100 messages/sec on standard senders, much lower on trial. Inspect `Twilio-Rate-Limit-Remaining`.
+9. Verify codes default to 6 digits and 10 minutes; configure on the Verify Service resource.
+
+## API Reference
+
+- REST API overview: https://www.twilio.com/docs/iam/api
+- Messages (SMS / MMS / WhatsApp): https://www.twilio.com/docs/messaging/api/message-resource
+- Calls (Voice): https://www.twilio.com/docs/voice/api/call-resource
+- Phone Numbers: https://www.twilio.com/docs/phone-numbers/api/incomingphonenumber-resource
+- Lookups v2: https://www.twilio.com/docs/lookup/v2-api
+- Verify v2: https://www.twilio.com/docs/verify/api
+- Status callbacks: https://www.twilio.com/docs/usage/webhooks


### PR DESCRIPTION
## Summary

Add SKILL.md for six SaaS services that authenticate via static API tokens or equivalent HTTP Basic credentials:

| Service | Auth | Notes |
|---|---|---|
| **SendGrid** | Bearer SG.xxx | Single-secret |
| **Twilio** | Basic(AccountSid:AuthToken) | Two static credentials, fixed host |
| **BrowserStack** | Basic(username:access_key) | Two static credentials, fixed host |
| **TestRail** | Basic(email:api_key) | Two credentials + instance subdomain |
| **ServiceNow** | Basic(username:password) | Two credentials + instance subdomain |
| **Altium 365** | Bearer user token | Token + workspace URL, 3-month TTL |

Each skill follows the canonical template (docs/skill-template.md): Troubleshooting section with `zero doctor check-connector`, file-based JSON payloads under `/tmp`, `<placeholder>` for dynamic IDs returned by API calls, and no inline JSON.

Paired connector definitions: vm0-ai/vm0#13195

### Excluded (don't support static API tokens)

- Google Analytics — OAuth2 / Service Account JWT only
- QuickBooks Online — OAuth2 with rotating refresh tokens
- Bill.com — multi-step session login
- Expensify — credentials in form body, not a header

## Test plan

- [ ] Each SKILL.md passes the docs/bad-smell.md checklist
- [ ] curl examples authenticate against the placeholder vocabulary the firewall expects
- [ ] Connector PR vm0-ai/vm0#13195 lands and Settings → Connectors shows each new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)