### PR TITLE
fix(x): use curl with X_TOKEN instead of xurl helper

### DIFF
--- a/x/SKILL.md
+++ b/x/SKILL.md
@@ -5,70 +5,105 @@ description: X (Twitter) API for tweets and profiles. Use when user mentions "X"
   social media posts.
 ---
 
-## How to Use
+## Authentication
 
-### 1. Get Authenticated User Profile
+The `X_TOKEN` Bearer is injected automatically at the network boundary for
+direct HTTPS calls to `https://api.x.com`. You do not need to register an app,
+run an OAuth flow, or manage refresh tokens. Just `curl` and the boundary does
+the rest.
+
+If a request returns 401, run:
 
 ```bash
-xurl whoami
+zero doctor check-connector --url https://api.x.com/2/users/me --method GET
+```
+
+## Base URL
+
+```
+https://api.x.com
+```
+
+All examples below assume `X_TOKEN` is available in the environment. Use
+`curl -sS` to surface HTTP status codes on failure.
+
+## Endpoints
+
+### 1. Authenticated User Profile
+
+```bash
+curl -sS "https://api.x.com/2/users/me" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 ### 2. Look Up User by Username
 
-> **Note:** Replace `elonmusk` with the actual username. Leading `@` is optional.
+> Replace `elonmusk` with the actual username. Leading `@` is optional.
 
 ```bash
-xurl user elonmusk
+curl -sS "https://api.x.com/2/users/by/username/elonmusk?user.fields=id,name,username,description,public_metrics,created_at,verified" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 ### 3. Look Up User by ID
 
-> **Note:** Replace `12345` with the actual user ID. You can obtain user IDs from other endpoint responses.
+> Replace `12345` with the actual user ID. You can obtain user IDs from other
+> endpoint responses.
 
 ```bash
-xurl /2/users/12345?user.fields=id,name,username,description,public_metrics,created_at
+curl -sS "https://api.x.com/2/users/12345?user.fields=id,name,username,description,public_metrics,created_at,verified" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 ### 4. Look Up Multiple Users
 
-Get profiles for multiple users at once (up to 100):
-
-> **Note:** Replace the IDs with actual user IDs, comma-separated.
+Up to 100 IDs per request:
 
 ```bash
-xurl '/2/users?ids=12345,67890&user.fields=id,name,username,description,public_metrics'
+curl -sS "https://api.x.com/2/users?ids=12345,67890&user.fields=id,name,username,description,public_metrics" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 ### 5. Get a Tweet by ID
 
-> **Note:** Replace `1234567890` with the actual tweet ID. Full URLs like `https://x.com/user/status/1234567890` also work.
+> Replace `1234567890` with the actual tweet ID. Full URLs like
+> `https://x.com/user/status/1234567890` also work — extract the ID after
+> `/status/`.
 
 ```bash
-xurl read 1234567890
+curl -sS "https://api.x.com/2/tweets/1234567890?tweet.fields=created_at,public_metrics,author_id,text,lang,conversation_id&expansions=author_id&user.fields=name,username" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 ### 6. Get Multiple Tweets
 
-Get details for multiple tweets at once (up to 100):
-
-> **Note:** Replace the IDs with actual tweet IDs, comma-separated.
+Up to 100 IDs per request:
 
 ```bash
-xurl '/2/tweets?ids=1234567890,0987654321&tweet.fields=created_at,public_metrics,author_id,text&expansions=author_id&user.fields=name,username'
+curl -sS "https://api.x.com/2/tweets?ids=1234567890,0987654321&tweet.fields=created_at,public_metrics,author_id,text,lang&expansions=author_id&user.fields=name,username" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
-### 7. Get User's Tweets (Timeline)
+### 7. Get a User's Tweets (Timeline)
 
-Get recent tweets posted by the authenticated user:
+Recent tweets posted by the authenticated user:
 
 ```bash
-xurl timeline -n 10
+curl -sSG "https://api.x.com/2/users/me/tweets" \
+  --data-urlencode "max_results=10" \
+  --data-urlencode "tweet.fields=created_at,public_metrics,text" \
+  --data-urlencode "exclude=retweets,replies" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
-Query parameters for raw API (if you need another user's timeline):
+For another user's timeline, replace `me` with the user ID:
 
 ```bash
-xurl '/2/users/USER_ID/tweets?max_results=10&tweet.fields=created_at,public_metrics,text&exclude=retweets,replies'
+curl -sSG "https://api.x.com/2/users/USER_ID/tweets" \
+  --data-urlencode "max_results=10" \
+  --data-urlencode "tweet.fields=created_at,public_metrics,text" \
+  --data-urlencode "exclude=retweets,replies" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 - `max_results` - 5 to 100 (default: 10)
@@ -77,20 +112,31 @@ xurl '/2/users/USER_ID/tweets?max_results=10&tweet.fields=created_at,public_metr
 - `pagination_token` - For paginating results
 - `exclude` - Comma-separated: `retweets`, `replies`
 
-### 8. Get User's Mentions
+### 8. Get Mentions of the Authenticated User
 
 ```bash
-xurl mentions -n 10
+curl -sSG "https://api.x.com/2/users/me/mentions" \
+  --data-urlencode "max_results=10" \
+  --data-urlencode "tweet.fields=created_at,public_metrics,text,author_id" \
+  --data-urlencode "expansions=author_id" \
+  --data-urlencode "user.fields=name,username" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 ### 9. Search Recent Tweets
 
-Search for tweets from the past 7 days:
-
-> **Note:** Replace the query with your search terms.
+Search for tweets from the past 7 days. Use `-G` so `curl` builds the query
+string from `--data-urlencode` pairs (handles spaces and special characters
+correctly):
 
 ```bash
-xurl search "openai lang:en -is:retweet" -n 10
+curl -sSG "https://api.x.com/2/tweets/search/recent" \
+  --data-urlencode "query=openai lang:en -is:retweet" \
+  --data-urlencode "max_results=10" \
+  --data-urlencode "tweet.fields=created_at,public_metrics,author_id,text" \
+  --data-urlencode "expansions=author_id" \
+  --data-urlencode "user.fields=name,username" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 Common search operators:
@@ -104,56 +150,66 @@ Common search operators:
 - `lang:en` - Filter by language
 - `conversation_id:123` - Tweets in a conversation thread
 
-### 10. Get User's Followers
+### 10. Get a User's Followers
 
-> **Note:** Replace `elonmusk` with the actual username.
+> Replace `elonmusk` with the actual username. For numeric IDs, use
+> `users/ID/followers` instead.
 
 ```bash
-xurl followers --of elonmusk -n 20
+curl -sSG "https://api.x.com/2/users/by/username/elonmusk/followers" \
+  --data-urlencode "max_results=20" \
+  --data-urlencode "user.fields=id,name,username,description,public_metrics" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
-### 11. Get User's Following
-
-> **Note:** Replace `elonmusk` with the actual username.
+### 11. Get a User's Following
 
 ```bash
-xurl following --of elonmusk -n 20
+curl -sSG "https://api.x.com/2/users/by/username/elonmusk/following" \
+  --data-urlencode "max_results=20" \
+  --data-urlencode "user.fields=id,name,username,description,public_metrics" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
 ## Pagination
 
-Most list endpoints support pagination. For shortcut commands, use `-n` to control result count.
-
-For raw API endpoints, check the `meta.next_token` field in the response:
+Most list endpoints support pagination. After a request, check
+`meta.next_token` in the response and pass it back as `pagination_token` on the
+next call:
 
 ```bash
-xurl '/2/tweets/search/recent?query=example&max_results=10' | jq .meta
+NEXT=$(curl -sS "https://api.x.com/2/tweets/search/recent?query=example&max_results=10" \
+  -H "Authorization: Bearer $X_TOKEN" | jq -r .meta.next_token)
+
+curl -sSG "https://api.x.com/2/tweets/search/recent" \
+  --data-urlencode "query=example" \
+  --data-urlencode "max_results=10" \
+  --data-urlencode "pagination_token=$NEXT" \
+  -H "Authorization: Bearer $X_TOKEN"
 ```
 
-Use the returned `next_token` value as `pagination_token` in the next request to get more results.
-
-## Common user.fields
+## Common `user.fields`
 
 | Field | Description |
 |-------|-------------|
 | `id` | Unique user ID |
 | `name` | Display name |
-| `username` | Handle (without @) |
+| `username` | Handle (without `@`) |
 | `description` | Bio text |
-| `created_at` | Account creation date |
-| `public_metrics` | Followers, following, tweet, and listed counts |
+| `created_at` | Account creation time |
+| `public_metrics` | Followers, following, tweet, listed counts |
 | `profile_image_url` | Avatar URL |
 | `verified` | Verification status |
 | `location` | User-defined location |
 | `url` | User-defined URL |
 
-## Common tweet.fields
+## Common `tweet.fields`
 
 | Field | Description |
 |-------|-------------|
-| `id` | Unique tweet ID |
+| `id` | Tweet ID |
 | `text` | Tweet content |
-| `created_at` | Post timestamp |
+| `created_at` | Post time |
 | `author_id` | Author's user ID |
 | `public_metrics` | Retweets, replies, likes, quotes, bookmarks, impressions |
 | `conversation_id` | Thread root tweet ID |
@@ -163,10 +219,21 @@ Use the returned `next_token` value as `pagination_token` in the next request to
 
 ## Guidelines
 
-1. **Read-only access**: This connector only grants read permissions; you cannot post, like, or retweet
-2. **Rate limits**: X API has strict rate limits; avoid rapid successive calls
-3. **Prefer shortcut commands**: Use `xurl search`, `xurl user`, `xurl read` etc. over raw API paths when possible
-4. **Raw API fallback**: For bulk lookups or advanced queries, use `xurl '/2/...'` with query parameters
-5. **Fields are opt-in (raw API only)**: Raw endpoints only return `id` and `text` by default; specify `tweet.fields` and `user.fields` for richer data. Shortcut commands include common fields automatically
-6. **7-day search window**: The recent search endpoint only covers the past 7 days
-7. **Pagination**: Use `-n` for shortcut commands, `max_results` and `pagination_token` for raw API
+1. **Read-only access**: This connector only grants read permissions; you cannot
+   post, like, retweet, or follow.
+2. **Use `curl -G` with `--data-urlencode` for query parameters** - it handles
+   spaces, quotes, and special characters in the query string correctly. Plain
+   `?query=...&max_results=...` in a URL breaks on any of these.
+3. **Fields are opt-in**: Raw endpoints return only `id` and `text` by default.
+   Always specify `tweet.fields` and `user.fields` for richer data, and
+   `expansions=author_id` + `user.fields` to resolve author usernames in tweet
+   responses.
+4. **7-day search window**: The recent search endpoint only covers the past
+   7 days. For older searches you need the academic / full-archive endpoint,
+   which requires elevated API access.
+5. **Rate limits**: X API enforces per-endpoint and per-user rate limits. Avoid
+   rapid successive calls; on 429 back off and retry.
+6. **No `xurl`**: The legacy `xurl` helper requires a locally registered X app
+   and an OAuth flow that does not run in this sandbox. Use `curl` directly —
+   the `X_TOKEN` bearer is injected by the runtime boundary for
+   `https://api.x.com/*` calls.


### PR DESCRIPTION
## Problem

The X skill shipped a copy of the official xurl CLI examples, but `xurl` requires a locally registered X developer app and an OAuth flow that does not run in the agent sandbox. As a result every request fails with `Auth Error: NoAuthMethod`, and any agent using this skill for the X API silently gets nothing back.

## Why this happened

- The X connector IS authorized at the platform level and the boundary injects a working `X_TOKEN` Bearer into direct HTTPS calls to `https://api.x.com` (verified with a real `curl` to `/2/users/me` returning the `@e7h4nz` account).
- `xurl` cannot see that boundary-injected token. It tries to use a locally configured app's OAuth1/OAuth2 credentials, which are absent in the sandbox.
- The repo's stated philosophy is `No MCPs. No SDKs. No CLI apps. Just curl.` — the xurl-based skill was the only outlier in the repo.

## Change

Rewrote `x/SKILL.md` to use plain `curl` with `Authorization: Bearer $X_TOKEN` against `https://api.x.com`. All operations from the previous skill are preserved:

- Authenticated user profile (`/2/users/me`)
- User lookup by username, by ID, and batch (up to 100)
- Tweet lookup by ID and batch (up to 100)
- User timeline and authenticated mentions
- Recent search (past 7 days) with the common search operators
- Followers and following lists

Other fixes folded in:

- All GET-with-query examples use `curl -G` with `--data-urlencode` so spaces, quotes, and operators like `-is:retweet` are encoded correctly.
- Tweet/user responses now opt in to `tweet.fields`, `user.fields`, and `expansions=author_id` so author names resolve (raw endpoints return only `id` and `text` by default).
- Added the `zero doctor check-connector` troubleshooting pointer used by other skills (axiom, cloudflare).
- Added a 7-day search window note and a 429 rate-limit backoff guideline.

## Verification

- `curl -sS https://api.x.com/2/users/me -H "Authorization: Bearer $X_TOKEN"` → HTTP 200, returns `@e7h4nz`.
- `curl -sSG https://api.x.com/2/tweets/search/recent --data-urlencode "query=AI agents -is:retweet lang:en" --data-urlencode "max_results=10" -H "Authorization: Bearer $X_TOKEN"` → HTTP 200, 10 real tweets from 2026-07-09 with resolved author usernames via `expansions=author_id`.
- Compared against the existing `axiom` skill — same `curl -G --data-urlencode` + `-H "Authorization: Bearer $X_TOKEN"` shape.

This is docs only; no application code is touched.