### PR TITLE
docs: guard against inferring goals from one-off tasks

### DIFF
--- a/goal/SKILL.md
+++ b/goal/SKILL.md
@@ -30,6 +30,16 @@ zero goal resume                                   # resume a paused/blocked goa
 - `zero goal get` returns `404: Goal not found` when no goal exists yet — that is
   normal, not an error.
 
+## When to create a goal
+
+Create a goal **only when the user explicitly asks** for a persistent,
+autonomous, cross-turn task ("keep working on this until it's done", "set a
+goal", "drive this to completion"). **Do not infer a goal from an ordinary
+one-off request.** A normal task you can finish in the current turn is not a
+goal — just do it. Turning a routine request into a self-continuing goal makes
+the agent run unprompted turn after turn, which is rarely what the user wants.
+When in doubt, do the work directly and ask before creating a goal.
+
 ## Step 1 - Create the goal
 
 Resolve the objective from the user's request, then:


### PR DESCRIPTION
## What

Adds a **"When to create a goal"** section to `goal/SKILL.md` instructing the agent to create a goal only on an explicit user request for persistent, autonomous, cross-turn work — and never to infer one from an ordinary one-off task.

## Why

Mirrors Codex's `create_goal` textual guard. Today vm0's only guard against spurious goal creation is architectural (goals exist only via explicit API); there is no prompt-level guard telling the agent *when* it should decide to create one. This closes that gap.

## Related

Companion to vm0-ai/vm0 PR for the goal edit / lifecycle / `zero goal create` help guard. This skills change should land first so cron-sync materializes the updated skill body before the vm0 change deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)