### PR TITLE
feat: add gong and ironclad skills

### DIFF
--- a/gong/SKILL.md
+++ b/gong/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: gong
+description: Gong API for revenue intelligence. Use when user mentions "Gong", "sales calls", "call recordings", "call transcripts", "conversation intelligence", or needs to read calls, transcripts, users, or deals from Gong.
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name GONG_ACCESS_KEY` or `zero doctor check-connector --url https://$GONG_API_BASE/v2/users --method GET`
+
+## Authentication
+
+Gong uses HTTP Basic authentication. The username is your **Access Key** and the password is your **Access Key Secret**. With curl, pass them via the `-u` flag (it handles Base64 encoding):
+
+```bash
+-u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET"
+```
+
+Generate the key pair in Gong under **Company Settings → Ecosystem → API**. It requires the "Technical Administrator" permission profile.
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `GONG_ACCESS_KEY` | Gong API Access Key |
+| `GONG_ACCESS_KEY_SECRET` | Gong API Access Key Secret |
+| `GONG_API_BASE` | API host for your Gong tenant (e.g. `api.gong.io`, or your region-specific host) |
+
+## Base URL
+
+`https://$GONG_API_BASE` — the host is shown on the same screen where you generate the API key ("API Base URL"). Standard tenants use `api.gong.io`; EU and other regional tenants have a region-specific host. All endpoints are under `/v2/`.
+
+Rate limit: 3 requests/second and 10,000 requests/day per API key.
+
+## Calls
+
+### List Calls
+
+Calls in a date range (ISO 8601 timestamps, max 90-day window):
+
+```bash
+curl -s "https://$GONG_API_BASE/v2/calls?fromDateTime=2026-01-01T00:00:00Z&toDateTime=2026-01-31T00:00:00Z" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET"
+```
+
+Paginate with the `cursor` query param returned in `records.cursor`.
+
+### Retrieve a Call
+
+```bash
+curl -s "https://$GONG_API_BASE/v2/calls/<call-id>" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET"
+```
+
+### Extensive Call Data
+
+Rich call data (parties, context, content, interaction stats) with filters. Write to `/tmp/gong_extensive.json`:
+
+```json
+{
+  "filter": {
+    "fromDateTime": "2026-01-01T00:00:00Z",
+    "toDateTime": "2026-01-31T00:00:00Z"
+  },
+  "contentSelector": {
+    "exposedFields": {
+      "parties": true,
+      "content": { "structure": true, "topics": true, "trackers": true },
+      "interaction": { "speakers": true }
+    }
+  }
+}
+```
+
+```bash
+curl -s -X POST "https://$GONG_API_BASE/v2/calls/extensive" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET" -H "Content-Type: application/json" -d @/tmp/gong_extensive.json
+```
+
+### Call Transcripts
+
+Write to `/tmp/gong_transcript.json`:
+
+```json
+{
+  "filter": {
+    "callIds": ["<call-id>"]
+  }
+}
+```
+
+```bash
+curl -s -X POST "https://$GONG_API_BASE/v2/calls/transcript" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET" -H "Content-Type: application/json" -d @/tmp/gong_transcript.json
+```
+
+## Users
+
+### List Users
+
+```bash
+curl -s "https://$GONG_API_BASE/v2/users" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET"
+```
+
+### Retrieve a User
+
+```bash
+curl -s "https://$GONG_API_BASE/v2/users/<user-id>" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET"
+```
+
+## Workspaces
+
+```bash
+curl -s "https://$GONG_API_BASE/v2/workspaces" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET"
+```
+
+## Scorecards
+
+```bash
+curl -s "https://$GONG_API_BASE/v2/settings/scorecards" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET"
+```
+
+## CRM Calls / Deals
+
+Aggregated activity stats for users. Write to `/tmp/gong_activity.json`:
+
+```json
+{
+  "filter": {
+    "fromDateTime": "2026-01-01T00:00:00Z",
+    "toDateTime": "2026-01-31T00:00:00Z"
+  }
+}
+```
+
+```bash
+curl -s -X POST "https://$GONG_API_BASE/v2/stats/activity/aggregate" -u "$GONG_ACCESS_KEY:$GONG_ACCESS_KEY_SECRET" -H "Content-Type: application/json" -d @/tmp/gong_activity.json
+```
+
+## Notes
+
+- All POST bodies require `Content-Type: application/json`.
+- List endpoints are cursor-paginated: pass `records.cursor` from the previous response as the `cursor` query param (GET) or body field (POST).
+- Date filters use ISO 8601 UTC timestamps and are capped at a 90-day window per request.

--- a/ironclad/SKILL.md
+++ b/ironclad/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: ironclad
+description: Ironclad API for contract lifecycle management. Use when user mentions "Ironclad", "contracts", "contract workflows", "CLM", "contract records", or needs to read/create workflows, records, or download contract documents.
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name IRONCLAD_API_KEY` or `zero doctor check-connector --url https://$IRONCLAD_HOST/public/api/v1/workflows --method GET`
+
+## Authentication
+
+Ironclad uses a static API key passed as a Bearer token:
+
+```
+Authorization: Bearer $IRONCLAD_API_KEY
+```
+
+Generate the key in Ironclad under **Company Settings → API**. Keys are scoped to a single Ironclad instance.
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `IRONCLAD_API_KEY` | Ironclad API key |
+| `IRONCLAD_HOST` | API host for your Ironclad instance |
+
+## Base URL
+
+`https://$IRONCLAD_HOST/public/api/v1/` — set `IRONCLAD_HOST` to match your instance's data region:
+
+| Region | Host |
+|---|---|
+| North America (default) | `ironcladapp.com` |
+| Europe | `eu1.ironcladapp.com` |
+| Demo | `demo.ironcladapp.com` |
+
+## Workflows
+
+### List Workflows
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/workflows" -H "Authorization: Bearer $IRONCLAD_API_KEY"
+```
+
+Paginate with `page` and `pageSize` query params.
+
+### Retrieve a Workflow
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/workflows/<workflow-id>" -H "Authorization: Bearer $IRONCLAD_API_KEY"
+```
+
+### List Workflow Schemas
+
+Schemas describe the launch form for each contract type:
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/workflow-schemas" -H "Authorization: Bearer $IRONCLAD_API_KEY"
+```
+
+### Launch a Workflow
+
+Write to `/tmp/ironclad_workflow.json`:
+
+```json
+{
+  "template": "<schema-id>",
+  "creator": { "email": "user@example.com" },
+  "attributes": {
+    "counterpartyName": "Acme Corp",
+    "agreementDate": { "type": "date", "value": "2026-01-15" }
+  }
+}
+```
+
+```bash
+curl -s -X POST "https://$IRONCLAD_HOST/public/api/v1/workflows" -H "Authorization: Bearer $IRONCLAD_API_KEY" -H "Content-Type: application/json" -d @/tmp/ironclad_workflow.json
+```
+
+### Download a Workflow Document
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/workflows/<workflow-id>/document/<document-key>/download" -H "Authorization: Bearer $IRONCLAD_API_KEY" -o /tmp/contract.pdf
+```
+
+## Records
+
+### List Records
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/records" -H "Authorization: Bearer $IRONCLAD_API_KEY"
+```
+
+### Retrieve a Record
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/records/<record-id>" -H "Authorization: Bearer $IRONCLAD_API_KEY"
+```
+
+### Create a Record
+
+Write to `/tmp/ironclad_record.json`:
+
+```json
+{
+  "type": "<record-type-id>",
+  "name": "Acme MSA",
+  "properties": {
+    "counterpartyName": { "type": "text", "value": "Acme Corp" }
+  }
+}
+```
+
+```bash
+curl -s -X POST "https://$IRONCLAD_HOST/public/api/v1/records" -H "Authorization: Bearer $IRONCLAD_API_KEY" -H "Content-Type: application/json" -d @/tmp/ironclad_record.json
+```
+
+## Approvals
+
+### List Workflow Approvals
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/workflows/<workflow-id>/approvals" -H "Authorization: Bearer $IRONCLAD_API_KEY"
+```
+
+## Webhooks
+
+### List Webhooks
+
+```bash
+curl -s "https://$IRONCLAD_HOST/public/api/v1/webhooks" -H "Authorization: Bearer $IRONCLAD_API_KEY"
+```
+
+### Create a Webhook
+
+Write to `/tmp/ironclad_webhook.json`:
+
+```json
+{
+  "events": ["workflow_launched", "workflow_completed"],
+  "targetURL": "https://example.com/ironclad-hook"
+}
+```
+
+```bash
+curl -s -X POST "https://$IRONCLAD_HOST/public/api/v1/webhooks" -H "Authorization: Bearer $IRONCLAD_API_KEY" -H "Content-Type: application/json" -d @/tmp/ironclad_webhook.json
+```
+
+## Notes
+
+- All POST bodies require `Content-Type: application/json`.
+- List endpoints are paginated with `page` (0-indexed) and `pageSize` query params; the response includes `count` and `list`.
+- `IRONCLAD_HOST` must match the region your Ironclad instance is hosted in — a North America key will not work against the EU host and vice versa.


### PR DESCRIPTION
## Summary
- Add `gong/SKILL.md` — Gong revenue intelligence API (calls, transcripts, extensive call data, users, workspaces, scorecards, activity stats).
- Add `ironclad/SKILL.md` — Ironclad contract lifecycle API (workflows, workflow schemas, records, document download, approvals, webhooks).
- Both are API-token connectors and document region-specific base URLs so EU tenants work.

Pairs with vm0-ai/vm0 PR adding the connector definitions.

## Test plan
- [ ] Verify `zero doctor check-connector` examples in each SKILL.md resolve once the connector is configured
- [ ] Confirm base URL / auth instructions match current Gong and Ironclad API docs