### PR TITLE
fix: broaden workflow-setup description to catch implicit automation intent

### DIFF
--- a/workflow-setup/SKILL.md
+++ b/workflow-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-setup
-description: Set up and manage Zero workflows and workflow automations through the Zero CLI. Use when the user asks to create, edit, inspect, run, schedule, trigger, enable, disable, copy, or delete a workflow or automation; wants to modify, refine, improve, optimize, or update an existing workflow; or asks for help with workflow/trigger setup. Keep this generic to all workflow trigger kinds; do not trigger only on a specific connector or event source.
+description: Set up and manage Zero workflows and workflow automations through the Zero CLI. Use when the user asks to create, edit, inspect, run, schedule, trigger, enable, disable, copy, or delete a workflow or automation; wants to modify, refine, improve, optimize, or update an existing workflow; or asks for help with workflow/trigger setup. Also use when the user describes a recurring or event-driven task without saying "workflow" — for example running something on a schedule or every morning/day/week, doing something when a new email, message, label, webhook, GitHub event, or calendar event arrives, "whenever X happens", monitoring or watching for something, reminding on a cadence, or keeping data in sync automatically. Keep this generic to all workflow trigger kinds; do not trigger only on a specific connector or event source.
 ---
 
 # Zero Workflow Setup


### PR DESCRIPTION
## Problem

The `workflow-setup` skill only triggered when the user explicitly said "workflow", "automation", or "trigger". Natural-language automation requests (e.g. "scan new Gmail for buying signals and write leads to a Sheet") never matched, so the agent built the workflow ad hoc without the skill's guidance.

## Change

Broadened the skill `description` to also fire on implicit recurring / event-driven intent — schedules ("every morning"), event sources (new email/message/label/webhook/GitHub/calendar event), "whenever X happens", monitoring/watching, cadence reminders, and keeping data in sync — even when the word "workflow" is absent. Kept the existing guard to stay generic across all trigger kinds.

Companion to vm0-ai/vm0#20728, which adds matching guidance to the base agent system prompt and aligns the workflow CLI wording.