### PR TITLE
feat: add 6 video-template styled resources (batch 1)

### DIFF
--- a/video-template/chinese-ink-art/SKILL.md
+++ b/video-template/chinese-ink-art/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: chinese-ink-art
-description: A Chinese ink-wash (shuimo) video style — monochrome ink gradients, generous white space, visible brushstroke texture, mist-and-mountain composition, and a calm classical-poetry mood. Applies to whatever subject the user brings. Trigger on /chinese-ink-art, "Chinese ink painting", "shuimo / 水墨", "ink wash animation", or "Eastern zen ink style".
+description: A Chinese ink-wash (shuimo) video style — monochrome ink gradients, generous white space, visible brushstroke texture, mist-and-mountain composition, and a calm classical-poetry mood. Applies to whatever subject the user brings. Trigger on /chinese-ink-art, "Chinese ink painting", "shuimo", "ink wash animation", or "Eastern zen ink style".
 ---
 
 # Chinese Ink Painting
 
-A **Chinese ink-wash (水墨) style**, not a fixed scene. Keep the user's subject exactly as briefed — a mountain, a crane, a figure, an object — and render it as flowing ink on paper in the look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+A **Chinese ink-wash (shuimo) style**, not a fixed scene. Keep the user's subject exactly as briefed — a mountain, a crane, a figure, an object — and render it as flowing ink on paper in the look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
 
 ## What this style is
 
-**The essence:** **stillness and emptiness as beauty** — a few confident ink strokes floating in vast white space, evoking a classical Chinese poem. The goal is **calm, breath, and suggestion** (留白): what's left unpainted matters as much as the ink.
+**The essence:** **stillness and emptiness as beauty** — a few confident ink strokes floating in vast white space, evoking a classical Chinese poem. The goal is **calm, breath, and negative space**: what's left unpainted matters as much as the ink.
 
 **Touchstones:** classical Chinese shuimo painting (Qi Baishi, Xu Beihong), *Shanshui* landscapes, the ink-animation of *Where Is Mama / Feeling from Mountain and Water* (Shanghai Animation Film Studio).
 

--- a/video-template/chinese-ink-art/SKILL.md
+++ b/video-template/chinese-ink-art/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: chinese-ink-art
+description: A Chinese ink-wash (shuimo) video style — monochrome ink gradients, generous white space, visible brushstroke texture, mist-and-mountain composition, and a calm classical-poetry mood. Applies to whatever subject the user brings. Trigger on /chinese-ink-art, "Chinese ink painting", "shuimo / 水墨", "ink wash animation", or "Eastern zen ink style".
+---
+
+# Chinese Ink Painting
+
+A **Chinese ink-wash (水墨) style**, not a fixed scene. Keep the user's subject exactly as briefed — a mountain, a crane, a figure, an object — and render it as flowing ink on paper in the look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+
+## What this style is
+
+**The essence:** **stillness and emptiness as beauty** — a few confident ink strokes floating in vast white space, evoking a classical Chinese poem. The goal is **calm, breath, and suggestion** (留白): what's left unpainted matters as much as the ink.
+
+**Touchstones:** classical Chinese shuimo painting (Qi Baishi, Xu Beihong), *Shanshui* landscapes, the ink-animation of *Where Is Mama / Feeling from Mountain and Water* (Shanghai Animation Film Studio).
+
+**What makes it distinct:** **monochrome ink + negative space + brushstroke**. Not color photography, not photoreal, not Western painting — black ink gradients on bright paper, mist, and generous emptiness, with at most a single tiny spot of color (e.g. a red seal or lantern).
+
+## Style dimensions (locked)
+
+- **Visual tone — cold / monochrome**: black ink gradients on bright off-white paper; desaturated; at most one tiny accent of color.
+- **Camera — slow push-in**: a slow, gentle drift or push; meditative, weightless.
+- **Editing pace — slow & meditative**: long, breathing shots; no cutting.
+- **Narrative mode — abstract / mood**: poetic suggestion, not narrative.
+- **Production type**: rendered as **ink-wash painting** (painterly, not photoreal). Mist and ink may animate softly.
+- **Emotional tone — calm & meditative**: serene, contemplative, zen.
+- **Style reference — Chinese ink wash (shuimo)**: brushstroke elegance, mist, and classical negative space.
+
+## Prompt construction
+
+Write **one cohesive video prompt in your own words**, adapted to the subject. Hit these beats in Seedance order:
+
+`subject (as briefed) → misty ink-wash setting with vast white space → gentle motion (drifting mist, flowing ink, ripples) → slow push-in → soft diffuse light → monochrome ink-wash brushstroke style`
+
+**Always convey:** Chinese ink-wash painting · monochrome black-ink gradients on bright paper · generous white negative space · visible brushstroke texture · mist / classical-poetry mood · calm slow motion · (optional) one tiny red-seal accent.
+
+**Never:** color photography, photorealism, Western oil-painting look, busy/cluttered composition, saturated color, harsh light.
+
+Adapt the subject and what little surrounds it; keep the emptiness. Put aspect ratio, negatives, and seed in the **params**.
+
+## Generation parameters
+
+- **aspectRatio**: `16:9` (handscroll-like) or `21:9` for a wide scroll feel.
+- **resolution & model tier**: pick a tier that supports the resolution — fast tiers cap lower (often `720p`); `1080p` needs a full tier.
+- **duration**: `5–8s`; let mist drift and ink bleed slowly.
+- **negativePrompt**: `color photography, photorealistic, Western oil painting, saturated colors, cluttered composition, harsh lighting, 3D render, low resolution`.
+- **generateAudio**: optional — soft guqin / water ambience suits it; often added in edit.
+- **seed**: mild lever for text-to-video; for look consistency use `firstFrameImageUrl`.
+- **firstFrameImageUrl** (strongest stability lever): generate one ink-wash still (see *Reference still*) and pass it as the first frame.
+
+## How to apply
+
+Render the user's subject as ink on paper with lots of empty space and mist. Keep monochrome (one tiny color accent at most). If the brief needs realistic color or a busy scene, this isn't the fit.
+
+## Worked examples
+
+Same ink-wash look; the subject changes.
+
+1. **"misty mountains"** → layered ink peaks fading into mist, a tiny boat and a single red lantern, vast white space, slow drift (the picker thumbnail).
+2. **"a crane by the water"** → a single ink crane among brushed reeds, mist, one small red seal stamp as the only color (see reference still).
+3. **"a lone pine on a cliff"** → a wind-bent ink pine, empty paper sky, soft mist, slow push-in.
+4. **"koi in a pond"** → a few ink koi and ripples in vast white water, minimal, meditative.
+
+## Reference output
+
+| Field | Value |
+| --- | --- |
+| Picker thumbnail | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/35a45e0a-095f-476c-9586-840b3e591947/thumbnail-chinese-ink-art.jpg` |
+| Reference still — ink crane (Seedream, seed 54) | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a8c55beb-59ac-4362-8abc-83a669d88ebb/image-a8c55beb.png` |
+| Canonical | monochrome ink · vast white space · brushstroke · mist · one tiny red accent · slow drift |
+
+> The reference still holds the ink-wash look on a different subject (crane vs. mountains/boat) — the style is subject-invariant. Pass it as `firstFrameImageUrl` to lock the look.

--- a/video-template/cyberpunk-anime/SKILL.md
+++ b/video-template/cyberpunk-anime/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cyberpunk-anime
+description: A 2D cyberpunk anime video style — hand-drawn cel-look characters in a neon megacity, rain-slicked streets, electric teal-and-magenta palette, and a melancholic mood. Applies to whatever character/scene the user brings. Trigger on /cyberpunk-anime, "cyberpunk anime", "neon anime city", "lo-fi anime night", or "2D anime cyberpunk scene".
+---
+
+# Cyberpunk Anime
+
+A **2D cyberpunk anime style**, not a fixed scene. Keep the user's character or subject exactly as briefed — and render it as hand-drawn anime in the neon-city look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and the look is **2D animation** (state this explicitly so the model doesn't drift to live action / 3D).
+
+## What this style is
+
+**The essence:** a lonely, beautiful **neon-noir mood in hand-drawn anime** — a small human moment dwarfed by a glowing, rain-soaked megacity. The goal is **atmosphere and melancholy**, the quiet feeling of a city at night, not action spectacle.
+
+**Touchstones:** *Blade Runner*-flavored anime, lo-fi "chillhop" anime loops, *Ghost in the Shell* / cyberpunk OVA backgrounds, neon city night illustrations.
+
+**What makes it distinct:** **2D cel animation + neon + rain + melancholy**. Not live action, not 3D CGI, not warm or natural — flat cel shading, electric teal/magenta neon, wet reflective streets, a pensive lone figure.
+
+## Style dimensions (locked)
+
+- **Visual tone — neon cyberpunk**: electric teal and magenta neon against deep night; glowing signage, wet reflective surfaces.
+- **Camera — dutch / slow drift**: subtly tilted or slowly drifting framing; atmospheric, observational, not frenetic.
+- **Editing pace — fast cut (restrained)**: can cut between moody beats; keep it atmospheric, not action-frantic.
+- **Narrative mode — abstract / mood**: vibe over plot; a feeling, not a story beat.
+- **Production type — 2D animation**: hand-drawn cel-shaded anime. **Explicitly not live action, not 3D CGI.**
+- **Emotional tone — melancholic**: pensive, lonely, bittersweet calm.
+- **Style reference — cyberpunk anime**: neon megacity OVA backgrounds, rain and reflections.
+
+## Prompt construction
+
+Write **one cohesive video prompt in your own words**, adapted to the subject. Hit these beats in Seedance order:
+
+`character/subject (as briefed) → neon rain-slicked city setting → quiet motion (rain, steam, drifting figure) → subtly tilted/drifting camera → teal-magenta neon glow → 2D cel anime style, melancholic`
+
+**Always convey:** **2D hand-drawn anime, cel-shaded** · neon megacity backdrop with glowing signage · rain-slicked reflective streets · electric teal + magenta palette · a melancholic, lonely mood · atmospheric framing.
+
+**Never:** live-action footage, 3D CGI, photorealism, warm natural daylight, bright cheerful tone.
+
+Adapt the character and city details to the brief. Put aspect ratio, negatives, and seed in the **params**.
+
+## Generation parameters
+
+- **aspectRatio**: `16:9` (cinematic anime) or `9:16` for vertical loops.
+- **resolution & model tier**: pick a tier that supports the resolution — fast tiers cap lower (often `720p`); `1080p` needs a full tier.
+- **duration**: `5–8s`; let rain, neon flicker, and a slow drift carry it.
+- **negativePrompt**: `live action, photorealistic, 3D CGI render, warm daylight, bright cheerful tone, natural landscape, low resolution, extra fingers`.
+- **generateAudio**: **on** for rain/city ambience (pairs well with lo-fi music in edit).
+- **seed**: mild lever for text-to-video; for look/character consistency use `firstFrameImageUrl`.
+- **firstFrameImageUrl** (strongest stability lever): generate one anime still (see *Reference still*) and pass it as the first frame — especially useful to lock a character design.
+
+## How to apply
+
+Render the user's subject as **2D cel anime** in a neon rain-city. Always state the 2D-anime medium in the prompt (the model drifts to live action otherwise). If the brief wants photoreal or a bright/warm mood, this isn't the fit.
+
+## Worked examples
+
+Same neon-anime look; the subject changes.
+
+1. **"a lone hacker"** → a hooded figure looking down a rain-slicked neon alley, glowing signage, melancholic, slow drift (the picker thumbnail).
+2. **"someone eating ramen at night"** → a lone figure at a glowing ramen stall, steam and neon reflections in wet pavement, pensive calm (see reference still).
+3. **"a girl on a train platform"** → standing under flickering neon, rain outside, teal-magenta glow, subtly tilted framing.
+4. **"a cat on a fire escape"** → a cat silhouetted against neon signs, rain, reflective puddles below.
+
+## Reference output
+
+| Field | Value |
+| --- | --- |
+| Picker thumbnail | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/b870f6c1-95a8-4ab6-aa0d-a125cb57dd3e/thumbnail-cyberpunk-anime.jpg` |
+| Reference still — ramen stall (Seedream, seed 53) | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/4084db29-b61f-4491-b90d-54a48220601c/image-4084db29.png` |
+| Canonical | 2D cel anime · neon megacity · rain-slicked reflections · teal+magenta · melancholic · drifting frame |
+
+> The reference still holds the neon-anime look on a different subject (ramen stall vs. hooded figure) — the style is subject-invariant. Pass it as `firstFrameImageUrl` to lock a character or scene for image-to-video.

--- a/video-template/gourmet-documentary/SKILL.md
+++ b/video-template/gourmet-documentary/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: gourmet-documentary
+description: A sensory culinary-documentary video style — macro food texture, rising steam, warm backlight, rich saturated color, shallow depth of field, and artisan hands in frame. Applies to whatever food/craft the user brings. Trigger on /gourmet-documentary, "food documentary", "Chef's Table style", "appetizing food video", or "sensory food close-up".
+---
+
+# Gourmet Documentary
+
+A **sensory food-documentary style**, not a fixed dish. Keep the user's food or craft exactly as briefed — sashimi, coffee, bread, a cocktail — and shoot it in the intimate macro look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+
+## What this style is
+
+**The essence:** make food feel **irresistible and crafted by human hands** — get close enough to read every texture, catch the steam, and feel the care. The goal is **appetite and craft reverence**, an intimate sensory moment.
+
+**Touchstones:** *Chef's Table*, *Salt Fat Acid Heat*, high-end recipe films, artisan-craft documentaries, premium food advertising macro work.
+
+**What makes it distinct:** **macro intimacy + warmth + the human hand**. Not a wide table scene, not cold or clinical — tight, warm, tactile, with a craftsperson's hands in the frame.
+
+## Style dimensions (locked)
+
+- **Visual tone — warm & natural**: warm appetizing tones, rich saturated food color, soft naturalistic light.
+- **Camera — extreme close-up / macro**: tight on texture and detail; subtle slow moves (slow push or slow slide) that explore the surface.
+- **Editing pace — slow & meditative**: lingering shots that let texture and steam breathe. No fast cutting.
+- **Narrative mode — observational**: no narrator; the food and hands tell it.
+- **Production type — live action**: photoreal food footage.
+- **Emotional tone — warm & nostalgic**: comforting, sensory, hand-made warmth.
+- **Style reference — gourmet documentary**: the macro, steam-and-texture register of prestige food films.
+
+## Prompt construction
+
+Write **one cohesive video prompt in your own words**, adapted to the food. Hit these beats in Seedance order:
+
+`food/craft (as briefed) → close intimate setting → a craft action + rising steam/motion → macro slow camera → warm backlight → rich warm grade, shallow focus`
+
+**Always convey:** macro close-up on food texture · visible steam or motion (a pour, a sprinkle, a cut) · artisan hands in frame · warm backlight catching the surface · rich saturated warm color · shallow depth of field · slow lingering pace.
+
+**Never:** cold/clinical lighting, fast editing, wide industrial/canteen setting, flat desaturated color, plastic-looking food.
+
+Adapt the dish, the craft action, and the texture to the brief. Put aspect ratio, negatives, and seed in the **params**.
+
+## Generation parameters
+
+- **aspectRatio**: `16:9` (or `9:16` for social food clips).
+- **resolution & model tier**: pick a tier that supports the resolution — fast tiers cap lower (often `720p`); `1080p` needs a full tier.
+- **duration**: `5–8s`; let one slow macro move and the steam breathe.
+- **negativePrompt**: `cold lighting, clinical look, fast cuts, wide industrial kitchen, flat desaturated color, plastic food, low resolution`.
+- **generateAudio**: **on** — sizzle / pour / ambient kitchen sound strengthens the sensory feel.
+- **seed**: mild lever for text-to-video; for look consistency use `firstFrameImageUrl`.
+- **firstFrameImageUrl** (strongest stability lever): generate one macro still (see *Reference still*) and pass it as the first frame.
+
+## How to apply
+
+Get intimate and warm: macro on texture, catch the steam, keep a craftsperson's hands in frame. If the brief wants a wide restaurant scene or a fast hype edit, this isn't the fit.
+
+## Worked examples
+
+Same warm macro look; the food changes.
+
+1. **"latte art"** → macro of a barista pouring a rosetta, steam rising, warm backlight, slow push-in, shallow focus (see reference still).
+2. **"fresh bread"** → hands tearing a warm loaf, steam escaping the crumb, golden backlight, slow lingering macro.
+3. **"a cocktail"** → a slow pour over ice, condensation and citrus oils catching light, warm tones, shallow focus.
+4. **"sashimi plating"** → chef's hands placing micro-herbs with tweezers, macro on the fish grain, warm key light (the picker thumbnail).
+
+## Reference output
+
+| Field | Value |
+| --- | --- |
+| Picker thumbnail | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/30ab1733-bec0-4ddb-9e15-8f707377af7b/thumbnail-gourmet-documentary.jpg` |
+| Reference still — latte pour (Seedream, seed 52) | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/71642cf3-f879-4684-a6a1-afeb52fb723a/image-71642cf3.png` |
+| Canonical | macro texture · rising steam · warm backlight · artisan hands · shallow focus · slow pace |
+
+> The reference still holds the warm macro look on a different subject (coffee vs. sashimi) — the style is subject-invariant. Pass it as `firstFrameImageUrl` to lock the look.

--- a/video-template/japanese-wabi-sabi/SKILL.md
+++ b/video-template/japanese-wabi-sabi/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: japanese-wabi-sabi
+description: A Japanese wabi-sabi lifestyle video style — natural imperfection, warm soft morning light, negative space, aged organic materials (wood, stone, moss), and a quiet unhurried mood. Applies to whatever subject the user brings. Trigger on /japanese-wabi-sabi, "wabi-sabi", "Japanese minimalist lifestyle", "quiet aesthetic", or "calm muji-style video".
+---
+
+# Japanese Wabi-Sabi
+
+A **wabi-sabi lifestyle style**, not a fixed scene. Keep the user's subject exactly as briefed — an object, a corner, a moment — and render it in the quiet, imperfect, softly-lit look below. The style supplies the *mood*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+
+## What this style is
+
+**The essence:** find beauty in **imperfection, age, and quiet** — a small, humble subject held in soft light and empty space, unhurried. The goal is **calm and intimacy** (the beauty of the incomplete and impermanent), not spectacle or polish.
+
+**Touchstones:** Japanese wabi-sabi philosophy, Muji / Kinfolk lifestyle films, slow-living and tea-ceremony aesthetics, soft natural-light still-life.
+
+**What makes it distinct:** **intimacy + imperfection + soft warm light**. Small in scale and gentle — the opposite of grand or saturated. Aged organic materials, negative space, and a single hushed moment.
+
+## Style dimensions (locked)
+
+- **Visual tone — warm & natural, muted**: soft warm morning light, understated muted colors; never punchy or saturated.
+- **Camera — slow push-in**: a slow, gentle drift toward the subject; often a low, intimate angle; shallow depth of field.
+- **Editing pace — slow & meditative**: long, quiet, breathing takes; no cutting.
+- **Narrative mode — observational**: a quiet found moment; no narration.
+- **Production type — live action**: photoreal, tactile real-world footage.
+- **Emotional tone — calm & meditative**: serene, intimate, contemplative.
+- **Style reference — wabi-sabi**: imperfection, aging, and quiet beauty in impermanence.
+
+## Prompt construction
+
+Write **one cohesive video prompt in your own words**, adapted to the subject. Hit these beats in Seedance order:
+
+`subject (as briefed) → intimate setting with aged organic materials → small quiet motion (drifting steam, a falling petal, soft breeze) → slow gentle push-in, shallow focus → soft warm morning light → muted wabi-sabi calm`
+
+**Always convey:** natural imperfection and aged organic textures (wood, stone, moss, ceramic) · soft warm morning light · generous negative space · shallow depth of field · a quiet unhurried single moment · muted understated color.
+
+**Never:** urban clutter, artificial/hard light, saturated punchy color, fast pacing, glossy perfection, busy composition.
+
+Adapt the humble subject and its textures to the brief. Put aspect ratio, negatives, and seed in the **params**.
+
+## Generation parameters
+
+- **aspectRatio**: `16:9` (or `9:16` for vertical lifestyle clips).
+- **resolution & model tier**: pick a tier that supports the resolution — fast tiers cap lower (often `720p`); `1080p` needs a full tier.
+- **duration**: `5–8s`; let one small motion and the light breathe.
+- **negativePrompt**: `urban clutter, artificial light, hard light, saturated colors, fast pacing, glossy perfection, busy composition, low resolution`.
+- **generateAudio**: optional — soft ambient (birdsong, water, breeze) suits the calm.
+- **seed**: mild lever for text-to-video; for look consistency use `firstFrameImageUrl`.
+- **firstFrameImageUrl** (strongest stability lever): generate one soft-light still (see *Reference still*) and pass it as the first frame.
+
+## How to apply
+
+Hold the user's subject in soft warm light and empty space, small and quiet, with aged natural textures. If the brief wants something bold, bright, fast, or grand, this isn't the fit.
+
+## Worked examples
+
+Same quiet wabi-sabi look; the subject changes.
+
+1. **"a cobblestone alley at dawn"** → low-angle on a wet stone path, fallen cherry petals, moss and aged ceramics, soft warm light (the picker thumbnail).
+2. **"a cup of tea"** → a weathered ceramic teacup on an aged wooden veranda, faint steam, soft morning light, shallow focus (see reference still).
+3. **"a potted plant by a window"** → a single plant in soft diffused light, dust motes drifting, muted tones, negative space.
+4. **"handmade pottery"** → an imperfect clay bowl on linen, gentle push-in catching the glaze texture, warm quiet light.
+
+## Reference output
+
+| Field | Value |
+| --- | --- |
+| Picker thumbnail | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/a7a69fe3-9e6c-48fd-af55-62c8a57a0371/thumbnail-japanese-wabi-sabi.jpg` |
+| Reference still — teacup (Seedream, seed 55) | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/418fc568-a83d-483f-b344-a494b962c0dd/image-418fc568.png` |
+| Canonical | aged organic textures · soft warm light · negative space · shallow focus · slow gentle pace · muted color |
+
+> The reference still holds the wabi-sabi look on a different subject (teacup vs. alley) — the style is subject-invariant. Pass it as `firstFrameImageUrl` to lock the look.

--- a/video-template/shortform-viral/SKILL.md
+++ b/video-template/shortform-viral/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: shortform-viral
+description: A short-form viral video style — vertical 9:16, fast hook, authentic handheld creator energy, bright saturated casual look, and a fast cut rhythm. Applies to whatever the user is filming. Trigger on /shortform-viral, "TikTok style", "Reels style", "viral short video", or "UGC creator clip".
+---
+
+# Shortform Viral
+
+A **social short-form style**, not a fixed scene. Keep the user's subject exactly as briefed — a product, a moment, people, a place — and shoot it like a creator's phone clip below. The style supplies the *energy*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+
+## What this style is
+
+**The essence:** feel like a real person filmed it on their phone and it blew up — **authentic, immediate, high-energy**. The goal is **relatable spontaneity and a fast hook**, not polish. It should look unproduced on purpose.
+
+**Touchstones:** TikTok / Reels creator content, GRWM and day-in-the-life clips, candid travel/lifestyle UGC, run-and-gun phone footage.
+
+**What makes it distinct:** **vertical, handheld, fast, bright**. The opposite of a locked tripod and a slow cinematic grade — its credibility comes from looking casual and real.
+
+## Style dimensions (locked)
+
+- **Visual tone — warm & natural, bright saturated**: punchy daylight, casual phone-camera look, lively color; not a graded "film" look.
+- **Camera — handheld raw**: natural handheld movement, slight shake and reframes, follows the action; feels human-held.
+- **Editing pace — fast cut**: quick rhythmic cuts; a strong hook in the **first second**. (Seedance can do multi-shot — use it here.)
+- **Narrative mode — observational**: candid, in-the-moment; no formal narration.
+- **Production type — live action**: real-world phone-grade footage.
+- **Emotional tone — playful & fun**: upbeat, joyful, casual energy.
+- **Style reference — short-form viral**: authentic creator content built to stop the scroll.
+
+## Prompt construction
+
+Write **one cohesive video prompt in your own words**, adapted to the subject. Hit these beats in Seedance order:
+
+`subject (as briefed) → casual real-world setting → energetic action → handheld camera following it → bright natural light → playful creator vibe`
+
+**Always convey:** vertical 9:16 phone framing · a strong action/hook right away · natural handheld movement · bright saturated casual daylight · playful authentic energy · fast pacing.
+
+**Never:** formal studio/tripod look, slow meditative pacing, cinematic letterbox, heavy color grade, staged stiffness.
+
+Adapt the action and setting to the subject. Put aspect ratio, negatives, and seed in the **params**.
+
+## Generation parameters
+
+- **aspectRatio**: `9:16` (vertical — non-negotiable for this style).
+- **resolution & model tier**: pick a tier that supports the resolution — fast tiers cap lower (often `720p`); `1080p` needs a full tier.
+- **duration**: `5–8s`; pack a hook + a beat or two of payoff. Multi-shot is welcome.
+- **negativePrompt**: `formal studio look, tripod locked frame, cinematic letterbox, slow pacing, heavy color grade, staged, stiff, low resolution`.
+- **generateAudio**: **on** — casual ambient/energy helps the authentic feel (swap for trending audio in edit).
+- **seed**: mild lever for text-to-video. For look consistency use `firstFrameImageUrl`.
+- **firstFrameImageUrl**: optional here — handheld energy matters more than a locked first frame; use a still anchor only if you need a specific opening look.
+
+## How to apply
+
+Shoot the user's subject like a creator would: vertical, in the moment, energetic, bright. If the brief wants a slow, premium, cinematic feel, this is the wrong style — pick a cinematic or product style instead.
+
+## Worked examples
+
+Same casual creator energy; the subject changes.
+
+1. **"unboxing our snack product"** → hands ripping open the pack to camera, quick cuts to a bite and a reaction, vertical, bright kitchen daylight, playful.
+2. **"a beach day with friends"** → friends running and laughing toward the water, handheld follow, bright saturated, fast cuts (see reference still / picker thumbnail).
+3. **"a coffee shop morning"** → POV walking in, quick cuts of the order and first sip, casual handheld, warm daylight.
+4. **"a sneaker drop"** → fast hook on feet stepping into frame, quick spins and angles, vertical, energetic.
+
+## Reference output
+
+| Field | Value |
+| --- | --- |
+| Picker thumbnail | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/40ab801f-16bc-4e29-8370-6b10cd394e30/thumbnail-shortform-viral.jpg` |
+| Reference still — rooftop party (Seedream, seed 51, 9:16) | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/06064f7a-abdb-4284-9562-507d6dce7ed4/image-06064f7a.png` |
+| Canonical | vertical 9:16 · handheld · bright saturated · fast cuts · playful creator energy |
+
+> The reference still holds the casual bright-energy look on a different subject (rooftop party vs. beach crew) — the style is subject-invariant.

--- a/video-template/tech-minimalist-reveal/SKILL.md
+++ b/video-template/tech-minimalist-reveal/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: tech-minimalist-reveal
+description: A minimalist tech/product reveal video style — a single product floating in a bright white seamless studio void, precise soft studio light, clean shadow, glossy reflection, cool neutral grade, and generous negative space. Applies to whatever product the user brings. Trigger on /tech-minimalist-reveal, "product reveal", "Phone Product Showcase", "Apple-style product video", or "clean studio product shot".
+---
+
+# Phone Product Showcase
+
+A premium **product-reveal style**, not a fixed product. Keep the user's product exactly as briefed — a phone, a watch, a bottle, a gadget — and present it in the locked studio look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and framing/negatives are expressed the way Seedance follows most reliably.
+
+## What this style is
+
+**The essence:** make a single object feel **precious and inevitable** — isolate it in clean empty space and let pristine light do all the talking. The goal is **focus and reverence for the object**, nothing else in the frame to distract.
+
+**Touchstones:** Apple product films, premium consumer-tech keynote reveals, high-end e-commerce hero shots, minimalist studio still-life.
+
+**What makes it distinct:** **emptiness + precision**. One product, a seamless white void, controlled studio light — the opposite of lifestyle context, clutter, or warmth. Not a scene; a reverent object study.
+
+## Style dimensions (locked)
+
+- **Visual tone — cool & desaturated**: clean, near-neutral white-to-grey, slightly cool grade; pristine, no warm cast.
+- **Camera — slow push-in**: one slow, smooth dolly toward the product; controlled, weightless, never handheld.
+- **Shot continuity**: one continuous unhurried take. No cuts.
+- **Setting & framing**: a **bright white seamless studio void** (cyclorama), product centered with generous negative space; glossy subtly reflective floor; one clean soft shadow. Macro inserts on key detail are allowed, but the establishing frame stays wide and empty.
+- **Light**: precise soft studio lighting — large soft sources, gentle gradient falloff, a clean rim; no hard speculars, no colored gels.
+- **Production type — live action**: photoreal product footage / CGI-grade realism. Not illustration.
+- **Style reference — minimalist tech reveal**: the empty-studio precision of a flagship product film.
+
+## Prompt construction
+
+Write **one cohesive video prompt in your own words**, adapted to the user's product. Compose naturally, hitting these beats in Seedance order:
+
+`product (as briefed) → seamless white studio void → subtle motion (slow rotation / float) → slow push-in → precise soft studio light → cool neutral grade`
+
+**Always convey:** a single product isolated in a bright white seamless void · generous negative space · precise soft studio lighting with one clean shadow · cool neutral grade · slow push-in or slow product rotation · pristine macro-sharp detail · photoreal.
+
+**Never:** cluttered or lifestyle background, warm/colored light, hard speculars, handheld shake, fast cuts, props or hands (unless the user asks).
+
+Adapt the product, its material highlights, and the exact move to what's briefed. Put aspect ratio, negatives, and seed in the **params**, not the prose.
+
+## Generation parameters
+
+- **aspectRatio**: `16:9` (hero) or `9:16` for social product clips.
+- **resolution & model tier**: target resolution must be supported by the chosen model tier — fast/draft tiers cap lower (often `720p`); `1080p` needs a full-quality tier.
+- **duration**: `5–8s`; pace one slow push-in or half-rotation to fill it.
+- **negativePrompt**: `cluttered background, lifestyle context, warm color, colored light, hard glare, handheld shake, fast cuts, busy scene, low resolution, distorted product`.
+- **generateAudio**: usually **off** for a clean product cut (add music/VO in edit); leave on only for a subtle ambient hum.
+- **seed**: mild lever for text-to-video; use it to re-roll the *same* prompt. The real consistency tool is `firstFrameImageUrl`.
+- **firstFrameImageUrl** (strongest stability lever): generate one studio still of the product (see *Reference still*) and pass it as the first frame for image-to-video.
+
+## How to apply
+
+Drop the user's product into the empty white studio and let it own the frame. Do **not** add lifestyle scenery, hands, or warm light. If the brief needs the product *in use* or in context, this style isn't the fit — prefer a lifestyle or commercial style.
+
+## Worked examples
+
+Same locked studio look; the product changes.
+
+1. **"our new wireless earbuds"** → an open earbuds case floating and slowly rotating in a white seamless void, precise soft light, one clean shadow, slow push-in, cool neutral grade.
+2. **"a smart water bottle"** → the bottle standing on a glossy reflective floor, slow push-in revealing condensation macro detail, pristine studio light.
+3. **"a luxury perfume bottle"** → the bottle on a low pedestal, slow orbit catching glass refractions, generous negative space (see reference still).
+4. **"a flagship phone"** → the phone floating upright, screen edge catching a clean rim light, slow push-in to a macro of the camera module.
+
+## Reference output
+
+| Field | Value |
+| --- | --- |
+| Picker thumbnail | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/c3219368-a46b-43ce-9e98-5b5826fcaa8d/thumbnail-tech-minimalist-reveal.jpg` |
+| Reference still — perfume (Seedream, seed 50) | `https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/6a2bf374-0049-4ade-80f9-bbd419787825/image-6a2bf374.png` |
+| Canonical | single product · white seamless void · clean shadow + reflection · cool neutral · slow push-in · 16:9 |
+
+> The reference still holds the studio look on a different product (perfume vs. phone) — the style is product-invariant. Pass it as `firstFrameImageUrl` to lock the look for image-to-video.


### PR DESCRIPTION
## What

Six video styles migrated from vm0's `VIDEO_STYLE_PRESETS` into `vm0-skills`, following the **epic-grandeur** standard template (merged in #259):

`What this style is` (essence + touchstones) → `Style dimensions (locked)` → Seedance-tuned `Prompt construction` (compose-your-own, not a fill-in template) → `Generation parameters` (negativePrompt / aspectRatio / seed / firstFrameImageUrl) → `Worked examples` → `Reference output`.

## The 6 (one per category — proves the template generalizes beyond grand exteriors)

| Style | Category | Hard axis it stress-tests |
|---|---|---|
| `tech-minimalist-reveal` (Phone Product Showcase) | brand_commercial | studio / close-up / indoor / cool grade |
| `shortform-viral` | energy_music | fast cuts / handheld / 9:16 vertical |
| `gourmet-documentary` | documentary | macro / sensory / warm |
| `cyberpunk-anime` | anime | **2D animation** medium (not live action) |
| `chinese-ink-art` | art_creative | 2D stylized / monochrome / negative space |
| `japanese-wabi-sabi` | lifestyle | intimate small-scale / muted |

## Method (avoiding earlier mistakes)

- Each style **grounded in its real sample thumbnail**, not the label.
- Each ships a **fresh Seedream reference still on a *different* subject** (seed-locked) to demonstrate the style is subject-invariant — e.g. perfume (not phone), latte (not sashimi), ramen stall (not hooded figure), crane (not boat), teacup (not alley).
- `negativePrompt` derived from each preset's source `promptConstraints`; non-visual dims handled honestly.

## Follow-up

Paired **vm0 registry PR** to add `video-template:<slug>` entries for all 6 (+ epic-grandeur), activating the `video-template` kind with `source.repo = vm0-ai/vm0-skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)