### PR TITLE
feat: add YC P26 connector skills

### DIFF
--- a/archer/SKILL.md
+++ b/archer/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: archer
+description: Archer API for gifting, rewards, and payouts. Use when the user mentions Archer, Archer Money, gift cards, rewards, or payout workflows.
+homepage: https://archermoney.com
+docs: https://docs.archermoney.com
+---
+
+## Prerequisites
+
+Connect the **Archer** connector at https://app.vm0.ai/connectors so `ARCHER_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name ARCHER_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $ARCHER_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<ARCHER_API_URL_FROM_DOCS>" --header "Authorization: Bearer $ARCHER_API_KEY" | jq .
+```

--- a/ardent/SKILL.md
+++ b/ardent/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ardent
+description: Ardent API for Postgres branching. Use when the user mentions Ardent, database branching, Postgres branches, or database preview environments.
+homepage: https://tryardent.com
+docs: https://docs.tryardent.com/
+---
+
+## Prerequisites
+
+Connect the **Ardent** connector at https://app.vm0.ai/connectors so `ARDENT_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name ARDENT_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $ARDENT_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<ARDENT_API_URL_FROM_DOCS>" --header "Authorization: Bearer $ARDENT_API_KEY" | jq .
+```

--- a/arga-labs/SKILL.md
+++ b/arga-labs/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: arga-labs
+description: Arga Labs API for API twins and sandboxes. Use when the user mentions Arga Labs, API twins, API mocks, sandboxes, or generated API environments.
+homepage: https://argalabs.com
+docs: https://argalabs.com/docs
+---
+
+## Prerequisites
+
+Connect the **Arga Labs** connector at https://app.vm0.ai/connectors so `ARGA_LABS_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name ARGA_LABS_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $ARGA_LABS_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<ARGA_LABS_API_URL_FROM_DOCS>" --header "Authorization: Bearer $ARGA_LABS_API_KEY" | jq .
+```

--- a/armature/SKILL.md
+++ b/armature/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: armature
+description: Armature API for agent session analytics and evaluations. Use when the user mentions Armature, agent traces, session analytics, or eval workflows.
+homepage: https://armature.tech
+docs: https://armature.tech/docs
+---
+
+## Prerequisites
+
+Connect the **Armature** connector at https://app.vm0.ai/connectors so `ARMATURE_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name ARMATURE_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $ARMATURE_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<ARMATURE_API_URL_FROM_DOCS>" --header "Authorization: Bearer $ARMATURE_API_KEY" | jq .
+```

--- a/bentolabs-ai/SKILL.md
+++ b/bentolabs-ai/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: bentolabs-ai
+description: BentoLabs AI API for agent observability. Use when the user mentions BentoLabs AI, Bento, agent observability, agent traces, or AI evaluation telemetry.
+homepage: https://bentolabs.ai
+docs: https://docs.bentolabs.ai/llms.txt
+---
+
+## Prerequisites
+
+Connect the **BentoLabs AI** connector at https://app.vm0.ai/connectors so `BENTOLABS_AI_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name BENTOLABS_AI_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $BENTOLABS_AI_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<BENTOLABS_AI_API_URL_FROM_DOCS>" --header "Authorization: Bearer $BENTOLABS_AI_API_KEY" | jq .
+```

--- a/bloom/SKILL.md
+++ b/bloom/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: bloom
+description: Bloom API and MCP for brand generation. Use when the user mentions Bloom, brand generation, design systems, brand assets, or marketing creative workflows.
+homepage: https://www.trybloom.ai
+docs: https://www.trybloom.ai/docs/api
+---
+
+## Prerequisites
+
+Connect the **Bloom** connector at https://app.vm0.ai/connectors so `BLOOM_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name BLOOM_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $BLOOM_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<BLOOM_API_URL_FROM_DOCS>" --header "Authorization: Bearer $BLOOM_API_KEY" | jq .
+```

--- a/chert/SKILL.md
+++ b/chert/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: chert
+description: Chert API for iMessage infrastructure. Use when the user mentions Chert, iMessage automation, Apple Messages workflows, or messaging infrastructure.
+homepage: https://trychert.com
+docs: https://docs.trychert.com/introduction
+---
+
+## Prerequisites
+
+Connect the **Chert** connector at https://app.vm0.ai/connectors so `CHERT_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name CHERT_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $CHERT_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<CHERT_API_URL_FROM_DOCS>" --header "Authorization: Bearer $CHERT_API_KEY" | jq .
+```

--- a/docs/saas.md
+++ b/docs/saas.md
@@ -1,6 +1,7 @@
 # Awesome N8N - SaaS Service List
 
 > Sources:
+>
 > - https://github.com/restyler/awesome-n8n
 > - https://linear.app/integrations
 
@@ -188,26 +189,62 @@
 
 ---
 
-## Statistics
+## YC P26 API Token Connectors
 
-| Category | API Count |
-| --------------------------------- | --------- |
-| Communication & Messaging | 16 |
-| Document & Content Generation | 2 |
-| Browser Automation & Web Scraping | 8 |
-| Data Processing & Utilities | 1 |
-| API & Cloud Integrations | 28 |
-| AI, LLM & Voice | 12 |
-| File & PDF Manipulation | 3 |
-| Analytics & Monitoring | 10 |
-| Development & Engineering | 6 |
-| Customer Support | 3 |
-| Security & Compliance | 4 |
-| Automation | 2 |
-| Design & Media | 4 |
-| Miscellaneous | 11 |
-| **Total** | **110** |
+- [x] [InsForge](https://docs.insforge.dev/) - Backend and cloud infrastructure APIs for agent-native apps
+- [x] [KugelAudio](https://docs.kugelaudio.com/) - Text-to-speech and voice AI API
+- [x] [Runtime](https://docs.runtm.com/introduction) - Agent runtime and sandbox API
+- [x] [TesterArmy](https://docs.tester.army/api-reference/) - AI web and mobile app testing API
+- [x] [Silmaril](https://www.silmaril.dev/docs) - AI application firewall API and SDK
+- [x] [Ardent](https://docs.tryardent.com/) - Postgres branching API
+- [x] [Armature](https://armature.tech/docs) - Agent session analytics and evaluation API
+- [x] [Minicor](https://www.minicor.com/docs) - Computer-use and RPA automation API
+- [x] [Archer](https://docs.archermoney.com) - Gifting, rewards, and payout API
+- [x] [River Markets](https://docs.rivermarkets.com/introduction) - Prediction-market execution and data API
+- [x] [smol machines](https://smolmachines.com/docs/cloud-api) - MicroVM and sandbox infrastructure API
+- [x] [Keyframe Labs](https://docs.keyframelabs.com) - Realtime AI video persona API
+- [x] [Voquill](https://docs.voquill.com/) - Medical lab workflow API
+- [x] [Oddpool](https://docs.oddpool.com/llms.txt) - Prediction-market data API
+- [x] [BentoLabs AI](https://docs.bentolabs.ai/llms.txt) - Agent observability API and SDK
+- [x] [StableBrowse](https://docs.stablebrowse.com/introduction) - Browser automation API
+- [x] [Arga Labs](https://argalabs.com/docs) - API twin and sandbox API
+- [x] [RentAHuman](https://rentahuman.ai/docs) - Human-task API and MCP for agent workflows
+- [x] [Salesgraph](https://docs.salesgraph.com) - Revenue agent API
+- [x] [qomplement](https://docs.qomplement.com/) - AI ERP and supply-chain API
+- [x] [Interfaze](https://interfaze.ai/docs) - Deterministic AI model API
+- [x] [Limrun](https://docs.limrun.com/docs) - Remote mobile build and simulator API
+- [x] [Trellis](https://docs.trellistech.com) - Short-rental operations API
+- [x] [Chert](https://docs.trychert.com/introduction) - iMessage infrastructure API
+- [x] [Replicas](https://docs.tryreplicas.com) - Cloud coding-agent API
+- [x] [Totalis](https://docs.totalis.trade/api-reference/introduction) - Prediction-market derivatives and trading API
+- [x] [primitive](https://www.primitive.dev/openapi.json) - Email infrastructure API
+- [x] [Bloom](https://www.trybloom.ai/docs/api) - Brand generation API and MCP
+- [x] [Inth](https://inth.com/docs/getting-started) - Privacy-compliance infrastructure API
+- [x] [Netter](https://netter.ai/docs) - AI data platform API
 
 ---
 
-> Last updated: 2026-06-17
+## Statistics
+
+| Category                          | API Count |
+| --------------------------------- | --------- |
+| Communication & Messaging         | 16        |
+| Document & Content Generation     | 2         |
+| Browser Automation & Web Scraping | 8         |
+| Data Processing & Utilities       | 1         |
+| API & Cloud Integrations          | 28        |
+| AI, LLM & Voice                   | 12        |
+| File & PDF Manipulation           | 3         |
+| Analytics & Monitoring            | 10        |
+| Development & Engineering         | 6         |
+| Customer Support                  | 3         |
+| Security & Compliance             | 4         |
+| Automation                        | 2         |
+| Design & Media                    | 4         |
+| Miscellaneous                     | 11        |
+| YC P26 API Token Connectors       | 30        |
+| **Total**                         | **140**   |
+
+---
+
+> Last updated: 2026-06-18

--- a/insforge/SKILL.md
+++ b/insforge/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: insforge
+description: InsForge API for backend and cloud infrastructure. Use when the user mentions InsForge, agent-native backends, cloud infrastructure APIs, or InsForge projects.
+homepage: https://www.insforge.dev
+docs: https://docs.insforge.dev/
+---
+
+## Prerequisites
+
+Connect the **InsForge** connector at https://app.vm0.ai/connectors so `INSFORGE_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name INSFORGE_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $INSFORGE_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<INSFORGE_API_URL_FROM_DOCS>" --header "Authorization: Bearer $INSFORGE_API_KEY" | jq .
+```

--- a/interfaze/SKILL.md
+++ b/interfaze/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: interfaze
+description: Interfaze API for deterministic AI models. Use when the user mentions Interfaze, deterministic AI, model APIs, or predictable AI outputs.
+homepage: https://interfaze.ai
+docs: https://interfaze.ai/docs
+---
+
+## Prerequisites
+
+Connect the **Interfaze** connector at https://app.vm0.ai/connectors so `INTERFAZE_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name INTERFAZE_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $INTERFAZE_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<INTERFAZE_API_URL_FROM_DOCS>" --header "Authorization: Bearer $INTERFAZE_API_KEY" | jq .
+```

--- a/inth/SKILL.md
+++ b/inth/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: inth
+description: Inth API for privacy-compliance infrastructure. Use when the user mentions Inth, privacy compliance, data subject requests, consent, or compliance automation.
+homepage: https://inth.com
+docs: https://inth.com/docs/getting-started
+---
+
+## Prerequisites
+
+Connect the **Inth** connector at https://app.vm0.ai/connectors so `INTH_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name INTH_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $INTH_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<INTH_API_URL_FROM_DOCS>" --header "Authorization: Bearer $INTH_API_KEY" | jq .
+```

--- a/keyframe-labs/SKILL.md
+++ b/keyframe-labs/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: keyframe-labs
+description: Keyframe Labs API for realtime AI video personas. Use when the user mentions Keyframe Labs, video personas, realtime video agents, or AI avatar video.
+homepage: https://keyframelabs.com
+docs: https://docs.keyframelabs.com
+---
+
+## Prerequisites
+
+Connect the **Keyframe Labs** connector at https://app.vm0.ai/connectors so `KEYFRAME_LABS_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name KEYFRAME_LABS_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $KEYFRAME_LABS_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<KEYFRAME_LABS_API_URL_FROM_DOCS>" --header "Authorization: Bearer $KEYFRAME_LABS_API_KEY" | jq .
+```

--- a/kugelaudio/SKILL.md
+++ b/kugelaudio/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: kugelaudio
+description: KugelAudio API for text-to-speech and voice AI. Use when the user mentions KugelAudio, TTS, speech generation, or voice AI workflows.
+homepage: https://www.kugelaudio.com
+docs: https://docs.kugelaudio.com/
+---
+
+## Prerequisites
+
+Connect the **KugelAudio** connector at https://app.vm0.ai/connectors so `KUGELAUDIO_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name KUGELAUDIO_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $KUGELAUDIO_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<KUGELAUDIO_API_URL_FROM_DOCS>" --header "Authorization: Bearer $KUGELAUDIO_API_KEY" | jq .
+```

--- a/limrun/SKILL.md
+++ b/limrun/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: limrun
+description: Limrun API for remote mobile builds and simulators. Use when the user mentions Limrun, mobile builds, iOS or Android simulators, or app testing environments.
+homepage: https://limrun.com
+docs: https://docs.limrun.com/docs
+---
+
+## Prerequisites
+
+Connect the **Limrun** connector at https://app.vm0.ai/connectors so `LIMRUN_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name LIMRUN_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $LIMRUN_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<LIMRUN_API_URL_FROM_DOCS>" --header "Authorization: Bearer $LIMRUN_API_KEY" | jq .
+```

--- a/minicor/SKILL.md
+++ b/minicor/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: minicor
+description: Minicor API for computer-use and RPA automation. Use when the user mentions Minicor, browser or desktop automation, RPA, or computer-use agents.
+homepage: https://www.minicor.com
+docs: https://www.minicor.com/docs
+---
+
+## Prerequisites
+
+Connect the **Minicor** connector at https://app.vm0.ai/connectors so `MINICOR_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name MINICOR_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $MINICOR_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<MINICOR_API_URL_FROM_DOCS>" --header "Authorization: Bearer $MINICOR_API_KEY" | jq .
+```

--- a/netter/SKILL.md
+++ b/netter/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: netter
+description: Netter API for AI data platforms. Use when the user mentions Netter, AI data pipelines, data platform APIs, or structured data workflows.
+homepage: https://netter.ai
+docs: https://netter.ai/docs
+---
+
+## Prerequisites
+
+Connect the **Netter** connector at https://app.vm0.ai/connectors so `NETTER_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name NETTER_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $NETTER_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<NETTER_API_URL_FROM_DOCS>" --header "Authorization: Bearer $NETTER_API_KEY" | jq .
+```

--- a/oddpool/SKILL.md
+++ b/oddpool/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: oddpool
+description: Oddpool API for prediction-market data. Use when the user mentions Oddpool, prediction markets, market series, or event market data.
+homepage: https://oddpool.com
+docs: https://docs.oddpool.com/llms.txt
+---
+
+## Prerequisites
+
+Connect the **Oddpool** connector at https://app.vm0.ai/connectors so `ODDPOOL_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name ODDPOOL_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $ODDPOOL_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<ODDPOOL_API_URL_FROM_DOCS>" --header "Authorization: Bearer $ODDPOOL_API_KEY" | jq .
+```

--- a/primitive/SKILL.md
+++ b/primitive/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: primitive
+description: primitive API for email infrastructure. Use when the user mentions primitive, email infrastructure, mail APIs, or programmatic email workflows.
+homepage: https://www.primitive.dev
+docs: https://www.primitive.dev/openapi.json
+---
+
+## Prerequisites
+
+Connect the **primitive** connector at https://app.vm0.ai/connectors so `PRIMITIVE_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name PRIMITIVE_API_KEY`.
+
+## Usage
+
+Use the official OpenAPI spec to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $PRIMITIVE_API_KEY`; if the spec specifies `x-api-key`, use that header instead.
+
+```bash
+curl -s "<PRIMITIVE_API_URL_FROM_OPENAPI>" --header "Authorization: Bearer $PRIMITIVE_API_KEY" | jq .
+```

--- a/qomplement/SKILL.md
+++ b/qomplement/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: qomplement
+description: qomplement API for AI ERP and supply-chain operations. Use when the user mentions qomplement, ERP workflows, supply-chain automation, or operations planning.
+homepage: https://qomplement.com
+docs: https://docs.qomplement.com/
+---
+
+## Prerequisites
+
+Connect the **qomplement** connector at https://app.vm0.ai/connectors so `QOMPLEMENT_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name QOMPLEMENT_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $QOMPLEMENT_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<QOMPLEMENT_API_URL_FROM_DOCS>" --header "Authorization: Bearer $QOMPLEMENT_API_KEY" | jq .
+```

--- a/rentahuman/SKILL.md
+++ b/rentahuman/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: rentahuman
+description: RentAHuman API for hiring humans from agent workflows. Use when the user mentions RentAHuman, human-in-the-loop tasks, human operators, or agent task delegation.
+homepage: https://rentahuman.ai
+docs: https://rentahuman.ai/docs
+---
+
+## Prerequisites
+
+Connect the **RentAHuman** connector at https://app.vm0.ai/connectors so `RENTAHUMAN_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name RENTAHUMAN_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $RENTAHUMAN_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<RENTAHUMAN_API_URL_FROM_DOCS>" --header "Authorization: Bearer $RENTAHUMAN_API_KEY" | jq .
+```

--- a/replicas/SKILL.md
+++ b/replicas/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: replicas
+description: Replicas API for cloud coding agents. Use when the user mentions Replicas, coding agents, cloud coding sessions, or agent development environments.
+homepage: https://tryreplicas.com
+docs: https://docs.tryreplicas.com
+---
+
+## Prerequisites
+
+Connect the **Replicas** connector at https://app.vm0.ai/connectors so `REPLICAS_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name REPLICAS_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $REPLICAS_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<REPLICAS_API_URL_FROM_DOCS>" --header "Authorization: Bearer $REPLICAS_API_KEY" | jq .
+```

--- a/river-markets/SKILL.md
+++ b/river-markets/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: river-markets
+description: River Markets API for prediction-market execution and data. Use when the user mentions River Markets, prediction markets, trading execution, or market data.
+homepage: https://rivermarkets.com
+docs: https://docs.rivermarkets.com/introduction
+---
+
+## Prerequisites
+
+Connect the **River Markets** connector at https://app.vm0.ai/connectors so `RIVER_MARKETS_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name RIVER_MARKETS_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $RIVER_MARKETS_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<RIVER_MARKETS_API_URL_FROM_DOCS>" --header "Authorization: Bearer $RIVER_MARKETS_API_KEY" | jq .
+```

--- a/runtime/SKILL.md
+++ b/runtime/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: runtime
+description: Runtime API for agent runtimes and sandboxes. Use when the user mentions Runtime, runtm, agent runtime infrastructure, or sandboxed agent execution.
+homepage: https://runtm.com
+docs: https://docs.runtm.com/introduction
+---
+
+## Prerequisites
+
+Connect the **Runtime** connector at https://app.vm0.ai/connectors so `RUNTIME_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name RUNTIME_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $RUNTIME_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<RUNTIME_API_URL_FROM_DOCS>" --header "Authorization: Bearer $RUNTIME_API_KEY" | jq .
+```

--- a/salesgraph/SKILL.md
+++ b/salesgraph/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: salesgraph
+description: Salesgraph API for revenue agents. Use when the user mentions Salesgraph, revenue workflows, sales automation, account research, or prospecting agents.
+homepage: https://salesgraph.com
+docs: https://docs.salesgraph.com
+---
+
+## Prerequisites
+
+Connect the **Salesgraph** connector at https://app.vm0.ai/connectors so `SALESGRAPH_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name SALESGRAPH_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $SALESGRAPH_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<SALESGRAPH_API_URL_FROM_DOCS>" --header "Authorization: Bearer $SALESGRAPH_API_KEY" | jq .
+```

--- a/silmaril/SKILL.md
+++ b/silmaril/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: silmaril
+description: Silmaril API and SDK for AI application firewalls. Use when the user mentions Silmaril, AI security, prompt injection defense, or AI firewall workflows.
+homepage: https://www.silmaril.dev
+docs: https://www.silmaril.dev/docs
+---
+
+## Prerequisites
+
+Connect the **Silmaril** connector at https://app.vm0.ai/connectors so `SILMARIL_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name SILMARIL_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $SILMARIL_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<SILMARIL_API_URL_FROM_DOCS>" --header "Authorization: Bearer $SILMARIL_API_KEY" | jq .
+```

--- a/smol-machines/SKILL.md
+++ b/smol-machines/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: smol-machines
+description: smol machines API for microVMs and sandboxes. Use when the user mentions smol machines, microVMs, cloud sandboxes, or isolated compute.
+homepage: https://smolmachines.com
+docs: https://smolmachines.com/docs/cloud-api
+---
+
+## Prerequisites
+
+Connect the **smol machines** connector at https://app.vm0.ai/connectors so `SMOL_MACHINES_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name SMOL_MACHINES_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $SMOL_MACHINES_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<SMOL_MACHINES_API_URL_FROM_DOCS>" --header "Authorization: Bearer $SMOL_MACHINES_API_KEY" | jq .
+```

--- a/stablebrowse/SKILL.md
+++ b/stablebrowse/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: stablebrowse
+description: StableBrowse API for browser automation. Use when the user mentions StableBrowse, browser automation, web agents, or hosted browsing workflows.
+homepage: https://stablebrowse.com
+docs: https://docs.stablebrowse.com/introduction
+---
+
+## Prerequisites
+
+Connect the **StableBrowse** connector at https://app.vm0.ai/connectors so `STABLEBROWSE_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name STABLEBROWSE_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $STABLEBROWSE_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<STABLEBROWSE_API_URL_FROM_DOCS>" --header "Authorization: Bearer $STABLEBROWSE_API_KEY" | jq .
+```

--- a/testerarmy/SKILL.md
+++ b/testerarmy/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: testerarmy
+description: TesterArmy API for AI web and mobile app testing. Use when the user mentions TesterArmy, QA automation, test runs, or app testing agents.
+homepage: https://tester.army
+docs: https://docs.tester.army/api-reference/
+---
+
+## Prerequisites
+
+Connect the **TesterArmy** connector at https://app.vm0.ai/connectors so `TESTERARMY_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name TESTERARMY_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $TESTERARMY_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<TESTERARMY_API_URL_FROM_DOCS>" --header "Authorization: Bearer $TESTERARMY_API_KEY" | jq .
+```

--- a/totalis/SKILL.md
+++ b/totalis/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: totalis
+description: Totalis API for prediction-market derivatives and trading. Use when the user mentions Totalis, prediction-market derivatives, trading APIs, or market positions.
+homepage: https://totalis.trade
+docs: https://docs.totalis.trade/api-reference/introduction
+---
+
+## Prerequisites
+
+Connect the **Totalis** connector at https://app.vm0.ai/connectors so `TOTALIS_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name TOTALIS_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $TOTALIS_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<TOTALIS_API_URL_FROM_DOCS>" --header "Authorization: Bearer $TOTALIS_API_KEY" | jq .
+```

--- a/trellis/SKILL.md
+++ b/trellis/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: trellis
+description: Trellis API for short-rental operations. Use when the user mentions Trellis, short-term rentals, property operations, or rental workflow automation.
+homepage: https://trellistech.com
+docs: https://docs.trellistech.com
+---
+
+## Prerequisites
+
+Connect the **Trellis** connector at https://app.vm0.ai/connectors so `TRELLIS_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name TRELLIS_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $TRELLIS_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<TRELLIS_API_URL_FROM_DOCS>" --header "Authorization: Bearer $TRELLIS_API_KEY" | jq .
+```

--- a/voquill/SKILL.md
+++ b/voquill/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: voquill
+description: Voquill API for medical lab workflows. Use when the user mentions Voquill, lab operations, medical testing workflows, or healthcare lab automation.
+homepage: https://voquill.com
+docs: https://docs.voquill.com/
+---
+
+## Prerequisites
+
+Connect the **Voquill** connector at https://app.vm0.ai/connectors so `VOQUILL_API_KEY` is available.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name VOQUILL_API_KEY`.
+
+## Usage
+
+Use the official docs to choose the endpoint and request body. Authenticated API calls typically use `Authorization: Bearer $VOQUILL_API_KEY`; if the docs specify `x-api-key`, use that header instead.
+
+```bash
+curl -s "<VOQUILL_API_URL_FROM_DOCS>" --header "Authorization: Bearer $VOQUILL_API_KEY" | jq .
+```


### PR DESCRIPTION
## Summary
- Add skill files for the 30 YC P26 API-token connector candidates, excluding AgentPhone because it is already connected.
- Include connector env var prerequisites, official docs links, troubleshooting commands, and generic authenticated API usage guidance.
- Update `docs/saas.md` with the YC P26 connector section and totals.

## Verification
- `pnpm dlx prettier@3.6.2 --write docs/saas.md ...`
- Verified all 30 expected `SKILL.md` files exist.
- Verified each new skill includes connector metadata and `zero doctor check-connector` guidance.