### PR TITLE
feat: add bentoml and reap skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,6 +55,15 @@
       ]
     },
     {
+      "name": "bentoml",
+      "description": "BentoML and BentoCloud API for model serving and protected deployment endpoints. Use this skill to call deployed Bento services and protected inference routes.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./bentoml"
+      ]
+    },
+    {
       "name": "bitrix",
       "description": "Bitrix24 REST API via curl. Use this skill to manage CRM (leads, deals, contacts), tasks, and users.",
       "source": "./",
@@ -664,6 +673,15 @@
       "strict": false,
       "skills": [
         "./qiita"
+      ]
+    },
+    {
+      "name": "reap",
+      "description": "Reap API for modular fintech infrastructure. Use this skill to manage users, accounts, cards, activities, reconciliations, and embedded finance workflows.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./reap"
       ]
     },
     {

--- a/bentoml/SKILL.md
+++ b/bentoml/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: bentoml
+description: BentoML and BentoCloud API for model serving, deployment endpoint calls,
+  and protected BentoCloud inference endpoints. Use when user mentions "BentoML",
+  "BentoCloud", "Bento", model serving, or protected deployment endpoints.
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name BENTO_CLOUD_API_KEY` or `zero doctor check-connector --url "$BENTO_CLOUD_API_ENDPOINT" --method GET`
+
+## Official Docs
+
+- BentoCloud API reference: https://docs.bentoml.com/en/latest/reference/bentocloud/bentocloud-api.html
+- Protected deployment endpoints: https://docs.bentoml.com/en/latest/scale-with-bentocloud/manage-api-tokens.html
+- Calling deployment endpoints: https://docs.bentoml.com/en/latest/scale-with-bentocloud/deployment/call-deployment-endpoints.html
+
+## Prerequisites
+
+Connect the **BentoML** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+
+The connector provides:
+
+- `BENTO_CLOUD_API_KEY`: BentoCloud API token
+- `BENTO_CLOUD_API_ENDPOINT`: organization endpoint, for example `https://your-org.cloud.bentoml.com`
+
+## How to Use
+
+### Call a Protected Deployment Endpoint
+
+Use the endpoint URL from the BentoCloud deployment page or Playground tab. Replace `<deployment-endpoint>` and `/summarize` with the actual endpoint URL and route for the deployment.
+
+Write to `/tmp/bentoml_request.json`:
+
+```json
+{
+  "text": "Summarize this text with the deployed Bento service."
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://<deployment-endpoint>/summarize" --header "Authorization: Bearer $BENTO_CLOUD_API_KEY" --header "Content-Type: application/json" -d @/tmp/bentoml_request.json
+```
+
+### Call a JSON Inference Route
+
+Write to `/tmp/bentoml_request.json`:
+
+```json
+{
+  "prompt": "Write a concise status update for this deployment."
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://<deployment-endpoint>/<route>" --header "Authorization: Bearer $BENTO_CLOUD_API_KEY" --header "Content-Type: application/json" -d @/tmp/bentoml_request.json | jq .
+```
+
+### Call a Text Response Route
+
+```bash
+curl -s -X POST "https://<deployment-endpoint>/<route>" --header "Authorization: Bearer $BENTO_CLOUD_API_KEY" --header "Content-Type: application/json" -d '{"text":"Hello from vm0"}'
+```
+
+### Access a BYOC Monitoring Federate Endpoint
+
+Monitoring tokens are only available for BYOC customers. Replace `<cluster>` with the BentoCloud cluster name.
+
+```bash
+curl -s --get "https://prometheus.monitoring.<cluster>.bentoml.ai/federate" --header "Authorization: Bearer $BENTO_CLOUD_API_KEY" --data-urlencode 'match[]={yatai_ai_bento_function!=""}'
+```
+
+## Guidelines
+
+- Use the exact endpoint URL and route from the BentoCloud Playground tab; BentoML deployments expose user-defined routes.
+- Protected deployments require a token with Protected Endpoint Access.
+- Use `BENTO_CLOUD_API_ENDPOINT` for BentoCloud organization API context and protected deployment URLs for inference calls.
+- Do not print or store BentoCloud API tokens.

--- a/exa/SKILL.md
+++ b/exa/SKILL.md
@@ -1,3 +1,63 @@
 ---
 name: exa
-description: Exa AI-native sema
+description: Exa API for AI-native web search, contents retrieval, answer generation,
+  and research. Use when user mentions "Exa", semantic search, web search for AI,
+  contents extraction, or grounded answers with citations.
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name EXA_TOKEN` or `zero doctor check-connector --url https://api.exa.ai/search --method POST`
+
+## Official Docs
+
+- Search API: https://exa.ai/docs/reference/search
+- Contents API: https://exa.ai/docs/reference/contents
+- Answer API: https://exa.ai/docs/reference/answer
+
+## Prerequisites
+
+Connect the **Exa** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+
+## Search
+
+Write to `/tmp/exa_search.json`:
+
+```json
+{
+  "query": "latest developments in LLM agents",
+  "type": "auto",
+  "contents": {
+    "highlights": true
+  }
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://api.exa.ai/search" --header "x-api-key: $EXA_TOKEN" --header "Content-Type: application/json" -d @/tmp/exa_search.json | jq .
+```
+
+## Answer
+
+Write to `/tmp/exa_answer.json`:
+
+```json
+{
+  "query": "What changed recently in AI agent infrastructure?",
+  "text": true
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://api.exa.ai/answer" --header "x-api-key: $EXA_TOKEN" --header "Content-Type: application/json" -d @/tmp/exa_answer.json | jq .
+```
+
+## Guidelines
+
+- Use `contents.text`, `contents.highlights`, or `contents.summary` when the answer needs source material, not just URLs.
+- Prefer `type: "auto"` unless the user specifically requests neural, fast, or deep search.
+- Treat generated answers as grounded summaries and inspect citations before using them in high-stakes contexts.

--- a/reap/SKILL.md
+++ b/reap/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: reap
+description: Reap API for modular fintech infrastructure, including users, companies,
+  accounts, cards, virtual assets, activities, and reconciliations. Use when user
+  mentions "Reap", fintech cards, wallets, compliance, or embedded finance APIs.
+---
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name REAP_API_KEY` or `zero doctor check-connector --url "$REAP_API_BASE_URL/users" --method GET`
+
+## Official Docs
+
+- API reference: https://docs.reap.global/api-reference/overview
+- Authentication: https://docs.reap.global/api-reference/authentication
+- OpenAPI spec: https://docs.reap.global/api-reference/openapi.json
+
+## Prerequisites
+
+Connect the **Reap** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+
+The connector provides:
+
+- `REAP_API_KEY`: Reap project API key
+- `REAP_API_BASE_URL`: Reap API base URL, usually `https://sandbox.api.reap.global/v1` or `https://prod.api.reap.global/v1`
+
+Every request must include `Authorization: Bearer $REAP_API_KEY` and `Reap-Version: 2025-02-14`.
+
+## Users
+
+### List Users
+
+```bash
+curl -s "$REAP_API_BASE_URL/users?limit=20" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### Get User by ID
+
+```bash
+curl -s "$REAP_API_BASE_URL/users/<user-id>" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### Create User
+
+Write to `/tmp/reap_user.json`:
+
+```json
+{
+  "email": "john.doe@example.com",
+  "phoneNumber": "+14155552671",
+  "firstName": "John",
+  "lastName": "Doe",
+  "termsAcceptance": {
+    "version": "2026-01-17",
+    "ipAddress": "192.168.1.1"
+  }
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "$REAP_API_BASE_URL/users" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" --header "Content-Type: application/json" -d @/tmp/reap_user.json | jq .
+```
+
+## Accounts
+
+### List Accounts
+
+```bash
+curl -s "$REAP_API_BASE_URL/accounts?limit=20" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### Get Account Balance
+
+```bash
+curl -s "$REAP_API_BASE_URL/accounts/<account-id>/balance" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### Get Account Assets
+
+```bash
+curl -s "$REAP_API_BASE_URL/accounts/<account-id>/assets" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+## Cards
+
+### List Cards
+
+```bash
+curl -s "$REAP_API_BASE_URL/cards?limit=20" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### Get Card by ID
+
+```bash
+curl -s "$REAP_API_BASE_URL/cards/<card-id>" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### Freeze Card
+
+```bash
+curl -s -X POST "$REAP_API_BASE_URL/cards/<card-id>/freeze" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### Unfreeze Card
+
+```bash
+curl -s -X POST "$REAP_API_BASE_URL/cards/<card-id>/unfreeze" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+## Activities and Reconciliations
+
+### List Activities
+
+```bash
+curl -s "$REAP_API_BASE_URL/activities?limit=20" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+### List Reconciliations
+
+```bash
+curl -s "$REAP_API_BASE_URL/reconciliations?limit=20" --header "Authorization: Bearer $REAP_API_KEY" --header "Reap-Version: 2025-02-14" | jq .
+```
+
+## Guidelines
+
+- Use cursor pagination by passing `cursor=<nextCursor>` from the previous response.
+- Sandbox and production API keys are environment-scoped; match the key to `REAP_API_BASE_URL`.
+- Treat card detail reveal URLs as sensitive. Do not log, store, or expose them outside the immediate secure display flow.
+- Reap APIs are program-mode dependent; some company fields apply only to corporate programs.


### PR DESCRIPTION
## Summary
- add a BentoML/BentoCloud skill for protected deployment endpoint calls
- add a Reap skill for users, accounts, cards, activities, and reconciliations
- register BentoML and Reap in the Claude plugin marketplace
- repair the truncated Exa skill frontmatter so repository-wide SKILL.md validation passes

Docs referenced:
- https://docs.bentoml.com/en/latest/scale-with-bentocloud/manage-api-tokens.html
- https://docs.bentoml.com/en/latest/scale-with-bentocloud/deployment/call-deployment-endpoints.html
- https://docs.reap.global/api-reference/authentication
- https://docs.reap.global/api-reference/openapi.json
- https://exa.ai/docs/reference/search

## Tests
- `jq empty .claude-plugin/marketplace.json`
- repository-wide SKILL.md frontmatter validation with `python3` + `yaml`
- `grep -rn '_ACCESS_TOKEN' --include='SKILL.md' .`
- `git diff --cached --check`