### PR TITLE
docs: use larksuite URLs for lark skill

### DIFF
--- a/docs/saas.md
+++ b/docs/saas.md
@@ -16,7 +16,7 @@
 - [ ] [WAHA](https://waha.devlike.pro/docs/) - WhatsApp HTTP API
 - [ ] [Z-API](https://developer.z-api.io/en/) - WhatsApp API
 - [ ] [Exotel](https://developer.exotel.com/api) - Cloud Communication Platform
-- [x] [Feishu/Lark](https://open.larkoffice.com/document/home/index) - Enterprise Collaboration Platform
+- [x] [Lark](https://open.larksuite.com/document/home/index) - Enterprise Collaboration Platform
 - [ ] [WhatsApp Business API](https://business.whatsapp.com/developers/developer-hub) - Official WhatsApp Business API
 - [x] [Instagram API](https://developers.facebook.com/docs/instagram-api) - Official Instagram API
 - [x] [Slack](https://api.slack.com/docs) - Team Communication Platform

--- a/lark/SKILL.md
+++ b/lark/SKILL.md
@@ -5,16 +5,23 @@ description: Lark API for collaboration. Use when user mentions "Lark", "Lark do
 
 ## Troubleshooting
 
-If requests fail, run `zero doctor check-connector --env-name LARK_TOKEN` or `zero doctor check-connector --url https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal --method POST`
+If requests fail, first check the required credentials:
+
+```bash
+zero doctor check-connector --env-name LARK_APP_ID
+zero doctor check-connector --env-name LARK_TOKEN
+```
+
+Then call the token endpoint with both values in the request body. The tenant access token endpoint requires `app_id` and `app_secret`; this skill stores the Lark app secret in `LARK_TOKEN`.
 
 ## Token Management
 
 Lark uses tenant access tokens that expire after 2 hours. Use this helper to get or refresh the token:
 
 ```bash
-# Get or refresh token (cached to /tmp/lark_token.json)
+# Get or refresh token. The cache is keyed by app ID so different apps do not reuse tokens.
 get_lark_token() {
-  local token_file="/tmp/lark_token.json"
+  local token_file="/tmp/lark_token_${LARK_APP_ID}.json"
   local current_time=$(date +%s)
 
   # Check if cached token is still valid
@@ -62,11 +69,13 @@ TOKEN=$(curl -s -X POST "https://open.larksuite.com/open-apis/auth/v3/tenant_acc
 Get and display tenant access token:
 
 Write to `/tmp/lark_request.json`:
-```json
+```bash
+cat > /tmp/lark_request.json <<EOF
 {
   "app_id": "${LARK_APP_ID}",
   "app_secret": "${LARK_TOKEN}"
 }
+EOF
 ```
 
 ```bash
@@ -260,18 +269,20 @@ curl -X GET "https://open.larksuite.com/open-apis/contact/v3/users/ou_xxx?user_i
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
-#### Search Users
+#### Look Up User IDs by Email or Mobile
 
 Write to `/tmp/lark_request.json`:
 ```json
 {
-  "query": "John"
+  "emails": ["user@example.com"],
+  "mobiles": ["+15551234567"],
+  "include_resigned": false
 }
 ```
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.larksuite.com/open-apis/contact/v3/users/search?user_id_type=open_id" \
+curl -X POST "https://open.larksuite.com/open-apis/contact/v3/users/batch_get_id?user_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -482,8 +493,12 @@ curl -X POST "https://open.larksuite.com/open-apis/calendar/v4/calendars/<calend
 
 6. **Content Escaping**: Message content must be JSON-escaped when passed as string. Use `jq` to build complex payloads:
    ```bash
-   CONTENT=$(jq -n --arg text "Hello" '{text: $text}')
-   curl ... -d "{\"content\": \"$(echo $CONTENT | jq -c .)\"}"
+   CONTENT=$(jq -cn --arg text "Hello" '{text: $text}')
+   jq -n \
+     --arg receive_id "ou_xxx" \
+     --arg content "$CONTENT" \
+     '{receive_id: $receive_id, msg_type: "text", content: $content}' \
+     > /tmp/lark_request.json
    ```
 
 7. **Date Conversion**: Calendar events require Unix timestamps. Use `date` command with appropriate flags for your OS:

--- a/lark/SKILL.md
+++ b/lark/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: lark
-description: Lark/Feishu API for collaboration. Use when user mentions "Lark", "Feishu",
-  "Lark docs", or asks about ByteDance workspace tools.
+description: Lark API for collaboration. Use when user mentions "Lark", "Lark docs", or asks about ByteDance workspace tools.
 ---
 
 ## Troubleshooting
 
-If requests fail, run `zero doctor check-connector --env-name LARK_TOKEN` or `zero doctor check-connector --url https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal --method POST`
+If requests fail, run `zero doctor check-connector --env-name LARK_TOKEN` or `zero doctor check-connector --url https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal --method POST`
 
 ## Token Management
 
@@ -28,7 +27,7 @@ get_lark_token() {
   fi
 
   # Get new token
-  local response=$(curl -s -X POST "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal" \
+  local response=$(curl -s -X POST "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal" \
     -H "Content-Type: application/json" \
     -d "{\"app_id\": \"${LARK_APP_ID}\", \"app_secret\": \"${LARK_TOKEN}\"}")
 
@@ -51,7 +50,7 @@ TOKEN=$(get_lark_token)
 Or get token directly without caching:
 
 ```bash
-TOKEN=$(curl -s -X POST "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal" \
+TOKEN=$(curl -s -X POST "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal" \
   -H "Content-Type: application/json" \
   -d "{\"app_id\": \"$LARK_APP_ID\", \"app_secret\": \"$LARK_TOKEN\"}" | jq -r '.tenant_access_token')
 ```
@@ -71,7 +70,7 @@ Write to `/tmp/lark_request.json`:
 ```
 
 ```bash
-curl -X POST "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal" \
+curl -X POST "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
 ```
@@ -91,7 +90,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=open_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/messages?receive_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -110,7 +109,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/messages?receive_id_type=chat_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -129,7 +128,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=open_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/messages?receive_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -148,7 +147,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/messages?receive_id_type=chat_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -166,7 +165,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/messages/om_xxx/reply" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/messages/om_xxx/reply" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -176,7 +175,7 @@ curl -X POST "https://open.feishu.cn/open-apis/im/v1/messages/om_xxx/reply" \
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/im/v1/messages?container_id_type=chat&container_id=oc_xxx&page_size=20" \
+curl -X GET "https://open.larksuite.com/open-apis/im/v1/messages?container_id_type=chat&container_id=oc_xxx&page_size=20" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -195,7 +194,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/chats?user_id_type=open_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/chats?user_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -205,7 +204,7 @@ curl -X POST "https://open.feishu.cn/open-apis/im/v1/chats?user_id_type=open_id"
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/im/v1/chats" \
+curl -X GET "https://open.larksuite.com/open-apis/im/v1/chats" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -213,7 +212,7 @@ curl -X GET "https://open.feishu.cn/open-apis/im/v1/chats" \
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/im/v1/chats/oc_xxx" \
+curl -X GET "https://open.larksuite.com/open-apis/im/v1/chats/oc_xxx" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -228,7 +227,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/chats/oc_xxx/members?member_id_type=open_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/chats/oc_xxx/members?member_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -245,7 +244,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X DELETE "https://open.feishu.cn/open-apis/im/v1/chats/oc_xxx/members?member_id_type=open_id" \
+curl -X DELETE "https://open.larksuite.com/open-apis/im/v1/chats/oc_xxx/members?member_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -257,7 +256,7 @@ curl -X DELETE "https://open.feishu.cn/open-apis/im/v1/chats/oc_xxx/members?memb
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/contact/v3/users/ou_xxx?user_id_type=open_id" \
+curl -X GET "https://open.larksuite.com/open-apis/contact/v3/users/ou_xxx?user_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -272,7 +271,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/contact/v3/users/search?user_id_type=open_id" \
+curl -X POST "https://open.larksuite.com/open-apis/contact/v3/users/search?user_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -282,7 +281,7 @@ curl -X POST "https://open.feishu.cn/open-apis/contact/v3/users/search?user_id_t
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/contact/v3/departments?parent_department_id=0" \
+curl -X GET "https://open.larksuite.com/open-apis/contact/v3/departments?parent_department_id=0" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -290,7 +289,7 @@ curl -X GET "https://open.feishu.cn/open-apis/contact/v3/departments?parent_depa
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/contact/v3/users/find_by_department?department_id=od_xxx&user_id_type=open_id" \
+curl -X GET "https://open.larksuite.com/open-apis/contact/v3/users/find_by_department?department_id=od_xxx&user_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -300,7 +299,7 @@ curl -X GET "https://open.feishu.cn/open-apis/contact/v3/users/find_by_departmen
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/calendar/v4/calendars" \
+curl -X GET "https://open.larksuite.com/open-apis/calendar/v4/calendars" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -316,7 +315,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/calendar/v4/calendars" \
+curl -X POST "https://open.larksuite.com/open-apis/calendar/v4/calendars" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -343,7 +342,7 @@ cat > /tmp/lark_request.json <<EOF
 }
 EOF
 
-curl -X POST "https://open.feishu.cn/open-apis/calendar/v4/calendars/<calendar_id>/events" \
+curl -X POST "https://open.larksuite.com/open-apis/calendar/v4/calendars/<calendar_id>/events" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -358,7 +357,7 @@ TOKEN=$(get_lark_token)
 START_TS=$(date -d "2025-01-01T00:00:00+08:00" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S%z" "2025-01-01T00:00:00+08:00" +%s)
 END_TS=$(date -d "2025-01-31T23:59:59+08:00" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%S%z" "2025-01-31T23:59:59+08:00" +%s)
 
-curl -X GET "https://open.feishu.cn/open-apis/calendar/v4/calendars/<calendar_id>/events?start_time=${START_TS}&end_time=${END_TS}" \
+curl -X GET "https://open.larksuite.com/open-apis/calendar/v4/calendars/<calendar_id>/events?start_time=${START_TS}&end_time=${END_TS}" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -368,7 +367,7 @@ curl -X GET "https://open.feishu.cn/open-apis/calendar/v4/calendars/<calendar_id
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X GET "https://open.feishu.cn/open-apis/bot/v3/info" \
+curl -X GET "https://open.larksuite.com/open-apis/bot/v3/info" \
   -H "Authorization: Bearer ${TOKEN}"
 ```
 
@@ -387,7 +386,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/messages?receive_id_type=chat_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -406,7 +405,7 @@ Write to `/tmp/lark_request.json`:
 
 ```bash
 TOKEN=$(get_lark_token)
-curl -X POST "https://open.feishu.cn/open-apis/im/v1/chats?user_id_type=open_id" \
+curl -X POST "https://open.larksuite.com/open-apis/im/v1/chats?user_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -418,11 +417,11 @@ curl -X POST "https://open.feishu.cn/open-apis/im/v1/chats?user_id_type=open_id"
 TOKEN=$(get_lark_token)
 
 # Get root departments
-curl -X GET "https://open.feishu.cn/open-apis/contact/v3/departments?parent_department_id=0" \
+curl -X GET "https://open.larksuite.com/open-apis/contact/v3/departments?parent_department_id=0" \
   -H "Authorization: Bearer ${TOKEN}" | jq '.data.items[] | {id: .department_id, name: .name}'
 
 # Get members in a department
-curl -X GET "https://open.feishu.cn/open-apis/contact/v3/users/find_by_department?department_id=od_xxx&user_id_type=open_id" \
+curl -X GET "https://open.larksuite.com/open-apis/contact/v3/users/find_by_department?department_id=od_xxx&user_id_type=open_id" \
   -H "Authorization: Bearer ${TOKEN}" | jq '.data.items[] | {id: .user_id, name: .name}'
 ```
 
@@ -444,7 +443,7 @@ cat > /tmp/lark_request.json <<EOF
 }
 EOF
 
-curl -X POST "https://open.feishu.cn/open-apis/calendar/v4/calendars/<calendar_id>/events" \
+curl -X POST "https://open.larksuite.com/open-apis/calendar/v4/calendars/<calendar_id>/events" \
   -H "Authorization: Bearer ${TOKEN}" \
   -H "Content-Type: application/json" \
   -d @/tmp/lark_request.json
@@ -477,7 +476,7 @@ curl -X POST "https://open.feishu.cn/open-apis/calendar/v4/calendars/<calendar_i
 
 3. **ID Types**: Use `open_id` for most user operations. Use `chat_id` when targeting group chats.
 
-4. **Card Builder**: Design complex interactive cards using Lark Card Builder: https://open.larkoffice.com/tool/cardbuilder
+4. **Card Builder**: Design complex interactive cards using Lark Card Builder: https://open.larksuite.com/tool/cardbuilder
 
 5. **Error Handling**: Check the `code` field in responses. `0` means success, non-zero indicates an error.
 
@@ -493,7 +492,7 @@ curl -X POST "https://open.feishu.cn/open-apis/calendar/v4/calendars/<calendar_i
 
 ## API Reference
 
-- API Documentation: https://open.larkoffice.com/document/home/index
-- API Explorer: https://open.larkoffice.com/api-explorer
-- Card Builder: https://open.larkoffice.com/tool/cardbuilder
-- Permissions: https://open.larkoffice.com/document/home/introduction-to-scope-and-authorization/overview
+- API Documentation: https://open.larksuite.com/document/home/index
+- API Explorer: https://open.larksuite.com/api-explorer
+- Card Builder: https://open.larksuite.com/tool/cardbuilder
+- Permissions: https://open.larksuite.com/document/home/introduction-to-scope-and-authorization/overview


### PR DESCRIPTION
## Summary
- update the Lark skill to use `open.larksuite.com` API and docs URLs
- remove Feishu naming from the Lark skill metadata
- update the SaaS catalog entry to list Lark only

## Testing
- `git diff --check`
- `rg -n "feishu|Feishu|open\.feishu\.cn|open\.larkoffice\.com|larkoffice" -S .` returned no matches