### PR TITLE
feat: add nintendo eshop catalog skill

### DIFF
--- a/nintendo-eshop-catalog/SKILL.md
+++ b/nintendo-eshop-catalog/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: nintendo-eshop-catalog
+description: Public Nintendo eShop catalog, search, metadata, and country pricing data for Nintendo Switch games. Use when user mentions Nintendo eShop, Switch game catalog, Nintendo game prices, regional eShop availability, sale prices, NSUIDs, title IDs, or Nintendo product metadata.
+---
+
+# Nintendo eShop Catalog
+
+Use the Nintendo eShop Catalog connector for public Nintendo Switch catalog, search, metadata, and pricing data. This connector does not use Nintendo Account login and does not provide player-specific data such as playtime, owned library, wishlist, friends, purchase history, or Parental Controls data.
+
+## Troubleshooting
+
+If public catalog requests fail, check the connector and one representative public source:
+
+```bash
+zero doctor check-connector --url https://api.ec.nintendo.com/v1/price --method GET
+zero doctor check-connector --url https://search.nintendo-europe.com/en/select --method GET
+```
+
+## Prerequisites
+
+- Enable Nintendo eShop Catalog under vm0.ai -> Settings -> Connectors.
+- No API key, OAuth token, Nintendo Account session, or user credential is required.
+- Requests are read-only public catalog/search/pricing requests.
+- Region and country matter: availability, title IDs, prices, sale windows, currencies, and metadata can differ by market.
+
+Supported catalog regions:
+
+- Americas Algolia locales: `en_us`, `en_ca`, `fr_ca`, `es_mx`, `pt_br`, `es_ar`, `es_cl`, `es_co`, `es_pe`
+- Europe language catalogs: `en`, `de`, `fr`, `es`, `it`, `nl`, `pt`
+- Japan: `jp`
+- Hong Kong: `hk`
+- Taiwan: `tw`
+- Korea: `kr`
+- Southeast Asia: `sg`, `th`, `my`, `ph`
+- Australia/New Zealand: `au`, `nz`
+
+Supported price countries:
+
+`US`, `CA`, `MX`, `BR`, `AR`, `CL`, `CO`, `PE`, `JP`, `KR`, `TW`, `HK`, `AU`, `NZ`, `GB`, `ZA`, `DE`, `FR`, `ES`, `IT`, `NL`, `PT`, `BE`, `CH`, `AT`, `DK`, `NO`, `SE`, `FI`, `PL`, `CZ`, `GR`, `HU`, `SK`, `IE`, `MT`, `LU`.
+
+## 1. Search the United States Catalog
+
+Use Nintendo's public Americas Algolia catalog. This example searches the `store_all_products_en_us` index.
+
+```bash
+curl -s -X POST "https://U3B6GR4UA3-dsn.algolia.net/1/indexes/store_all_products_en_us/query" \
+  --header "Content-Type: application/json" \
+  --header "X-Algolia-Application-Id: U3B6GR4UA3" \
+  --header "X-Algolia-API-Key: a29c6927638bfd8cee23993e51e721c9" \
+  -d '{"query":"zelda","hitsPerPage":10,"page":0}' \
+  | jq '.hits[] | {title: (.title // .name), nsuid, product_url, release_date}'
+```
+
+## 2. Search a Europe Catalog
+
+Use the language-level Europe/PAL Solr catalog. Use country-specific pricing separately.
+
+```bash
+curl -s -G "https://search.nintendo-europe.com/en/select" \
+  --data-urlencode "q=zelda" \
+  --data-urlencode "rows=10" \
+  --data-urlencode "start=0" \
+  --data-urlencode "wt=json" \
+  | jq '.response.docs[] | {title: (.title // .name), nsuid, url, release_date}'
+```
+
+## 3. Fetch Japan Catalog XML
+
+```bash
+curl -s "https://www.nintendo.co.jp/data/software/xml/switch.xml" \
+  | xmllint --xpath '//*[contains(translate(string(.), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"), "zelda")][position() <= 10]' -
+```
+
+## 4. Search Taiwan or Korea
+
+```bash
+curl -s -G "https://www.nintendo.com/tw/api/search" \
+  --data-urlencode "q=zelda" \
+  | jq .
+```
+
+```bash
+curl -s -G "https://www.nintendo.com/kr/api/search" \
+  --data-urlencode "q=zelda" \
+  | jq .
+```
+
+## 5. Search Southeast Asia
+
+Use `sg`, `th`, `my`, or `ph`. Southeast Asia search records can include local price fields such as `price`, `current_price`, `sale_flg`, `sdate`, and `pdate`.
+
+```bash
+REGION=sg
+curl -s "https://search.nintendo.jp/nintendo_soft_${REGION}/search.json" \
+  | jq '[.result.items[]? | select((.title // "" | ascii_downcase) | contains("zelda")) | {title, nsuid, price, current_price, sale_flg, sdate, pdate}] | .[:10]'
+```
+
+## 6. Search Australia/New Zealand
+
+```bash
+curl -s -X POST "https://FMW57F6ERV-dsn.algolia.net/1/indexes/prod_games/query" \
+  --header "Content-Type: application/json" \
+  --header "X-Algolia-Application-Id: FMW57F6ERV" \
+  --header "X-Algolia-API-Key: c8e4e9f60190ef785d167da77ba0b4fe" \
+  -d '{"query":"zelda","hitsPerPage":10,"page":0}' \
+  | jq '.hits[] | {title: (.title // .name), url, platform, release_date}'
+```
+
+## 7. Fetch Country-Specific Prices
+
+Use title IDs from catalog records. Prices are title-id-specific and country-specific.
+
+```bash
+curl -s -G "https://api.ec.nintendo.com/v1/price" \
+  --data-urlencode "country=US" \
+  --data-urlencode "ids=<title-id-1>,<title-id-2>" \
+  --data-urlencode "lang=en" \
+  | jq '.prices[]? | {title_id: (.title_id // .titleId), regular_price, discount_price, sale_start, sale_end}'
+```
+
+## Guidelines
+
+1. Pick the catalog region that matches the user's requested market, then fetch prices with the matching country code when title IDs are available.
+2. Do not infer global availability from one region's catalog result.
+3. Use Southeast Asia search price fields for `sg`, `th`, `my`, and `ph`; representative country/title price API calls may return `not_found` for those markets.
+4. Keep requests small with explicit search terms, limits, and pagination.
+5. Do not claim support for Nintendo Account data, owned games, playtime, wishlist, friends, or purchase history through this connector.

--- a/nintendo-eshop-catalog/SKILL.md
+++ b/nintendo-eshop-catalog/SKILL.md
@@ -7,6 +7,8 @@ description: Public Nintendo eShop catalog, search, metadata, and country pricin
 
 Use the Nintendo eShop Catalog connector for public Nintendo Switch catalog, search, metadata, and pricing data. This connector does not use Nintendo Account login and does not provide player-specific data such as playtime, owned library, wishlist, friends, purchase history, or Parental Controls data.
 
+Nintendo's public catalog sources are unauthenticated public endpoints and can change their response shape. Prefer the normalized vm0 connector fields when they are available; when debugging a public source directly, inspect the raw response before assuming a field exists.
+
 ## Troubleshooting
 
 If public catalog requests fail, first verify that the public source is reachable from the sandbox:
@@ -83,7 +85,7 @@ curl -s "https://www.nintendo.co.jp/data/software/xml/switch.xml" \
 
 ```bash
 curl -s "https://www.nintendo.com/hk/data/json/switch_software.json" \
-  | jq '[.[]? | {title, item_code, product_code, link, price, release_date}] | .[:10]'
+  | jq '[.[]? | {title, titleId: (if (.item_code // "") != "" then .item_code else (try (.link | capture("(?<id>[0-9]{14})$").id) catch null) end), product_code, link, price, release_date}] | .[:10]'
 ```
 
 ## 5. Browse Taiwan or Korea
@@ -94,14 +96,14 @@ Use `/api/software` to browse current catalog records. `/api/search` uses the sa
 curl -s -G "https://www.nintendo.com/tw/api/software" \
   --data-urlencode "limit=10" \
   --data-urlencode "offset=0" \
-  | jq '[.items[]? | {title, nsuid, releaseDate, hardwareCategory}]'
+  | jq '[.items[]? | {title, nsuid, releaseDate, hardwareCategory}] | .[:10]'
 ```
 
 ```bash
 curl -s -G "https://www.nintendo.com/kr/api/software" \
   --data-urlencode "limit=10" \
   --data-urlencode "offset=0" \
-  | jq '[.items[]? | {title, nsuid, releaseDate, hardwareCategory}]'
+  | jq '[.items[]? | {title, nsuid, releaseDate, hardwareCategory}] | .[:10]'
 ```
 
 ## 6. Search Southeast Asia

--- a/nintendo-eshop-catalog/SKILL.md
+++ b/nintendo-eshop-catalog/SKILL.md
@@ -52,7 +52,7 @@ curl -s -X POST "https://U3B6GR4UA3-dsn.algolia.net/1/indexes/store_all_products
   --header "X-Algolia-Application-Id: U3B6GR4UA3" \
   --header "X-Algolia-API-Key: a29c6927638bfd8cee23993e51e721c9" \
   -d '{"query":"zelda","hitsPerPage":10,"page":0}' \
-  | jq '.hits[] | {title: (.title // .name), nsuid, product_url, release_date}'
+  | jq '.hits[] | {title: (.title // .name), nsuid, url, platform, releaseDate: (.releaseDate // .releaseDateDisplay)}'
 ```
 
 For browsing without a search term, use Nintendo's multi-query endpoint with `store_all_products_{locale}` and, where available, `ncom_game_{locale}`.
@@ -64,40 +64,44 @@ Use the language-level Europe/PAL Solr catalog. Use country-specific pricing sep
 ```bash
 curl -s -G "https://search.nintendo-europe.com/en/select" \
   --data-urlencode "q=*zelda*" \
+  --data-urlencode "fq=type:(GAME OR DLC)" \
+  --data-urlencode "fq=nsuid_txt:*" \
   --data-urlencode "rows=10" \
   --data-urlencode "start=0" \
   --data-urlencode "wt=json" \
-  | jq '.response.docs[] | {title: (.title // .name), nsuid, url, release_date}'
+  | jq '.response.docs[] | {title: (.title // .name), nsuid: (.nsuid_txt[0]? // .nsuid), url, type, system_names_txt}'
 ```
 
 ## 3. Fetch Japan Catalog XML
 
 ```bash
 curl -s "https://www.nintendo.co.jp/data/software/xml/switch.xml" \
-  | python3 -c 'import re,sys; text=sys.stdin.read(); print("\n".join(m.group(0)[:500] for m in re.finditer(r"<TitleInfo>[\\s\\S]*?</TitleInfo>", text) if "zelda" in m.group(0).lower()))'
+  | python3 -c 'import itertools,re,sys; text=sys.stdin.read(); print("\n".join(m.group(0)[:500] for m in itertools.islice(re.finditer(r"<TitleInfo>[\s\S]*?</TitleInfo>", text), 5)))'
 ```
 
 ## 4. Fetch Hong Kong Catalog JSON
 
 ```bash
 curl -s "https://www.nintendo.com/hk/data/json/switch_software.json" \
-  | jq '[.soft[]? | {title: (.title // .name), nsuid, price, currency}] | .[:10]'
+  | jq '[.[]? | {title, item_code, product_code, link, price, release_date}] | .[:10]'
 ```
 
-## 5. Search Taiwan or Korea
+## 5. Browse Taiwan or Korea
 
-Use `/api/search` when there is a query. Use `/api/software` to browse without a query.
+Use `/api/software` to browse current catalog records. `/api/search` uses the same `items` response shape when Nintendo returns matches for a localized query.
 
 ```bash
-curl -s -G "https://www.nintendo.com/tw/api/search" \
-  --data-urlencode "q=zelda" \
-  | jq .
+curl -s -G "https://www.nintendo.com/tw/api/software" \
+  --data-urlencode "limit=10" \
+  --data-urlencode "offset=0" \
+  | jq '[.items[]? | {title, nsuid, releaseDate, hardwareCategory}]'
 ```
 
 ```bash
-curl -s -G "https://www.nintendo.com/kr/api/search" \
-  --data-urlencode "q=zelda" \
-  | jq .
+curl -s -G "https://www.nintendo.com/kr/api/software" \
+  --data-urlencode "limit=10" \
+  --data-urlencode "offset=0" \
+  | jq '[.items[]? | {title, nsuid, releaseDate, hardwareCategory}]'
 ```
 
 ## 6. Search Southeast Asia
@@ -107,7 +111,7 @@ Use `sg`, `th`, `my`, or `ph`. Southeast Asia search records can include local p
 ```bash
 REGION=sg
 curl -s "https://search.nintendo.jp/nintendo_soft_${REGION}/search.json" \
-  | jq '[.result.items[]? | select((.title // "" | ascii_downcase) | contains("zelda")) | {title, nsuid, price, current_price, sale_flg, sdate, pdate}] | .[:10]'
+  | jq '[.result.items[]? | {title, nsuid, price, current_price, sale_flg, sdate, pdate}] | .[:10]'
 ```
 
 ## 7. Search Australia/New Zealand
@@ -118,7 +122,7 @@ curl -s -X POST "https://FMW57F6ERV-dsn.algolia.net/1/indexes/prod_games/query" 
   --header "X-Algolia-Application-Id: FMW57F6ERV" \
   --header "X-Algolia-API-Key: c8e4e9f60190ef785d167da77ba0b4fe" \
   -d '{"query":"zelda","hitsPerPage":10,"page":0}' \
-  | jq '.hits[] | {title: (.title // .name), url, platform, release_date}'
+  | jq '.hits[] | {title: (.title // .name), fullURL, console, dateTag, classification}'
 ```
 
 ## 8. Fetch Country-Specific Prices
@@ -127,9 +131,9 @@ Use title IDs from catalog records. Prices are title-id-specific and country-spe
 
 ```bash
 curl -s -G "https://api.ec.nintendo.com/v1/price" \
-  --data-urlencode "country=US" \
-  --data-urlencode "ids=<title-id-1>,<title-id-2>" \
-  --data-urlencode "lang=en" \
+  --data-urlencode "country=JP" \
+  --data-urlencode "ids=70010000000026" \
+  --data-urlencode "lang=ja" \
   | jq '.prices[]? | {title_id: (.title_id // .titleId), regular_price, discount_price, sale_start: .discount_price.start_datetime, sale_end: .discount_price.end_datetime}'
 ```
 

--- a/nintendo-eshop-catalog/SKILL.md
+++ b/nintendo-eshop-catalog/SKILL.md
@@ -9,11 +9,14 @@ Use the Nintendo eShop Catalog connector for public Nintendo Switch catalog, sea
 
 ## Troubleshooting
 
-If public catalog requests fail, check the connector and one representative public source:
+If public catalog requests fail, first verify that the public source is reachable from the sandbox:
 
 ```bash
-zero doctor check-connector --url https://api.ec.nintendo.com/v1/price --method GET
-zero doctor check-connector --url https://search.nintendo-europe.com/en/select --method GET
+curl -fsS -G "https://search.nintendo-europe.com/en/select" \
+  --data-urlencode "q=*" \
+  --data-urlencode "rows=1" \
+  --data-urlencode "wt=json" \
+  | jq '.response.docs | length'
 ```
 
 ## Prerequisites
@@ -22,6 +25,7 @@ zero doctor check-connector --url https://search.nintendo-europe.com/en/select -
 - No API key, OAuth token, Nintendo Account session, or user credential is required.
 - Requests are read-only public catalog/search/pricing requests.
 - Region and country matter: availability, title IDs, prices, sale windows, currencies, and metadata can differ by market.
+- The normalized connector surface returns `sourceFamily`, `region`, `countryCode`, `language`, `title`, `nsuid`, `titleId`, `gameCode`, `productUrl`, `platform`, `releaseDate`, `listPrice`, `salePrice`, `currency`, `saleStart`, `saleEnd`, and `onSale` when available.
 
 Supported catalog regions:
 
@@ -51,13 +55,15 @@ curl -s -X POST "https://U3B6GR4UA3-dsn.algolia.net/1/indexes/store_all_products
   | jq '.hits[] | {title: (.title // .name), nsuid, product_url, release_date}'
 ```
 
+For browsing without a search term, use Nintendo's multi-query endpoint with `store_all_products_{locale}` and, where available, `ncom_game_{locale}`.
+
 ## 2. Search a Europe Catalog
 
 Use the language-level Europe/PAL Solr catalog. Use country-specific pricing separately.
 
 ```bash
 curl -s -G "https://search.nintendo-europe.com/en/select" \
-  --data-urlencode "q=zelda" \
+  --data-urlencode "q=*zelda*" \
   --data-urlencode "rows=10" \
   --data-urlencode "start=0" \
   --data-urlencode "wt=json" \
@@ -68,10 +74,19 @@ curl -s -G "https://search.nintendo-europe.com/en/select" \
 
 ```bash
 curl -s "https://www.nintendo.co.jp/data/software/xml/switch.xml" \
-  | xmllint --xpath '//*[contains(translate(string(.), "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz"), "zelda")][position() <= 10]' -
+  | python3 -c 'import re,sys; text=sys.stdin.read(); print("\n".join(m.group(0)[:500] for m in re.finditer(r"<TitleInfo>[\\s\\S]*?</TitleInfo>", text) if "zelda" in m.group(0).lower()))'
 ```
 
-## 4. Search Taiwan or Korea
+## 4. Fetch Hong Kong Catalog JSON
+
+```bash
+curl -s "https://www.nintendo.com/hk/data/json/switch_software.json" \
+  | jq '[.soft[]? | {title: (.title // .name), nsuid, price, currency}] | .[:10]'
+```
+
+## 5. Search Taiwan or Korea
+
+Use `/api/search` when there is a query. Use `/api/software` to browse without a query.
 
 ```bash
 curl -s -G "https://www.nintendo.com/tw/api/search" \
@@ -85,7 +100,7 @@ curl -s -G "https://www.nintendo.com/kr/api/search" \
   | jq .
 ```
 
-## 5. Search Southeast Asia
+## 6. Search Southeast Asia
 
 Use `sg`, `th`, `my`, or `ph`. Southeast Asia search records can include local price fields such as `price`, `current_price`, `sale_flg`, `sdate`, and `pdate`.
 
@@ -95,7 +110,7 @@ curl -s "https://search.nintendo.jp/nintendo_soft_${REGION}/search.json" \
   | jq '[.result.items[]? | select((.title // "" | ascii_downcase) | contains("zelda")) | {title, nsuid, price, current_price, sale_flg, sdate, pdate}] | .[:10]'
 ```
 
-## 6. Search Australia/New Zealand
+## 7. Search Australia/New Zealand
 
 ```bash
 curl -s -X POST "https://FMW57F6ERV-dsn.algolia.net/1/indexes/prod_games/query" \
@@ -106,7 +121,7 @@ curl -s -X POST "https://FMW57F6ERV-dsn.algolia.net/1/indexes/prod_games/query" 
   | jq '.hits[] | {title: (.title // .name), url, platform, release_date}'
 ```
 
-## 7. Fetch Country-Specific Prices
+## 8. Fetch Country-Specific Prices
 
 Use title IDs from catalog records. Prices are title-id-specific and country-specific.
 
@@ -115,7 +130,7 @@ curl -s -G "https://api.ec.nintendo.com/v1/price" \
   --data-urlencode "country=US" \
   --data-urlencode "ids=<title-id-1>,<title-id-2>" \
   --data-urlencode "lang=en" \
-  | jq '.prices[]? | {title_id: (.title_id // .titleId), regular_price, discount_price, sale_start, sale_end}'
+  | jq '.prices[]? | {title_id: (.title_id // .titleId), regular_price, discount_price, sale_start: .discount_price.start_datetime, sale_end: .discount_price.end_datetime}'
 ```
 
 ## Guidelines


### PR DESCRIPTION
## Summary
- add Nintendo eShop Catalog skill guidance for public catalog/search/pricing data
- document supported catalog regions, price countries, and representative public source endpoints
- clarify that this connector does not expose Nintendo Account/player data such as playtime, wishlist, friends, or owned library

## Tests
- `git diff --check`

## Related
- vm0-ai/vm0#20660