### PR TITLE
fix: tighten vm0 illustration style guidance

### DIFF
--- a/illustration-template/vm0-illustration/SKILL.md
+++ b/illustration-template/vm0-illustration/SKILL.md
@@ -12,17 +12,22 @@ This style is separate from Notion Illustration. Notion Illustration is black br
 ## Locked Style
 
 - Square spot illustration, usually 1024 x 1024.
-- Transparent final background.
+- Transparent final background in the delivered artifact.
+- Preferred generation setup: generate on a flat full-canvas warm gray background (`#eeeeee`), then remove only that gray background to transparency. This preserves pure-white object interiors. Direct transparent-background generation often creates unwanted glow/vignette and gray object fills.
 - One central product metaphor or object, not a character scene.
-- Bold black hand-drawn ink line drawing with confident, slightly imperfect strokes.
-- Minimal detail: essential contours only, no crosshatching, no shading, no texture-heavy rendering.
-- White-filled interior inside the line art so the drawing stays opaque over the color shape.
-- One soft rounded color block behind the drawing, like a halo, pill, oval, or rounded-square badge.
+- Bold confident black brush-pen ink line drawing, with thick chunky decisive strokes and natural hand-drawn wobble. Lines should look committed and drawn once, not ruler-straight or vector-clean.
+- Outlines have intentional small gaps and breaks for a breathy hand-drawn quality.
+- Minimal detail: only essential contours and one or two key details. No fine textures, no crosshatching, no heavy shading.
+- Pure white (`#FFFFFF`) filled interior inside the line art so the drawing stays opaque over the color shape. The interior must not be gray, dark, shaded, translucent, or blended with the backdrop.
+- The black ink drawing sits firmly on top of the white fill. Where the subject overlaps the color block, the white-filled object completely hides the color underneath.
+- One solid opaque flat soft-rounded color block behind the drawing, like a halo, chunky oval, generous pill, or rounded-square badge.
+- The color block has no gradient, no watercolor, no texture, no glow, and no transparency. Slightly imperfect hand-drawn edges are fine.
 - The color block supports the drawing; it should not fully contain it.
-- The drawing extends beyond the color block on 2-3 sides.
-- The color block occupies roughly 30-50% of the canvas.
-- Pixels outside the line art and color block must be transparent. Do not add any glow, vignette, cast shadow, ambient lighting, gray paper, or background wash.
-- No logo, no text, no UI chrome, no watermark, no border.
+- The drawing extends beyond the color block on at least 2-3 sides.
+- The color block occupies roughly 30-40% of the canvas and may be slightly off-center or rotated for editorial flair.
+- The full composition fills roughly 60-75% of the canvas with generous breathing room around it.
+- Pixels outside the line art and color block must be transparent in the final artifact. Do not add any glow, vignette, cast shadow, ambient lighting, gray paper, or background wash.
+- No logo, no text, no letters, no numbers, no UI chrome, no watermark, no border, no third color.
 
 ## Color Direction
 
@@ -53,19 +58,22 @@ Good metaphors:
 - product update: a gift box with lid lifting and a few sparkles
 - retry/loop: two curved arrows chasing each other in a circular refresh loop
 
-Use a concise prompt with these constraints:
+Use a concise prompt with these constraints. If the generation tool supports background removal or post-processing, prefer the warm-gray-background workflow:
 
 ```text
 vm0-style vm0 in-app spot illustration of <metaphor>.
-Square transparent-background PNG. Bold hand-drawn black ink line art with confident natural wobble and intentional small contour breaks. The object has an opaque white-filled interior. Behind it is a single soft rounded <color name> color block using <hex>, like a pill or rounded-square halo. The drawing extends beyond the color block on multiple sides. Pixels outside the drawing and color block are fully transparent. Minimal iconic detail only. No text, no logo, no UI, no border, no shadows, no glow, no vignette, no hatching, no gray background.
+Square 1:1 spot illustration on a flat full-canvas warm gray #eeeeee background that will be removed to transparency after generation. Bold confident black brush-pen ink line art with thick chunky decisive strokes, natural hand-drawn wobble, and intentional small contour breaks. The object has an opaque pure white #FFFFFF filled interior, not gray, not dark, not shaded, and not blended with the backdrop. The white-filled object sits on top of a single solid opaque flat soft-rounded <color name> color block using <hex>, like a pill, chunky oval, or rounded-square halo. The color block has no gradient, no watercolor, no texture, no glow, and no transparency. The drawing extends beyond the color block on at least 2-3 sides and fills 60-75% of the canvas. Minimal iconic detail only. No text, no letters, no numbers, no logo, no UI, no border, no shadows, no glow, no vignette, no hatching, no third color.
 ```
+
+If direct transparent-background generation is the only available path, keep the same style constraints and additionally require that all pixels outside the drawing and color block are fully transparent. Be strict about no glow/vignette and pure white subject interiors, because direct transparent generation tends to drift there.
 
 ## Evaluation Checklist
 
 - The image reads as one simple iconic product metaphor.
 - The line art is bold and hand-drawn, not vector-clean.
-- The object interior is white-filled, not transparent.
+- The object interior is pure white-filled, not transparent, gray, dark, shaded, or backdrop-colored.
 - The color block sits behind the drawing and does not trap it inside.
+- The color block is solid flat color, not gradient/watercolor/textured.
 - The final background is transparent.
 - There is no glow, vignette, cast shadow, gray wash, or background outside the color block.
-- There is no text, logo, UI chrome, border, or watermark.
+- There is no text, letters, numbers, logo, UI chrome, border, watermark, or third color.


### PR DESCRIPTION
## Summary
- align vm0 Illustration resource more closely with the original `illustration` custom skill
- document the original warm-gray `#eeeeee` generation workflow followed by background removal to transparency
- strengthen brush-pen line, pure-white fill, flat opaque color block, composition, and no-third-color constraints

## Why
Smoke output from direct transparent generation had transparent alpha but visually drifted: gray/dark subject interiors and glow/vignette. The original Lucas/vm0 illustration skill avoids this by generating on `#eeeeee` and keying that background out while preserving white fills.

## Key differences copied from the original skill
- generate on flat warm gray first, deliver transparent after post-processing
- thick chunky decisive brush-pen strokes, intentional breathy breaks
- subject interior must be pure white `#FFFFFF` and hide the color block underneath
- color block is solid opaque flat color, no gradient/watercolor/texture/glow
- color block is about 30-40% of canvas; composition fills 60-75%
- no text, letters, numbers, logo, UI, border, watermark, or third color

## Validation
- frontmatter/content sanity check passed
- smoke artifact that motivated this fix: https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/933b07f8-5f25-4ffb-875d-27880f7996ff/image-933b07f8.png