### PR TITLE
docs: add connector intent hints for shared-base skills

### DIFF
--- a/instagram/SKILL.md
+++ b/instagram/SKILL.md
@@ -18,12 +18,16 @@ INSTAGRAM_TOKEN
 INSTAGRAM_BUSINESS_ACCOUNT_ID
 ```
 
+Because Graph API is shared by multiple Zero connectors, include `X-VM0-Connector-Intent: instagram` on Graph API calls. This is a VM0 proxy routing hint only; it is not authentication or permission.
+
 ### 1. Fetch recent media for the account
 
 Fetch the most recent media (photos / videos / Reels) for the account:
 
 ```bash
-curl -s -X GET "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/media?fields=id,caption,media_type,media_url,permalink,timestamp" --header "Authorization: Bearer $INSTAGRAM_TOKEN"
+curl -s -X GET "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/media?fields=id,caption,media_type,media_url,permalink,timestamp" \
+  --header "Authorization: Bearer $INSTAGRAM_TOKEN" \
+  --header "X-VM0-Connector-Intent: instagram"
 ```
 
 **Notes:**
@@ -42,7 +46,9 @@ curl -s -X GET "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/
 If you already have a media `id`, you can fetch more complete information. Replace `<your-media-id>` with the `id` field from the "Get User Media" response (section 1 above):
 
 ```bash
-curl -s -X GET "https://graph.facebook.com/v21.0/<your-media-id>?fields=id,caption,media_type,media_url,permalink,thumbnail_url,timestamp,username" --header "Authorization: Bearer $INSTAGRAM_TOKEN"
+curl -s -X GET "https://graph.facebook.com/v21.0/<your-media-id>?fields=id,caption,media_type,media_url,permalink,thumbnail_url,timestamp,username" \
+  --header "Authorization: Bearer $INSTAGRAM_TOKEN" \
+  --header "X-VM0-Connector-Intent: instagram"
 ```
 
 ### 3. Search media by hashtag
@@ -56,7 +62,9 @@ This usually involves two steps:
 Replace `<hashtag-name>` with any hashtag name you want to search for (without the # symbol), e.g., "travel", "food", "photography":
 
 ```bash
-curl -s -X GET "https://graph.facebook.com/v21.0/ig_hashtag_search?user_id=$INSTAGRAM_BUSINESS_ACCOUNT_ID&q=<hashtag-name>" --header "Authorization: Bearer $INSTAGRAM_TOKEN"
+curl -s -X GET "https://graph.facebook.com/v21.0/ig_hashtag_search?user_id=$INSTAGRAM_BUSINESS_ACCOUNT_ID&q=<hashtag-name>" \
+  --header "Authorization: Bearer $INSTAGRAM_TOKEN" \
+  --header "X-VM0-Connector-Intent: instagram"
 ```
 
 Note the `id` field in the returned JSON for use in the next step.
@@ -66,7 +74,9 @@ Note the `id` field in the returned JSON for use in the next step.
 Replace `<hashtag-id>` with the `id` field from the "Search Hashtag" response (section 3.1 above):
 
 ```bash
-curl -s -X GET "https://graph.facebook.com/v21.0/<hashtag-id>/recent_media?user_id=$INSTAGRAM_BUSINESS_ACCOUNT_ID&fields=id,caption,media_type,media_url,permalink,timestamp" --header "Authorization: Bearer $INSTAGRAM_TOKEN"
+curl -s -X GET "https://graph.facebook.com/v21.0/<hashtag-id>/recent_media?user_id=$INSTAGRAM_BUSINESS_ACCOUNT_ID&fields=id,caption,media_type,media_url,permalink,timestamp" \
+  --header "Authorization: Bearer $INSTAGRAM_TOKEN" \
+  --header "X-VM0-Connector-Intent: instagram"
 ```
 
 ### 4. Publish an image post
@@ -90,7 +100,9 @@ Write the request data to `/tmp/request.json`:
 Replace `https://example.com/image.jpg` with any publicly accessible image URL and update the caption text as needed.
 
 ```bash
-curl -s -X POST "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/media" -H "Content-Type: application/json" -d @/tmp/request.json --header "Authorization: Bearer $INSTAGRAM_TOKEN"
+curl -s -X POST "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/media" -H "Content-Type: application/json" -d @/tmp/request.json \
+  --header "Authorization: Bearer $INSTAGRAM_TOKEN" \
+  --header "X-VM0-Connector-Intent: instagram"
 ```
 
 The response will contain an `id` (media container ID), for example:
@@ -116,7 +128,9 @@ Write the request data to `/tmp/request.json`:
 Replace `<your-creation-id>` with the `id` field from the "Create Media Container" response (section 4.1 above):
 
 ```bash
-curl -s -X POST "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/media_publish" -H "Content-Type: application/json" -d @/tmp/request.json --header "Authorization: Bearer $INSTAGRAM_TOKEN"
+curl -s -X POST "https://graph.facebook.com/v21.0/$INSTAGRAM_BUSINESS_ACCOUNT_ID/media_publish" -H "Content-Type: application/json" -d @/tmp/request.json \
+  --header "Authorization: Bearer $INSTAGRAM_TOKEN" \
+  --header "X-VM0-Connector-Intent: instagram"
 ```
 
 If successful, the response will contain the final media `id`:

--- a/meta-ads/SKILL.md
+++ b/meta-ads/SKILL.md
@@ -18,6 +18,8 @@ Normal connector requests require this header:
 Authorization: Bearer $META_ADS_TOKEN
 ```
 
+Because Graph API is shared by multiple Zero connectors, include `X-VM0-Connector-Intent: meta-ads` on Graph API calls. This is a VM0 proxy routing hint only; it is not authentication or permission.
+
 Do not pass `META_ADS_TOKEN` as an `access_token` query parameter or in the request body. Zero connector tokens are placeholders that are resolved at the network boundary when sent as the `Authorization` header to `https://graph.facebook.com`. Putting the placeholder in `access_token=` can send it literally and cause Meta to return a malformed access token error.
 
 Exception: Page access tokens returned by Graph API are real secondary tokens, not Zero placeholders. For Page-token-only endpoints such as `/{page-id}/ads_posts`, get the Page access token with the connector token first, then use `Authorization: Bearer $page_token` for that Page-token request.
@@ -35,7 +37,8 @@ If `/{page-id}/ads_posts` returns `(#200) Not enough permission to call this end
 ```bash
 curl -sS --get "https://graph.facebook.com/v22.0/me/accounts" \
   --data-urlencode "fields=id,name,tasks" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, tasks}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {id, name, tasks}'
 ```
 
 ### Test Page Ads Posts (`pages_manage_ads`)
@@ -47,12 +50,14 @@ PAGE_ID="{page-id}"
 
 page_token=$(curl -sS --get "https://graph.facebook.com/v22.0/$PAGE_ID" \
   --data-urlencode "fields=id,name,access_token" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq -r '.access_token')
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq -r '.access_token')
 
 curl -sS --get "https://graph.facebook.com/v22.0/$PAGE_ID/ads_posts" \
   --data-urlencode "fields=id,created_time" \
   --data-urlencode "limit=1" \
-  --header "Authorization: Bearer $page_token" | jq .
+  --header "Authorization: Bearer $page_token" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq .
 ```
 
 An empty response such as `{"data":[]}` is a successful call when the Page has no ad posts.
@@ -63,14 +68,16 @@ An empty response such as `{"data":[]}` is a successful call when the Page has n
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/me/adaccounts?fields=id,name,account_status,currency,timezone_name,amount_spent" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, account_status, currency}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {id, name, account_status, currency}'
 ```
 
 ### Get Ad Account Details
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}?fields=id,name,account_status,currency,timezone_name,balance,amount_spent,spend_cap" \
-  --header "Authorization: Bearer $META_ADS_TOKEN"
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads"
 ```
 
 ## Campaigns
@@ -79,14 +86,16 @@ curl -s "https://graph.facebook.com/v22.0/{ad-account-id}?fields=id,name,account
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/campaigns?fields=id,name,status,objective,daily_budget,lifetime_budget,start_time,stop_time" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, status, objective}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {id, name, status, objective}'
 ```
 
 ### Get Campaign Details
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{campaign-id}?fields=id,name,status,objective,daily_budget,lifetime_budget,start_time,stop_time,created_time,updated_time" \
-  --header "Authorization: Bearer $META_ADS_TOKEN"
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads"
 ```
 
 ### Create Campaign
@@ -105,6 +114,7 @@ cat > /tmp/campaign.json << 'EOF'
 EOF
 curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/campaigns" \
   --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" \
   --header "Content-Type: application/json" \
   -d @/tmp/campaign.json
 ```
@@ -120,6 +130,7 @@ cat > /tmp/campaign-update.json << 'EOF'
 EOF
 curl -s -X POST "https://graph.facebook.com/v22.0/{campaign-id}" \
   --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" \
   --header "Content-Type: application/json" \
   -d @/tmp/campaign-update.json
 ```
@@ -128,7 +139,8 @@ curl -s -X POST "https://graph.facebook.com/v22.0/{campaign-id}" \
 
 ```bash
 curl -s -X DELETE "https://graph.facebook.com/v22.0/{campaign-id}" \
-  --header "Authorization: Bearer $META_ADS_TOKEN"
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads"
 ```
 
 ## Ad Sets
@@ -137,14 +149,16 @@ curl -s -X DELETE "https://graph.facebook.com/v22.0/{campaign-id}" \
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/adsets?fields=id,name,status,campaign_id,daily_budget,lifetime_budget,start_time,end_time,targeting" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, status, campaign_id, daily_budget}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {id, name, status, campaign_id, daily_budget}'
 ```
 
 ### Get Ad Set Details
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{adset-id}?fields=id,name,status,campaign_id,daily_budget,lifetime_budget,bid_amount,billing_event,optimization_goal,start_time,end_time,targeting" \
-  --header "Authorization: Bearer $META_ADS_TOKEN"
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads"
 ```
 
 ### Create Ad Set
@@ -171,6 +185,7 @@ cat > /tmp/adset.json << 'EOF'
 EOF
 curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/adsets" \
   --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" \
   --header "Content-Type: application/json" \
   -d @/tmp/adset.json
 ```
@@ -181,14 +196,16 @@ curl -s -X POST "https://graph.facebook.com/v22.0/{ad-account-id}/adsets" \
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/ads?fields=id,name,status,adset_id,campaign_id,created_time" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, status, adset_id}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {id, name, status, adset_id}'
 ```
 
 ### Get Ad Details
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-id}?fields=id,name,status,adset_id,campaign_id,creative,created_time,updated_time" \
-  --header "Authorization: Bearer $META_ADS_TOKEN"
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads"
 ```
 
 ## Insights (Performance Analytics)
@@ -199,35 +216,40 @@ Get overall account performance for the last 7 days:
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr,cpc,cpm,reach,frequency&date_preset=last_7d" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[0]'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[0]'
 ```
 
 ### Campaign-Level Insights
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=campaign_name,campaign_id,impressions,clicks,spend,ctr,cpc,actions&level=campaign&date_preset=last_30d" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {campaign_name, impressions, clicks, spend, ctr}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {campaign_name, impressions, clicks, spend, ctr}'
 ```
 
 ### Insights with Date Range
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr,cpc,reach,actions&time_range={\"since\":\"2026-01-01\",\"until\":\"2026-01-31\"}" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[0]'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[0]'
 ```
 
 ### Insights with Daily Breakdown
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend,ctr&date_preset=last_7d&time_increment=1" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {date_start, impressions, clicks, spend}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {date_start, impressions, clicks, spend}'
 ```
 
 ### Insights by Age and Gender
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impressions,clicks,spend&date_preset=last_30d&breakdowns=age,gender" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {age, gender, impressions, clicks, spend}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {age, gender, impressions, clicks, spend}'
 ```
 
 ## Custom Audiences
@@ -236,7 +258,8 @@ curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/insights?fields=impres
 
 ```bash
 curl -s "https://graph.facebook.com/v22.0/{ad-account-id}/customaudiences?fields=id,name,approximate_count_lower_bound,approximate_count_upper_bound" \
-  --header "Authorization: Bearer $META_ADS_TOKEN" | jq '.data[] | {id, name, approximate_count_lower_bound}'
+  --header "Authorization: Bearer $META_ADS_TOKEN" \
+  --header "X-VM0-Connector-Intent: meta-ads" | jq '.data[] | {id, name, approximate_count_lower_bound}'
 ```
 
 ## Guidelines

--- a/microsoft-365/SKILL.md
+++ b/microsoft-365/SKILL.md
@@ -15,13 +15,16 @@ Base URL: `https://graph.microsoft.com`
 
 All calls use `Authorization: Bearer $MICROSOFT_365_TOKEN`. `MICROSOFT_GRAPH_TOKEN` is also bound to the same OAuth access token for compatibility.
 
+Because Microsoft Graph is shared by multiple Zero connectors, include `X-VM0-Connector-Intent: microsoft-365` on Graph API calls. This is a VM0 proxy routing hint only; it is not authentication or permission.
+
 ## User
 
 ### Get Current User
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/me" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '{id, displayName, userPrincipalName, mail}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '{id, displayName, userPrincipalName, mail}'
 ```
 
 ## OneDrive
@@ -30,14 +33,16 @@ curl -s "https://graph.microsoft.com/v1.0/me" \
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/me/drive/root/children" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, name, folder, file, size, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, name, folder, file, size, webUrl}'
 ```
 
 ### Get Item Metadata
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/me/drive/items/<item-id>" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '{id, name, size, file, folder, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '{id, name, size, file, folder, webUrl}'
 ```
 
 ### Download File
@@ -45,6 +50,7 @@ curl -s "https://graph.microsoft.com/v1.0/me/drive/items/<item-id>" \
 ```bash
 curl -L "https://graph.microsoft.com/v1.0/me/drive/items/<item-id>/content" \
   --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" \
   -o /tmp/onedrive-download.bin
 ```
 
@@ -55,6 +61,7 @@ This works for files up to 250 MB.
 ```bash
 curl -s -X PUT "https://graph.microsoft.com/v1.0/me/drive/root:/Uploads/report.txt:/content" \
   --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" \
   --header "Content-Type: text/plain" \
   --data-binary @/tmp/report.txt | jq '{id, name, size, webUrl}'
 ```
@@ -64,6 +71,7 @@ curl -s -X PUT "https://graph.microsoft.com/v1.0/me/drive/root:/Uploads/report.t
 ```bash
 curl -s -X POST "https://graph.microsoft.com/v1.0/me/drive/root/children" \
   --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" \
   --header "Content-Type: application/json" \
   -d '{"name":"Project Files","folder":{},"@microsoft.graph.conflictBehavior":"rename"}' | jq '{id, name, webUrl}'
 ```
@@ -72,7 +80,8 @@ curl -s -X POST "https://graph.microsoft.com/v1.0/me/drive/root/children" \
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/me/drive/root/search(q='report')" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, name, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, name, webUrl}'
 ```
 
 ## SharePoint
@@ -81,35 +90,40 @@ curl -s "https://graph.microsoft.com/v1.0/me/drive/root/search(q='report')" \
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/sites?search=*" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, name, displayName, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, name, displayName, webUrl}'
 ```
 
 ### Get Site by Hostname and Path
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/sites/<tenant>.sharepoint.com:/sites/<site-name>" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '{id, name, displayName, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '{id, name, displayName, webUrl}'
 ```
 
 ### List Site Drives
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/sites/<site-id>/drives" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, name, driveType, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, name, driveType, webUrl}'
 ```
 
 ### List SharePoint Drive Items
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/drives/<drive-id>/root/children" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, name, folder, file, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, name, folder, file, webUrl}'
 ```
 
 ### List Site Lists
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/sites/<site-id>/lists" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, name, displayName, webUrl}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, name, displayName, webUrl}'
 ```
 
 ## Teams
@@ -118,21 +132,24 @@ curl -s "https://graph.microsoft.com/v1.0/sites/<site-id>/lists" \
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/me/joinedTeams" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, displayName, description}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, displayName, description}'
 ```
 
 ### List Team Channels
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/teams/<team-id>/channels" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, displayName, description, membershipType}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, displayName, description, membershipType}'
 ```
 
 ### List Channel Messages
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/teams/<team-id>/channels/<channel-id>/messages" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, from, createdDateTime, body}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, from, createdDateTime, body}'
 ```
 
 ### Send Channel Message
@@ -150,6 +167,7 @@ Write to `/tmp/teams_message.json`:
 ```bash
 curl -s -X POST "https://graph.microsoft.com/v1.0/teams/<team-id>/channels/<channel-id>/messages" \
   --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" \
   --header "Content-Type: application/json" \
   -d @/tmp/teams_message.json | jq '{id, createdDateTime, webUrl}'
 ```
@@ -158,7 +176,8 @@ curl -s -X POST "https://graph.microsoft.com/v1.0/teams/<team-id>/channels/<chan
 
 ```bash
 curl -s "https://graph.microsoft.com/v1.0/chats" \
-  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" | jq '.value[] | {id, topic, chatType}'
+  --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" | jq '.value[] | {id, topic, chatType}'
 ```
 
 ### Send Chat Message
@@ -166,6 +185,7 @@ curl -s "https://graph.microsoft.com/v1.0/chats" \
 ```bash
 curl -s -X POST "https://graph.microsoft.com/v1.0/chats/<chat-id>/messages" \
   --header "Authorization: Bearer $MICROSOFT_365_TOKEN" \
+  --header "X-VM0-Connector-Intent: microsoft-365" \
   --header "Content-Type: application/json" \
   -d '{"body":{"content":"Hello from Zero"}}' | jq '{id, createdDateTime}'
 ```

--- a/railway-project/SKILL.md
+++ b/railway-project/SKILL.md
@@ -15,6 +15,8 @@ Railway exposes a single GraphQL endpoint. A **project token** is scoped to one 
 Project-Access-Token: $RAILWAY_PROJECT_TOKEN
 ```
 
+Because Railway account/workspace and project tokens share one GraphQL endpoint, include `X-VM0-Connector-Intent: railway-project` on Railway GraphQL calls. This is a VM0 proxy routing hint only; it is not authentication or permission.
+
 > Do NOT also send `Authorization: Bearer` — Railway will accept the project token but you should treat the two auth surfaces as mutually exclusive. If you need cross-project or account-level operations, switch to the broader **railway** skill.
 
 ## Environment Variables
@@ -57,7 +59,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "X-VM0-Connector-Intent: railway-project" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ## Discover the Schema
@@ -74,7 +76,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "X-VM0-Connector-Intent: railway-project" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 Re-run with `"Query"`, `"Project"`, `"Service"`, `"Deployment"`, etc.
@@ -101,7 +103,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "X-VM0-Connector-Intent: railway-project" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ### Redeploy a Deployment
@@ -118,7 +120,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "X-VM0-Connector-Intent: railway-project" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ### Trigger a New Deployment from Latest
@@ -138,7 +140,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "X-VM0-Connector-Intent: railway-project" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ## Variables
@@ -159,7 +161,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "X-VM0-Connector-Intent: railway-project" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ### Upsert a Variable
@@ -182,7 +184,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Project-Access-Token: $RAILWAY_PROJECT_TOKEN" --header "X-VM0-Connector-Intent: railway-project" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ## Guidelines

--- a/railway/SKILL.md
+++ b/railway/SKILL.md
@@ -15,6 +15,8 @@ Railway exposes a single GraphQL endpoint. Requests authenticate with an **accou
 Authorization: Bearer $RAILWAY_TOKEN
 ```
 
+Because Railway account/workspace and project tokens share one GraphQL endpoint, include `X-VM0-Connector-Intent: railway` on Railway GraphQL calls. This is a VM0 proxy routing hint only; it is not authentication or permission.
+
 Account tokens span every workspace the user belongs to. Workspace tokens are scoped to a single workspace but expose the same query/mutation surface. For environment-scoped automation use the separate **railway-project** skill instead — it sends `Project-Access-Token` and has different scope rules.
 
 ## Environment Variables
@@ -47,7 +49,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ## Discover the Schema
@@ -64,7 +66,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 Re-run with `"name": "Mutation"`, `"name": "Project"`, `"name": "Service"`, etc. to drill into specific types.
@@ -82,7 +84,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ### Get a Project (with services and environments)
@@ -99,7 +101,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ## Deployments
@@ -124,7 +126,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ### Redeploy a Deployment
@@ -141,7 +143,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ### Trigger a New Deployment from Latest
@@ -161,7 +163,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ## Variables
@@ -182,7 +184,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ### Upsert a Variable
@@ -205,7 +207,7 @@ Write to `/tmp/railway_request.json`:
 ```
 
 ```bash
-curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "Content-Type: application/json" -d @/tmp/railway_request.json
+curl -s -X POST "https://backboard.railway.com/graphql/v2" --header "Authorization: Bearer $RAILWAY_TOKEN" --header "X-VM0-Connector-Intent: railway" --header "Content-Type: application/json" -d @/tmp/railway_request.json
 ```
 
 ## Guidelines


### PR DESCRIPTION
## Summary

- Add `X-VM0-Connector-Intent` guidance to shared-base connector skills.
- Update Microsoft Graph, Meta Graph, and Railway GraphQL curl examples to include the connector intent hint.
- Keep the wording explicit that this is a VM0 proxy routing hint, not authentication or permission.

Related: vm0-ai/vm0#19906

## Validation

- `git diff --check`
- Scanned affected bash examples to confirm shared-base requests include `X-VM0-Connector-Intent`.