### PR TITLE
fix: use authorization header for Meta Ads token

### DIFF
--- a/meta-ads/SKILL.md
+++ b/meta-ads/SKILL.md
@@ -4,6 +4,22 @@ description: Meta Ads API for Facebook/Instagram advertising. Use when user ment
   "Meta Ads", "Facebook Ads", "Instagram Ads", or ad campaigns.
 ---
 
+## Prerequisites
+
+1. Connect Meta Ads in Zero at Settings > Connectors > Meta Ads.
+2. Requests require `META_ADS_TOKEN`.
+3. Ad account IDs usually use the `act_<account-id>` format when calling ad account endpoints.
+
+## Authentication
+
+Every request requires this header:
+
+```
+Authorization: Bearer $META_ADS_TOKEN
+```
+
+Do not pass `META_ADS_TOKEN` as an `access_token` query parameter or in the request body. Zero connector tokens are placeholders that are resolved at the network boundary when sent as the `Authorization` header to `https://graph.facebook.com`. Putting the placeholder in `access_token=` can send it literally and cause Meta to return a malformed access token error.
+
 ## Troubleshooting
 
 If requests fail, run `zero doctor check-connector --env-name META_ADS_TOKEN` or `zero doctor check-connector --url https://graph.facebook.com/v22.0/me/adaccounts --method GET`
@@ -13,13 +29,15 @@ If requests fail, run `zero doctor check-connector --env-name META_ADS_TOKEN` or
 ### List Ad Accounts
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/me/adaccounts?fields=id,name,account_status,currency,timezone_name,amount_spent&access_token=$META_ADS_TOKEN" | jq '.data[] | {id, name, account_status, currency}'
+curl -s "https://graph.facebook.com/v22.0/me/adaccounts?fields=id,name,account_status,currency,timezone_name,amount_spent" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, account_status, currency}'
 ```
 
 ### Get Ad Account Details
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}?fields=id,name,account_status,currency,timezone_name,balance,amount_spent,spend_cap&access_token=$META_ADS_TOKEN"
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}?fields=id,name,account_status,currency,timezone_name,balance,amount_spent,spend_cap" \
+  --header "Authorization: Bearer $META_ADS_TOKEN"
 ```
 
 ## Campaigns
@@ -27,13 +45,15 @@ curl -s "https://graph.facebook.com/v22.0/{ad-account-id}?fields=id,name,account
 ### List Campaigns
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/campaigns?fields=id,name,status,objective,daily_budget,lifetime_budget,start_time,stop_time&access_token=$META_ADS_TOKEN" | jq '.data[] | {id, name, status, objective}'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/campaigns?fields=id,name,status,objective,daily_budget,lifetime_budget,start_time,stop_time" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, status, objective}'
 ```
 
 ### Get Campaign Details
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{campaign-id}?fields=id,name,status,objective,daily_budget,lifetime_budget,start_time,stop_time,created_time,updated_time&access_token=$META_ADS_TOKEN"
+curl -s "https://graph.facebook.com/v22.0/{campaign-id}?fields=id,name,status,objective,daily_budget,lifetime_budget,start_time,stop_time,created_time,updated_time" \
+  --header "Authorization: Bearer $META_ADS_TOKEN"
 ```
 
 ### Create Campaign
@@ -49,7 +69,10 @@ cat > /tmp/campaign.json << 'EOF'
   "special_ad_categories": []
 }
 EOF
-curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/campaigns?access_token=$META_ADS_TOKEN" --header "Content-Type: application/json" -d @/tmp/campaign.json
+curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/campaigns" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "Content-Type: application/json" \
+  -d @/tmp/campaign.json
 ```
 
 ### Update Campaign
@@ -61,13 +84,17 @@ cat > /tmp/campaign-update.json << 'EOF'
   "status": "PAUSED"
 }
 EOF
-curl -s -X POST "https://graph.facebook.com/v22.0/{campaign-id}?access_token=$META_ADS_TOKEN" --header "Content-Type: application/json" -d @/tmp/campaign-update.json
+curl -s -X POST "https://graph.facebook.com/v22.0/{campaign-id}" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "Content-Type: application/json" \
+  -d @/tmp/campaign-update.json
 ```
 
 ### Delete Campaign
 
 ```bash
-curl -s -X DELETE "https://graph.facebook.com/v22.0/{campaign-id}?access_token=$META_ADS_TOKEN"
+curl -s -X DELETE "https://graph.facebook.com/v22.0/{campaign-id}" \
+  --header "Authorization: Bearer $META_ADS_TOKEN"
 ```
 
 ## Ad Sets
@@ -75,13 +102,15 @@ curl -s -X DELETE "https://graph.facebook.com/v22.0/{campaign-id}?access_token=$
 ### List Ad Sets
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/adsets?fields=id,name,status,campaign_id,daily_budget,lifetime_budget,start_time,end_time,targeting&access_token=$META_ADS_TOKEN" | jq '.data[] | {id, name, status, campaign_id, daily_budget}'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/adsets?fields=id,name,status,campaign_id,daily_budget,lifetime_budget,start_time,end_time,targeting" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, status, campaign_id, daily_budget}'
 ```
 
 ### Get Ad Set Details
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{adset-id}?fields=id,name,status,campaign_id,daily_budget,lifetime_budget,bid_amount,billing_event,optimization_goal,start_time,end_time,targeting&access_token=$META_ADS_TOKEN"
+curl -s "https://graph.facebook.com/v22.0/{adset-id}?fields=id,name,status,campaign_id,daily_budget,lifetime_budget,bid_amount,billing_event,optimization_goal,start_time,end_time,targeting" \
+  --header "Authorization: Bearer $META_ADS_TOKEN"
 ```
 
 ### Create Ad Set
@@ -106,7 +135,10 @@ cat > /tmp/adset.json << 'EOF'
   "status": "PAUSED"
 }
 EOF
-curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/adsets?access_token=$META_ADS_TOKEN" --header "Content-Type: application/json" -d @/tmp/adset.json
+curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/adsets" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "Content-Type: application/json" \
+  -d @/tmp/adset.json
 ```
 
 ## Ads
@@ -114,13 +146,15 @@ curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/adsets?access_
 ### List Ads
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/ads?fields=id,name,status,adset_id,campaign_id,created_time&access_token=$META_ADS_TOKEN" | jq '.data[] | {id, name, status, adset_id}'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/ads?fields=id,name,status,adset_id,campaign_id,created_time" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, status, adset_id}'
 ```
 
 ### Get Ad Details
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-id}?fields=id,name,status,adset_id,campaign_id,creative,created_time,updated_time&access_token=$META_ADS_TOKEN"
+curl -s "https://graph.facebook.com/v22.0/{ad-id}?fields=id,name,status,adset_id,campaign_id,creative,created_time,updated_time" \
+  --header "Authorization: Bearer $META_ADS_TOKEN"
 ```
 
 ## Insights (Performance Analytics)
@@ -130,31 +164,36 @@ curl -s "https://graph.facebook.com/v22.0/{ad-id}?fields=id,name,status,adset_id
 Get overall account performance for the last 7 days:
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr,cpc,cpm,reach,frequency&date_preset=last_7d&access_token=$META_ADS_TOKEN" | jq '.data[0]'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr,cpc,cpm,reach,frequency&date_preset=last_7d" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[0]'
 ```
 
 ### Campaign-Level Insights
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=campaign_name,campaign_id,impressions,clicks,spend,ctr,cpc,actions&level=campaign&date_preset=last_30d&access_token=$META_ADS_TOKEN" | jq '.data[] | {campaign_name, impressions, clicks, spend, ctr}'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=campaign_name,campaign_id,impressions,clicks,spend,ctr,cpc,actions&level=campaign&date_preset=last_30d" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {campaign_name, impressions, clicks, spend, ctr}'
 ```
 
 ### Insights with Date Range
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr,cpc,reach,actions&time_range={\"since\":\"2026-01-01\",\"until\":\"2026-01-31\"}&access_token=$META_ADS_TOKEN" | jq '.data[0]'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr,cpc,reach,actions&time_range={\"since\":\"2026-01-01\",\"until\":\"2026-01-31\"}" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[0]'
 ```
 
 ### Insights with Daily Breakdown
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr&date_preset=last_7d&time_increment=1&access_token=$META_ADS_TOKEN" | jq '.data[] | {date_start, impressions, clicks, spend}'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr&date_preset=last_7d&time_increment=1" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {date_start, impressions, clicks, spend}'
 ```
 
 ### Insights by Age and Gender
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend&date_preset=last_30d&breakdowns=age,gender&access_token=$META_ADS_TOKEN" | jq '.data[] | {age, gender, impressions, clicks, spend}'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend&date_preset=last_30d&breakdowns=age,gender" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {age, gender, impressions, clicks, spend}'
 ```
 
 ## Custom Audiences
@@ -162,7 +201,8 @@ curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impres
 ### List Custom Audiences
 
 ```bash
-curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/customaudiences?fields=id,name,approximate_count_lower_bound,approximate_count_upper_bound&access_token=$META_ADS_TOKEN" | jq '.data[] | {id, name, approximate_count_lower_bound}'
+curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/customaudiences?fields=id,name,approximate_count_lower_bound,approximate_count_upper_bound" \
+  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, approximate_count_lower_bound}'
 ```
 
 ## Guidelines


### PR DESCRIPTION
## Summary
- add Meta Ads authentication guidance that mirrors the header-based connector pattern
- warn agents not to pass META_ADS_TOKEN through access_token query parameters or request bodies
- update Meta Ads curl examples to use Authorization: Bearer $META_ADS_TOKEN

## Validation
- python3 /home/user/.codex/skills/.system/skill-creator/scripts/quick_validate.py /home/user/workspace/vm0-skills/meta-ads
- git diff --check
- read-only Graph API sanity check with Authorization header