### PR TITLE
docs: update google maps oauth guidance

### DIFF
--- a/google-maps/SKILL.md
+++ b/google-maps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-maps
-description: Google Maps Platform API for geocoding, places, routes, and distance matrices. Use when user mentions "Google Maps", "geocode", "directions", "places API", route matrix, or asks to look up an address, route, or place metadata.
+description: Google Maps Platform API for supported OAuth-based geocoding, places, routes, and route matrix requests. Use when user mentions "Google Maps", "geocode", "directions", "places API", route matrix, or asks to look up an address, route, or place metadata.
 ---
 
 # Google Maps
@@ -18,19 +18,37 @@ zero doctor check-connector --url https://places.googleapis.com/v1/places:search
 zero doctor check-connector --url https://routes.googleapis.com/directions/v2:computeRoutes --method POST
 ```
 
+The `check-connector --url` command verifies connector and firewall matching. It does not prove the Google API request body, field mask, billing, or project configuration is valid.
+
 ## Prerequisites
 
 - Connect Google Maps under vm0.ai -> Settings -> Connectors (OAuth).
 - The connected Google account must have access to a Google Cloud project with the relevant Maps Platform APIs enabled.
-- The OAuth access token is injected as `$GOOGLE_MAPS_TOKEN`.
-- Send the token with `Authorization: Bearer $GOOGLE_MAPS_TOKEN`.
-- Do not pass `$GOOGLE_MAPS_TOKEN` as a `key=` query parameter; the sandbox value is a placeholder, not an API key.
+- The sandbox exposes `$GOOGLE_MAPS_TOKEN` as a placeholder for the connected OAuth access token.
+- Send it only with `Authorization: Bearer $GOOGLE_MAPS_TOKEN`; vm0 replaces the header at the network boundary.
+- Do not pass `$GOOGLE_MAPS_TOKEN` as a `key=` query parameter. It is not a Maps API key.
 
-Base URLs:
+OAuth API hosts:
 
 - Geocoding v4: `https://geocode.googleapis.com`
 - Places API (New): `https://places.googleapis.com`
 - Routes API: `https://routes.googleapis.com`
+
+Recommended endpoints:
+
+- `GET https://geocode.googleapis.com/v4/geocode/address/{address_query}`
+- `GET https://geocode.googleapis.com/v4/geocode/location/{location_query}`
+- `POST https://places.googleapis.com/v1/places:searchText`
+- `GET https://places.googleapis.com/v1/places/{place_id}`
+- `POST https://routes.googleapis.com/directions/v2:computeRoutes`
+- `POST https://routes.googleapis.com/distanceMatrix/v2:computeRouteMatrix`
+
+## Billing and Field Masks
+
+- Google Maps Platform requests are billable by Google. Keep requests scoped to what the user asked for.
+- Always send an explicit `X-Goog-FieldMask` for Geocoding v4, Places API (New), and Routes API responses.
+- Do not use wildcard field masks such as `*` unless the user explicitly needs every field.
+- Route Matrix cost and latency scale with route elements: `origins.length * destinations.length`.
 
 ## 1. Forward Geocode an Address
 
@@ -96,8 +114,8 @@ curl -s -X POST "https://routes.googleapis.com/distanceMatrix/v2:computeRouteMat
 
 ## Guidelines
 
-1. Prefer the newer OAuth-compatible APIs above over legacy `maps.googleapis.com/maps/api/...` endpoints.
-2. Always send an explicit `X-Goog-FieldMask` for Geocoding v4, Places API (New), and Routes API responses.
-3. URL-encode address path segments for Geocoding v4.
+1. Prefer the newer OAuth-compatible APIs above. Legacy `maps.googleapis.com/maps/api/...` endpoints are not covered by this connector.
+2. Keep field masks minimal and avoid wildcard `*` masks.
+3. URL-encode address and coordinate path segments when using Geocoding v4 path bindings.
 4. Keep request bodies small and ask only for fields needed by the user.
 5. Check API-level errors in the JSON response; connector and permission errors usually surface as HTTP 4xx or 5xx responses before the Google API response.


### PR DESCRIPTION
## Summary
- document Google Maps OAuth token handling and avoid `key=` usage
- list the OAuth API hosts covered by the connector
- add recommended modern Maps API endpoints and field mask guidance

## Tests
- Not run; documentation-only change.

Refs vm0-ai/vm0#18143