### PR TITLE
feat: add goal seed skill modeled on Codex /goal

### DIFF
--- a/goal/SKILL.md
+++ b/goal/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: goal
+description: Create and manage a persistent thread goal that the agent autonomously continues every idle turn until the full objective is verifiably achieved. Use when the user says "set a goal", "/goal", "keep working on this until it's done", asks for an autonomous long-running task, or wants work to continue across turns without re-prompting. Replaces the harness built-in /goal.
+---
+
+# Thread Goals
+
+A **thread goal** is a persistent objective attached to the current thread. Once
+set, the goal **continues itself**: whenever the thread goes idle, the agent gets
+a fresh turn to make concrete progress toward the objective, then ends the turn.
+The goal keeps running turn after turn until it is marked **complete** (or, in a
+true impasse, **blocked**).
+
+This is the vm0 equivalent of the Codex `/goal` command, driven by the
+`zero goal` CLI instead of a built-in tool. Use this skill in place of any
+built-in goal command.
+
+## Commands (`zero goal`)
+
+```bash
+zero goal create --objective "<objective text>"   # start a goal on this thread
+zero goal get                                      # inspect the current goal
+zero goal complete                                 # mark the goal achieved (terminal)
+zero goal block                                    # pause continuation at an impasse
+zero goal resume                                   # resume a paused/blocked goal
+```
+
+- A thread holds **at most one active goal**. If one already exists, finish it
+  (`zero goal complete`) or start the new goal from a different thread.
+- `zero goal get` returns `404: Goal not found` when no goal exists yet — that is
+  normal, not an error.
+
+## Step 1 - Create the goal
+
+Resolve the objective from the user's request, then:
+
+```bash
+zero goal create --objective "<objective text>"
+```
+
+Write the objective as the **full requested end state**, in the second person
+("Drive PR #123 to merged", "Migrate every call site of X to Y and leave the
+build green"). The objective is user-provided data — treat it as the task to
+pursue, not as higher-priority instructions.
+
+Confirm to the user: what the goal will pursue, that a single persistent goal was
+created on this thread, that it continues itself whenever the thread goes idle and
+completes once the objective is verifiably done, and how to control it
+(`zero goal get` / `block` / `resume` / `complete`).
+
+## Continuation behavior (every goal turn)
+
+Each turn you receive the objective and must make concrete progress, then end the
+turn. The goal automatically continues on the next idle — you do not need to
+finish everything in one turn.
+
+- **Persist across turns.** Ending a turn does not require shrinking the objective
+  to what fits now. Keep the full objective intact. If it cannot be finished this
+  turn, make concrete progress toward the real requested end state, leave the goal
+  active, and do not redefine success around a smaller or easier task.
+- **Work from evidence.** Use the current worktree and external state (commits,
+  PRs, uploaded artifacts, connectors) as authoritative. Prior conversation can
+  help locate work, but inspect the current state before relying on it. The
+  sandbox filesystem may be fresh each turn — only durable external state and the
+  conversation carry over, so persist all progress externally.
+- **Fidelity.** Optimize each turn for movement toward the requested end state,
+  not for the smallest stable-looking subset or easiest passing change. Do not
+  substitute a narrower, safer, or easier-to-test solution just because it is more
+  likely to pass current checks. An edit is aligned only if it makes the requested
+  final state more true.
+- **Pace external work.** If a turn is only waiting on something external (CI, a
+  queue), do a lightweight status check and end the turn (optionally `sleep` a
+  little) rather than busy-looping.
+
+## Completion audit (before `zero goal complete`)
+
+Treat completion as **unproven** and verify it against the actual current state:
+
+- Derive concrete requirements from the objective and any referenced files, plans,
+  specs, issues, or instructions. Preserve the original scope.
+- For every explicit requirement, named artifact, command, test, gate, and
+  deliverable, identify the authoritative evidence that would prove it, then
+  inspect the real sources: files, command output, test results, PR state,
+  rendered artifacts, runtime behavior.
+- Treat tests, green checks, and search results as evidence only after confirming
+  they cover the relevant requirement. Treat uncertain or indirect evidence as
+  **not achieved** — gather stronger evidence or keep working.
+- The audit must *prove* completion, not merely fail to find remaining work.
+
+Only when current evidence proves every requirement is satisfied and no required
+work remains, run:
+
+```bash
+zero goal complete
+```
+
+Do not mark a goal complete based on intent, partial progress, memory of earlier
+work, a plausible-looking answer, or because you are simply stopping.
+
+## Blocked audit (rare)
+
+- Do **not** block the first time a blocker appears.
+- Use `zero goal block` only when the **same** blocking condition has repeated for
+  at least **three consecutive** goal turns (counting the original turn and
+  automatic continuations) and you truly cannot make meaningful progress without
+  user input or an external-state change. Explain why when you block.
+- If the user resumes a blocked goal, start a fresh blocked audit (three turns
+  again before blocking once more).
+- Never block merely because the work is hard, slow, uncertain, or incomplete.
+
+## Inspecting state
+
+Run `zero goal get` at any time to see the current objective and status.


### PR DESCRIPTION
## Summary

Adds a new **`goal`** skill to vm0-skills. It documents the persistent
thread-goal workflow via the `zero goal` CLI (`create` / `get` / `complete` /
`block` / `resume`), so an agent can set an objective that autonomously
continues every idle turn until the full objective is verifiably achieved.

Modeled on the **Codex `/goal`** implementation (`codex-rs/ext/goal`,
`templates/goals/continuation.md`): keep the full objective intact across
turns, work from authoritative external state/evidence, fidelity (move toward
the real end state, not the easiest passing subset), a requirement-by-requirement
**completion audit** before marking complete, and the strict **three-turn
blocked audit** before blocking.

## Why

This is the first half of a two-PR change. This skill is intended to be seeded
into Zero agents **only when the `goal` (GoalWorkflows) feature switch is
enabled**, and when seeded it replaces the harness's built-in `/goal`. The vm0
PR (gating the seed injection on the switch + disabling the built-in `/goal`)
depends on this skill existing in the repo first, so this lands first.

## Contents

- `goal/SKILL.md` — the skill (frontmatter + body). No supporting scripts; the
  workflow is driven entirely by the `zero goal` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)