### PR TITLE
docs: broaden workflow setup skill triggers

### DIFF
--- a/workflow-setup/SKILL.md
+++ b/workflow-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-setup
-description: Set up and manage Zero workflows and workflow automations through the Zero CLI. Use when the user asks to create, edit, inspect, run, schedule, trigger, enable, disable, copy, or delete a workflow or automation, or asks for help with workflow/trigger setup. Keep this generic to all workflow trigger kinds; do not trigger only on a specific connector or event source.
+description: Set up and manage Zero workflows and workflow automations through the Zero CLI. Use when the user asks to create, edit, inspect, run, schedule, trigger, enable, disable, copy, or delete a workflow or automation; wants to modify, refine, improve, optimize, or update an existing workflow; or asks for help with workflow/trigger setup. Keep this generic to all workflow trigger kinds; do not trigger only on a specific connector or event source.
 ---
 
 # Zero Workflow Setup


### PR DESCRIPTION
## Summary
- Extend the workflow-setup skill description so requests to modify, refine, improve, optimize, or update an existing workflow trigger the skill.
- Keep the trigger language generic across workflow and automation trigger kinds.

## Verification
- Ran skill quick validation: `python3 /home/user/.codex/skills/.system/skill-creator/scripts/quick_validate.py /home/user/workspace/vm0-skills/workflow-setup`