### PR TITLE
feat(gen): add Video Style Library with 25 cinematic style specs

### DIFF
--- a/gen/SKILL.md
+++ b/gen/SKILL.md
@@ -57,6 +57,7 @@ Run `zero generate <type>` with no prompt to list available providers for that a
    - Preserve the user's core intent, constraints, audience, brand, source materials, aspect ratio, duration, size, format, and delivery target.
    - Add operational details only when they improve generation reliability: composition, visual hierarchy, must-include/must-avoid elements, target medium, and reference handling.
    - For style-guided image generation, let the selected registry style drive stylistic details. Do not manually rewrite the style into the skill; pass `--style <id>`.
+   - For video generation with a named style or aesthetic, look up the style in the **Video Style Library** below. Inject the listed hard constraint terms into the prompt and pass `--negative-prompt` for `veo3.1-fast` and `kling-v3-4k`. Style names alone are unreliable — models interpret them inconsistently.
    - For prompt text that is long or quote-sensitive, write it to a temp file and pipe it into the command to avoid shell quoting issues.
 
 6. Execute and wait for completion.
@@ -129,3 +130,205 @@ npx -p @vm0/cli zero generate website --prompt "<brief>"
 ```
 
 Then follow the returned packet to build and host the artifact.
+
+## Video Style Library
+
+When the user names a cinematic style, genre, or visual aesthetic, look up the entry below. Inject the listed **prompt constraints** verbatim — do not rely on style names alone. For `veo3.1-fast` and `kling-v3-4k`, always pass `--negative-prompt` with the listed exclusion terms.
+
+---
+
+### Film Noir / Classic B&W
+**Triggers:** film noir, black and white, classic noir, 1940s thriller, B&W cinematic  
+**Prompt constraints:** `monochrome, grayscale film stock, high-contrast chiaroscuro lighting, deep shadow pools, single harsh key light, venetian blind shadow patterns, no color`  
+**Negative prompt:** `color, colorized, saturated, neo-noir, chromatic, vibrant`  
+**Best model:** veo3.1-fast  
+**Known bias:** Veo and Kling default to neo-noir (colorful). Without hard constraints + negative prompt, output will be color.
+
+---
+
+### Cyberpunk / Neo-Noir
+**Triggers:** cyberpunk, neo-noir, blade runner, neon dystopia, rain-soaked city  
+**Prompt constraints:** `neon-lit rain-soaked streets, blue and magenta color grade, volumetric fog, holographic signage, wet reflective pavement, high-tech low-life, practical neon lighting`  
+**Negative prompt:** `daylight, bright natural light, clean environment, pastoral, warm golden tones`  
+**Best model:** veo3.1-fast, kling-v3-4k  
+**Known bias:** Models produce generic city-night without density; fog and practical neon must be explicit.
+
+---
+
+### Horror / Thriller
+**Triggers:** horror, thriller, psychological horror, slasher, supernatural, suspense  
+**Prompt constraints:** `desaturated cold palette, deep shadow pools, motivated practical lighting only, shallow depth of field, unstable handheld camera, isolated subject, dread atmosphere`  
+**Negative prompt:** `bright cheerful lighting, warm tones, saturated colors, wide establishing shot`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models produce neutral clean frames with no tension; lighting constraints are required.
+
+---
+
+### Fantasy / Magical Realism
+**Triggers:** fantasy, magical realism, fairy tale, epic fantasy, enchanted, mythical  
+**Prompt constraints:** `ethereal soft light, golden-hour rim light, practical particles (embers, motes, fireflies), impossible scale architecture, painterly color palette, lush oversaturated environment`  
+**Negative prompt:** `urban, industrial, modern architecture, harsh flat daylight`  
+**Best model:** dreamina-seedance-2.0, veo3.1-fast  
+**Known bias:** Models produce generic forests without scale or light magic; particle and scale terms are required.
+
+---
+
+### Action / High Energy
+**Triggers:** action, fight scene, chase, explosion, high energy, intense  
+**Prompt constraints:** `dynamic tracking shot, motion blur, Dutch angle, whip pan, rapid cut rhythm, impact moment freeze, adrenaline-driven framing`  
+**Negative prompt:** `static camera, slow motion, calm atmosphere, locked-off wide shot`  
+**Best model:** kling-v3-4k  
+**Known bias:** Models default to stable cinematography; motion, angle, and rhythm must be forced.
+
+---
+
+### Romantic / Soft Focus
+**Triggers:** romantic, love story, soft focus, dreamy, tender, warm  
+**Prompt constraints:** `warm golden-hour backlight, shallow depth of field, soft diffusion filter, cream and peach tones, slow deliberate push-in, gentle lens flare`  
+**Negative prompt:** `harsh lighting, cold color temperature, sharp hard edges, high contrast`  
+**Best model:** dreamina-seedance-2.0  
+**Known bias:** Models produce neutral sharp output; warmth and diffusion must be specified.
+
+---
+
+### Sci-Fi Futuristic
+**Triggers:** sci-fi, futuristic, space opera, hard sci-fi, near-future, space station  
+**Prompt constraints:** `clinical environment, practical panel lighting, cold blue or ultraviolet color grade, holographic HUD elements, vast scale architecture, minimal surface design, deep space vacuum`  
+**Negative prompt:** `organic materials, warm tones, natural environment, vintage aesthetics`  
+**Best model:** veo3.1-fast, dreamina-seedance-2.0  
+**Known bias:** Models produce generic "tech look"; cold clinical grade and architectural scale need explicit terms.
+
+---
+
+### Cinéma Vérité / Documentary Handheld
+**Triggers:** documentary, handheld, cinéma vérité, observational, raw footage, journalistic  
+**Prompt constraints:** `handheld organic camera shake, available light only, no artificial fill, natural color grade, intimate subject proximity, real-environment background`  
+**Negative prompt:** `studio lighting, clean production look, tripod locked-off, saturated color grade`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models default to polished cinematic output; organic imperfection must be forced.
+
+---
+
+### Nature Documentary
+**Triggers:** nature documentary, BBC Planet Earth, wildlife, animal behavior, David Attenborough  
+**Prompt constraints:** `telephoto lens compression, tripod locked-off, overcast diffused natural light, shallow depth of field on subject, muted natural palette (greens, browns, grays), behavioral moment composition`  
+**Negative prompt:** `human environment, urban, studio lighting, dramatic artificial color grade`  
+**Best model:** dreamina-seedance-2.0  
+**Known bias:** Models produce generic outdoor footage; telephoto compression and static tripod framing need explicit terms.
+
+---
+
+### News / Broadcast
+**Triggers:** news, broadcast, TV news, live report, journalism, on-the-ground reporting  
+**Prompt constraints:** `shoulder-mounted camera, broadcast flat lighting, reporter foreground subject, news environment background, 50mm equivalent focal length, neutral color grade`  
+**Negative prompt:** `cinematic color grade, shallow depth of field, dramatic lighting, music video pacing`  
+**Best model:** dreamina-seedance-2.0-fast  
+**Known bias:** Models apply cinematic treatments by default; flat broadcast look must be forced.
+
+---
+
+### Slow Motion
+**Triggers:** slow motion, slow-mo, ultra slow-mo, high-speed camera, slo-mo  
+**Prompt constraints:** `ultra-slow playback, subject at peak-action moment, motion trail visible, clean well-lit environment for motion clarity, time-freeze composition`  
+**Negative prompt:** `real-time speed, fast cut pacing, motion blur from camera shake`  
+**Best model:** kling-v3-4k (native slow-mo), veo3.1-fast  
+**Known bias:** Models generate real-time footage; frame the scene as a peak-action freeze to get slow-motion composition even when the model renders at 24fps.
+
+---
+
+### Timelapse / Hyperlapse
+**Triggers:** timelapse, time-lapse, hyperlapse, accelerated motion, clouds racing, city flow  
+**Prompt constraints:** `extreme time compression, motion trails on moving subjects (clouds, traffic, people), star trail streaks in night sky, light painting from long exposure, static world with fluid motion`  
+**Negative prompt:** `real-time speed, static subjects, normal motion`  
+**Best model:** dreamina-seedance-2.0, veo3.1-fast  
+**Known bias:** Models generate normal-speed video; timelapse must be described as visible motion trails and streaking light, not just named.
+
+---
+
+### Stop Motion
+**Triggers:** stop motion, stop-motion, claymation, frame-by-frame, puppet animation  
+**Prompt constraints:** `deliberate jitter between frames, handmade physical texture, tactile material surfaces (clay, felt, paper), studio key light, smooth loop-back movement, visible set edges`  
+**Negative prompt:** `smooth digital motion blur, CGI sheen, photoreal rendering, fluid camera movement`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models apply smooth motion by default; jitter and handmade texture must be forced.
+
+---
+
+### Vintage 1970s Film
+**Triggers:** vintage, 1970s, 70s cinema, retro, analog film, period film  
+**Prompt constraints:** `heavy 16mm film grain, warm color shift (yellows and oranges dominant), faded blacks, soft contrast, anamorphic horizontal lens flares, slightly desaturated mids`  
+**Negative prompt:** `clean digital, sharp edges, cool color grade, 4K clarity, modern production`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models produce clean digital output; grain, warm shift, and faded contrast must be explicit.
+
+---
+
+### VHS / Retro 80s
+**Triggers:** VHS, retro 80s, 80s aesthetic, lo-fi video, tape, scan lines  
+**Prompt constraints:** `VHS tracking artifacts, horizontal scan lines, chroma bleeding on high-contrast edges, washed-out highlights, color bleed, low-resolution softness, heavy noise grain`  
+**Negative prompt:** `HD clarity, sharp edges, clean color grade, modern post-production`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models produce clean video; VHS degradation must be described as specific artifacts, not just "VHS style."
+
+---
+
+### Super 8mm
+**Triggers:** Super 8, 8mm, indie film, home movie, analog indie  
+**Prompt constraints:** `heavy 8mm grain, soft focus edges, overexposed highlights, warm pushed reds and yellows, light leak artifacts, visible sprocket holes, flickering exposure`  
+**Negative prompt:** `clean digital, sharp corners, 4K, flat color grade, modern equipment`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models conflate 8mm with generic vintage; sprocket artifacts and pushed grain need explicit terms.
+
+---
+
+### Luxury Product Commercial
+**Triggers:** luxury commercial, high-end ad, premium product, luxury brand  
+**Prompt constraints:** `macro product close-up, controlled studio specular highlights, black or white seamless backdrop, precise key and rim lighting, slow deliberate push-in, neutral cool-to-warm grade`  
+**Negative prompt:** `handheld shake, organic environment, natural-light inconsistency, cluttered background`  
+**Best model:** kling-v3-4k (4K for product clarity)  
+**Known bias:** Models add environmental context; seamless backdrop and controlled lighting must be explicit.
+
+---
+
+### Tech Product Demo
+**Triggers:** tech demo, product demo, app demo, software showcase, SaaS ad  
+**Prompt constraints:** `clean minimal environment, device on neutral surface, screen UI clearly visible, cool neutral color grade, flat studio lighting, tight framing on product`  
+**Negative prompt:** `clutter, organic elements, dramatic lighting, warm tones, busy background`  
+**Best model:** dreamina-seedance-2.0  
+**Known bias:** Models add lifestyle context; minimal studio isolation must be forced.
+
+---
+
+### Food & Beverage Commercial
+**Triggers:** food commercial, food ad, beverage ad, culinary, restaurant, food photography  
+**Prompt constraints:** `macro food detail, steam or condensation in frame, warm backlight, saturated natural food colors, shallow depth of field, slate or wood surface texture, food-stylist composition`  
+**Negative prompt:** `flat lighting, cool color grade, abstract background, blurry product`  
+**Best model:** kling-v3-4k  
+**Known bias:** Models produce generic food shots; steam, condensation, and warm backlight must be explicit.
+
+---
+
+### Anime / Manga Motion
+**Triggers:** anime, manga, Japanese animation, Ghibli, shonen, cel animation  
+**Prompt constraints:** `cel-shaded flat color fills, clean anime line art, flat painted background, limited animation style, large expressive eyes, speed lines on action beats`  
+**Negative prompt:** `photorealistic, CGI render, live action, 3D sheen, western cartoon`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models blend anime with CGI or generic animation; cel-shaded flat fills and limited animation style need explicit terms.
+
+---
+
+### 3D CGI / Render
+**Triggers:** 3D CGI, CGI animation, 3D render, Pixar style, Blender render, photoreal 3D  
+**Prompt constraints:** `photoreal 3D render, subsurface scattering, ray-traced global illumination, depth of field, PBR materials, studio or environment lighting, smooth surface sheen`  
+**Negative prompt:** `live action footage, hand-drawn, 2D flat, cel-shaded, painted texture`  
+**Best model:** dreamina-seedance-2.0  
+**Known bias:** Models produce cartoon-adjacent output without explicit PBR and ray-trace descriptors.
+
+---
+
+### Watercolor / Painterly
+**Triggers:** watercolor, painterly, painted animation, impressionist, hand-painted, artistic  
+**Prompt constraints:** `visible brushstroke texture, watercolor pigment bleed at edges, limited palette (5–7 colors), white paper showing through light areas, soft diffuse edges, gestural mark-making`  
+**Negative prompt:** `photorealistic, sharp edges, clean digital lines, photography, CGI sheen`  
+**Best model:** veo3.1-fast  
+**Known bias:** Models produce digitally smooth output; brushstroke texture and pigment bleed must be explicitly forced.


### PR DESCRIPTION
## Summary

- Video generation has no style registry equivalent to image's `--style` system, so agents pass style names verbatim and models interpret them inconsistently (e.g. "film noir" → colorful neo-noir output)
- Adds a **Video Style Library** section to `gen/SKILL.md` with a complete entry for every common cinematic/video style
- Also adds a pointer in Step 5 (Build the prompt) directing agents to consult the library for video style requests

## What each entry covers

Every style entry has the same 5 fields:
- **Triggers** — keywords that identify the style
- **Prompt constraints** — exact technical terms to inject (no style names, no narrative fluff)
- **Negative prompt** — exclusion terms for `veo3.1-fast` / `kling-v3-4k`
- **Best model** — which model handles the style most reliably
- **Known bias** — what models get wrong without these constraints

## Styles covered (25 total)

| Category | Styles |
|---|---|
| Cinematic | Film Noir, Cyberpunk, Horror/Thriller, Fantasy, Action, Romantic, Sci-Fi |
| Documentary/Realism | Cinéma Vérité, Nature Documentary, News/Broadcast |
| Motion/Time | Slow Motion, Timelapse, Stop Motion |
| Era/Format | Vintage 1970s, VHS/Retro 80s, Super 8mm |
| Commercial | Luxury Product, Tech Product Demo, Food & Beverage |
| Animation/Art | Anime, 3D CGI, Watercolor/Painterly |

## Test plan

- [ ] Generate a Film Noir video — confirm agent injects `monochrome, grayscale film stock` and passes `--negative-prompt "color, colorized"` to veo3.1-fast
- [ ] Generate a Cyberpunk video — confirm `volumetric fog, wet reflective pavement, blue and magenta color grade` appear in prompt
- [ ] Generate a Nature Documentary — confirm `telephoto lens compression, tripod locked-off` are injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)