### PR TITLE
feat: add Semrush and Massive skills

### DIFF
--- a/docs/saas.md
+++ b/docs/saas.md
@@ -116,6 +116,8 @@
 
 - [x] [Axiom](https://axiom.co/docs/restapi/introduction) - Cloud-Native Observability Platform
 - [x] [Plausible](https://plausible.io/docs) - Privacy-Friendly Web Analytics
+- [x] [Semrush](https://developer.semrush.com/api/get-started/quick-start/) - SEO, keyword, backlink, and competitive intelligence API
+- [x] [Massive](https://massive.com/docs/rest/quickstart) - Market data API for stocks, options, forex, crypto, and indices
 - [ ] [Datadog](https://docs.datadoghq.com/api/) - Infrastructure Monitoring & APM
 - [ ] [Airbyte](https://docs.airbyte.com/api-documentation) - Data Integration Platform
 - [ ] [Retool](https://docs.retool.com/docs) - Internal Tool Builder
@@ -195,15 +197,15 @@
 | API & Cloud Integrations | 27 |
 | AI, LLM & Voice | 12 |
 | File & PDF Manipulation | 3 |
-| Analytics & Monitoring | 7 |
+| Analytics & Monitoring | 9 |
 | Development & Engineering | 6 |
 | Customer Support | 3 |
 | Security & Compliance | 4 |
 | Automation | 2 |
 | Design & Media | 4 |
 | Miscellaneous | 11 |
-| **Total** | **106** |
+| **Total** | **108** |
 
 ---
 
-> Last updated: 2026-05-23
+> Last updated: 2026-06-10

--- a/massive/SKILL.md
+++ b/massive/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: massive
+description: Massive market data API for stocks, options, futures, forex, crypto,
+  indices, and reference data. Use when user mentions "Massive", "Polygon.io",
+  "Polygon", "market data", "stock prices", "forex", or "crypto prices".
+---
+
+# Massive
+
+Use the Massive REST API to retrieve market reference data, historical bars,
+snapshots, and trading calendar information.
+
+> Official docs: `https://massive.com/docs/rest/quickstart`
+
+---
+
+## When to Use
+
+Use this skill when you need to:
+
+- Look up stock, forex, crypto, option, future, or index tickers
+- Retrieve OHLC bars, previous close data, market snapshots, or market status
+- Enrich financial workflows with Massive market reference data
+
+---
+
+## Prerequisites
+
+Connect the **Massive** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+
+> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name MASSIVE_TOKEN` or `zero doctor check-connector --url "https://api.massive.com/v3/reference/tickers?market=stocks&limit=1" --method GET`
+
+---
+
+## How to Use
+
+### 1. List Stock Tickers
+
+List active stock tickers. Adjust `market`, `active`, and `limit` as needed.
+
+```bash
+curl -s "https://api.massive.com/v3/reference/tickers?market=stocks&active=true&limit=10" --header "Authorization: Bearer $MASSIVE_TOKEN" | jq '.results[] | {ticker, name, market, primary_exchange}'
+```
+
+Docs: `https://massive.com/docs/rest/stocks/tickers/all-tickers`
+
+### 2. Get Ticker Overview
+
+Replace `<ticker>` with an exchange symbol such as `AAPL`.
+
+```bash
+curl -s "https://api.massive.com/v3/reference/tickers/<ticker>" --header "Authorization: Bearer $MASSIVE_TOKEN" | jq '.results | {ticker, name, market, market_cap, sic_description, homepage_url}'
+```
+
+Docs: `https://massive.com/docs/rest/stocks/tickers/ticker-overview`
+
+### 3. Get Previous Day OHLC
+
+Replace `<ticker>` with an exchange symbol such as `AAPL`.
+
+```bash
+curl -s "https://api.massive.com/v2/aggs/ticker/<ticker>/prev?adjusted=true" --header "Authorization: Bearer $MASSIVE_TOKEN" | jq '.results[] | {open: .o, high: .h, low: .l, close: .c, volume: .v, timestamp: .t}'
+```
+
+Docs: `https://massive.com/docs/rest/stocks/aggregates/previous-day-bar`
+
+### 4. Get Historical Daily Bars
+
+Replace `<ticker>`, `<from-date>`, and `<to-date>`. Dates use `YYYY-MM-DD`.
+
+```bash
+curl -s "https://api.massive.com/v2/aggs/ticker/<ticker>/range/1/day/<from-date>/<to-date>?adjusted=true&sort=asc&limit=120" --header "Authorization: Bearer $MASSIVE_TOKEN" | jq '.results[] | {date_ms: .t, open: .o, high: .h, low: .l, close: .c, volume: .v}'
+```
+
+Docs: `https://massive.com/docs/rest/stocks/aggregates/custom-bars`
+
+### 5. Get Daily Market Summary
+
+Replace `<date>` with a trading date in `YYYY-MM-DD` format.
+
+```bash
+curl -s "https://api.massive.com/v2/aggs/grouped/locale/us/market/stocks/<date>?adjusted=true&include_otc=false" --header "Authorization: Bearer $MASSIVE_TOKEN" | jq '.results[:20][] | {ticker: .T, open: .o, high: .h, low: .l, close: .c, volume: .v}'
+```
+
+Docs: `https://massive.com/docs/rest/stocks/aggregates/daily-market-summary`
+
+### 6. Get Forex Previous Day OHLC
+
+Replace `<forex-ticker>` with a Massive forex ticker such as `C:EURUSD`.
+
+```bash
+curl -s "https://api.massive.com/v2/aggs/ticker/<forex-ticker>/prev?adjusted=true" --header "Authorization: Bearer $MASSIVE_TOKEN" | jq '.results[] | {open: .o, high: .h, low: .l, close: .c, volume: .v, timestamp: .t}'
+```
+
+Docs: `https://massive.com/docs/rest/forex/aggregates/previous-day-bar`
+
+### 7. Check Market Status
+
+```bash
+curl -s "https://api.massive.com/v1/marketstatus/now" --header "Authorization: Bearer $MASSIVE_TOKEN" | jq '{market, serverTime, exchanges, currencies}'
+```
+
+Docs: `https://massive.com/docs/rest/stocks/market-operations/market-status`
+
+---
+
+## Guidelines
+
+1. **Use Bearer auth**: Prefer `Authorization: Bearer $MASSIVE_TOKEN`; Massive also supports `apiKey` query auth, but headers keep keys out of URLs.
+2. **Ticker formats vary by asset class**: Stocks use symbols like `AAPL`; forex commonly uses `C:EURUSD`; crypto commonly uses `X:BTCUSD`.
+3. **Plan access affects freshness and history**: Free and paid plans differ by recency, history, and supported asset classes.
+4. **Paginate when needed**: Many endpoints return `next_url`; fetch it with the same Authorization header.
+5. **Use the official docs for endpoint-specific plan limits**: Massive shows plan access, recency, and history on each endpoint page.

--- a/semrush/SKILL.md
+++ b/semrush/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: semrush
+description: Semrush API for SEO, keyword research, backlinks, domain analytics,
+  traffic, and competitive intelligence. Use when user mentions "Semrush", "SEO",
+  "keyword research", "backlinks", "domain rankings", or "competitive research".
+---
+
+# Semrush
+
+Use the Semrush API to retrieve SEO, keyword, backlink, traffic, and competitive
+research data.
+
+> Official docs: `https://developer.semrush.com/api/get-started/quick-start/`
+
+---
+
+## When to Use
+
+Use this skill when you need to:
+
+- Analyze domain rankings, organic keywords, paid keywords, or competitors
+- Retrieve backlink overview and referring domain data
+- Pull Semrush SEO API reports into an analysis or automation workflow
+
+---
+
+## Prerequisites
+
+Connect the **Semrush** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+
+> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name SEMRUSH_TOKEN` or `zero doctor check-connector --url "https://api.semrush.com/?type=domain_rank&domain=example.com&database=us&export_columns=Dn,Rk" --method GET`
+
+---
+
+## How to Use
+
+### 1. Get Domain Overview
+
+Replace `<domain>` with a bare domain such as `example.com`. The Semrush SEO API
+returns CSV for these reports.
+
+```bash
+curl -s "https://api.semrush.com/?type=domain_rank&key=$SEMRUSH_TOKEN&export_columns=Dn,Rk,Or,Ot,Oc,Ad,At,Ac&domain=<domain>&database=us"
+```
+
+Docs: `https://developer.semrush.com/api/seo/overview-reports/`
+
+### 2. Get Organic Search Keywords
+
+Replace `<domain>` with a bare domain. `display_limit` controls the number of
+returned rows and helps manage API unit usage.
+
+```bash
+curl -s "https://api.semrush.com/?type=domain_organic&key=$SEMRUSH_TOKEN&display_limit=10&export_columns=Ph,Po,Pp,Pd,Nq,Cp,Ur,Tr,Tc,Co,Nr,Td&domain=<domain>&display_sort=tr_desc&database=us"
+```
+
+Docs: `https://developer.semrush.com/api/seo/domain-reports/`
+
+### 3. Get Paid Search Keywords
+
+Replace `<domain>` with a bare domain.
+
+```bash
+curl -s "https://api.semrush.com/?type=domain_adwords&key=$SEMRUSH_TOKEN&display_limit=10&export_columns=Ph,Po,Pp,Pd,Nq,Cp,Vu,Ur,Tr,Tc,Co,Nr,Td&domain=<domain>&display_sort=tr_desc&database=us"
+```
+
+Docs: `https://developer.semrush.com/api/seo/domain-reports/`
+
+### 4. Find Organic Competitors
+
+Replace `<domain>` with a bare domain.
+
+```bash
+curl -s "https://api.semrush.com/?type=domain_organic_organic&key=$SEMRUSH_TOKEN&display_limit=10&export_columns=Dn,Cr,Np,Or,Ot,Oc,Ad,At,Ac&domain=<domain>&database=us"
+```
+
+Docs: `https://developer.semrush.com/api/seo/domain-reports/`
+
+### 5. Get Backlinks Overview
+
+Replace `<target-domain>` with a bare domain. Use `target_type=root_domain` for
+root-domain-level analysis.
+
+```bash
+curl -s "https://api.semrush.com/analytics/v1/?type=backlinks_overview&key=$SEMRUSH_TOKEN&target=<target-domain>&target_type=root_domain&export_columns=ascore,total,domains_num,ips_num,follows_num,nofollows_num"
+```
+
+Docs: `https://developer.semrush.com/api/seo/backlinks/`
+
+### 6. Get Referring Domains
+
+Replace `<target-domain>` with a bare domain.
+
+```bash
+curl -s "https://api.semrush.com/analytics/v1/?type=backlinks_refdomains&key=$SEMRUSH_TOKEN&target=<target-domain>&target_type=root_domain&display_limit=10&export_columns=domain_ascore,domain,backlinks_num,first_seen,last_seen"
+```
+
+Docs: `https://developer.semrush.com/api/seo/backlinks/`
+
+---
+
+## Guidelines
+
+1. **Most SEO API reports return CSV**: Do not assume JSON unless the endpoint documentation explicitly says so.
+2. **Use `display_limit` aggressively**: Semrush API usage is metered by API units, often per returned line.
+3. **Use bare domains**: Pass `example.com`, not `https://example.com`, unless an endpoint explicitly accepts URLs.
+4. **Pick the right regional database**: Common values include `us`, `uk`, `de`, and other Semrush regional database codes.
+5. **URL-encode filters**: If using `display_filter` or special characters, write the filter to `/tmp/query.txt` and use `--data-urlencode "display_filter@/tmp/query.txt"` with `curl -G`.


### PR DESCRIPTION
## Summary
- Add `semrush` skill for SEO, keyword, domain, and backlink API workflows
- Add `massive` skill for market data, ticker reference, OHLC bars, forex, and market status workflows
- Mark Semrush and Massive as completed in `docs/saas.md`

## Related PRs
- Connector implementation: https://github.com/vm0-ai/vm0/pull/17147

## Validation
- Read `docs/skill-template.md` and `docs/bad-smell.md`
- Checked Semrush and Massive official API docs for auth and endpoint paths
- Ran static bad-smell checks for useless `jq .`, `-H`, `bash -c`, `printenv`, inline JSON bodies, and line continuations
- Ran `git diff --cached --check`

## Notes
- Semrush SEO API examples return CSV, so the skill avoids JSON assumptions for those endpoints.
- Massive examples use Bearer auth to match the connector firewall and avoid query-string API keys.