### PR TITLE
chore: shrink high-impact skill descriptions

### DIFF
--- a/account-reconciliation/SKILL.md
+++ b/account-reconciliation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: account-reconciliation
-description: Perform account reconciliations comparing general ledger balances against subledgers, bank statements, or external records. Use for bank reconciliation, GL-to-subledger reconciliation, intercompany reconciliation, balance sheet reconciliation, reconciling item analysis, outstanding item aging, or clearing open items.
+description: Reconcile accounts, ledgers, bank statements, subledgers, variances, and supporting schedules.
 ---
 
 ## Reconciliation Categories

--- a/analysis-qa/SKILL.md
+++ b/analysis-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analysis-qa
-description: Quality-check a data analysis before sharing — verify joins, aggregations, denominators, time ranges, and metric definitions. Detect pitfalls like survivorship bias, average-of-averages, join explosion, timezone mismatches, incomplete periods, and selection bias. Includes documentation templates for reproducible analyses.
+description: Quality-check data analysis for joins, metrics, denominators, date ranges, leakage, and statistical pitfalls.
 ---
 
 ## Review Checklist

--- a/audit-readiness/SKILL.md
+++ b/audit-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: audit-readiness
-description: Prepare for internal and external audits with SOX 404 control testing, sample selection, workpaper documentation, and deficiency evaluation. Use for SOX compliance, control testing methodology, audit sample selection, audit workpaper preparation, control deficiency classification, material weakness evaluation, ITGC testing, remediation tracking, or audit evidence standards.
+description: Prepare audit workpapers, control tests, samples, evidence, deficiencies, and remediation tracking.
 ---
 
 ## SOX 404 Testing Lifecycle

--- a/brand-guidelines/SKILL.md
+++ b/brand-guidelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brand-guidelines
-description: Define, document, and enforce brand voice, tone, messaging pillars, style rules, and terminology standards. Trigger on requests about brand consistency, voice documentation, tone of voice guides, style guide creation, messaging frameworks, terminology governance, inclusive language, or reviewing content for brand compliance.
+description: Define or enforce brand voice, messaging, terminology, tone, and style standards.
 ---
 
 ## Building a Brand Voice Document

--- a/campaign-strategy/SKILL.md
+++ b/campaign-strategy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: campaign-strategy
-description: Plan and structure marketing campaigns — set objectives, segment audiences, choose channels, build content calendars, allocate budgets, and define KPIs. Trigger on requests for campaign planning, product launch strategy, go-to-market plans, content scheduling, media mix decisions, campaign briefs, or marketing budget allocation.
+description: Plan marketing campaigns, launches, audiences, channels, calendars, budgets, and KPIs.
 ---
 
 ## Five-Part Campaign Architecture

--- a/competitor-matrix/SKILL.md
+++ b/competitor-matrix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: competitor-matrix
-description: Conduct competitive analysis with feature comparison matrices, positioning teardowns, win/loss evaluation, and market trend assessment. Activate when researching competitors, building a feature comparison table, evaluating competitive positioning, preparing a competitive brief, analyzing win/loss patterns, mapping the competitive landscape, or assessing market threats and opportunities.
+description: Research competitors and produce feature matrices, positioning notes, win/loss analysis, or market briefs.
 ---
 
 ## Mapping the Competitive Landscape

--- a/computer-use/SKILL.md
+++ b/computer-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: computer-use
-description: Operate the user's connected desktop apps through Zero Computer Use. Use when a task explicitly asks for zero computer-use, desktop computer use, opening or inspecting a local app, reading a GUI, clicking UI elements, using Slack/Safari/Chrome/Arc/Notion/Finder or another desktop app, taking an app screenshot, or performing a UI workflow that cannot be completed through normal APIs alone.
+description: Operate connected desktop apps or GUI workflows through Zero Computer Use when APIs are not enough.
 ---
 
 # Computer Use

--- a/contract-redline/SKILL.md
+++ b/contract-redline/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contract-redline
-description: Analyze commercial agreements clause-by-clause against organizational playbooks, flag deviations by severity, and produce ready-to-send redline markup with fallback positions. Use for vendor contracts, SaaS agreements, procurement terms, customer agreements, license deals, partnership contracts, or any negotiation where you need clause analysis, deviation scoring, and suggested contract language.
+description: Review commercial contracts against a playbook, flag risk, and draft redlines or fallback language.
 ---
 
 ## Pre-Review Setup

--- a/copywriting/SKILL.md
+++ b/copywriting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: copywriting
-description: Write and edit marketing copy for any channel — blogs, emails, social posts, landing pages, press releases, case studies, ads, and web pages. Trigger on requests for drafting content, writing headlines, crafting CTAs, SEO copywriting, email subject lines, social captions, or any persuasive marketing text.
+description: Write or edit marketing copy for blogs, emails, landing pages, ads, social posts, and case studies.
 ---
 
 ## Channel Formats and Anatomy

--- a/customer-intel/SKILL.md
+++ b/customer-intel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customer-intel
-description: Investigate and answer customer questions by gathering information from docs, CRMs, wikis, tickets, emails, and web sources, then deliver a confidence-rated response with citations. Activate for customer inquiry research, account background investigation, support question lookup, customer context gathering, or knowledge base queries.
+description: Research customer context across docs, tickets, CRM, email, and web sources with cited confidence.
 ---
 
 ## Investigation Framework

--- a/customer-reply/SKILL.md
+++ b/customer-reply/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customer-reply
-description: Compose professional, empathetic customer-facing messages tailored to context, channel, and urgency. Activate when writing support ticket replies, outage notifications, bug acknowledgments, feature request responses, billing communications, follow-up emails, escalation updates, or any external customer correspondence that needs the right tone and structure.
+description: Write customer-facing support, outage, billing, bug, feature-request, and escalation replies.
 ---
 
 ## Foundational Communication Principles

--- a/data-profiling/SKILL.md
+++ b/data-profiling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: data-profiling
-description: Profile and explore unfamiliar datasets — assess schema structure, column distributions, data quality, null rates, cardinality, outliers, relationships between tables, and temporal coverage. Use when onboarding to a new data source, auditing data freshness, discovering foreign keys, or deciding what to analyze.
+description: Profile datasets for schema, distributions, nulls, cardinality, outliers, relationships, and data quality.
 ---
 
 ## Structural Reconnaissance

--- a/escalation-brief/SKILL.md
+++ b/escalation-brief/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: escalation-brief
-description: Prepare structured escalation packages for engineering, product, security, or leadership with reproduction steps, business impact, and full context. Activate when a support issue needs to go beyond the support team, when writing an escalation document, when evaluating whether a problem warrants escalation, or when tracking follow-through after handing off an issue.
+description: Create escalation briefs with impact, reproduction, context, owner, and follow-up tracking.
 ---
 
 ## Deciding: Escalate or Resolve In-House?

--- a/flux-analysis/SKILL.md
+++ b/flux-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flux-analysis
-description: Decompose financial variances into underlying drivers and produce narrative explanations with waterfall bridge analysis. Use for budget vs actual analysis, period-over-period comparison, revenue variance decomposition, expense variance analysis, variance commentary, waterfall charts, forecast accuracy measurement, or P&L flux review.
+description: Explain financial variances with driver analysis, period comparisons, waterfall bridges, and commentary.
 ---
 
 ## Decomposition Techniques

--- a/gaap-reporting/SKILL.md
+++ b/gaap-reporting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gaap-reporting
-description: Prepare GAAP-compliant financial statements including P&L, balance sheet, and cash flow statement with proper classification, disclosure requirements, and period comparisons. Use for income statement generation, balance sheet preparation, statement of cash flows, financial report formatting, ASC standards compliance, reclassification entries, or building management reporting packages.
+description: Prepare GAAP financial statements, classifications, disclosures, and management reporting packages.
 ---
 
 ## Profit and Loss Statement

--- a/gen/SKILL.md
+++ b/gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gen
-description: Use vm0 Zero generation pipelines via `zero generate` for images, videos, voice, presentations, websites, reports, posters, docs designs, dashboard designs, mobile app designs, and connector-backed text/code/document generation. Use when a user asks to generate an artifact and the right built-in pipeline, style, model, or connector should be discovered at runtime.
+description: Use Zero generation pipelines for images, video, voice, presentations, websites, reports, and designs.
 ---
 
 # Gen

--- a/goal/SKILL.md
+++ b/goal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal
-description: Create and manage a persistent thread goal that the agent autonomously continues every idle turn until the full objective is verifiably achieved. Use when the user says "set a goal", "/goal", "keep working on this until it's done", asks for an autonomous long-running task, or wants work to continue across turns without re-prompting. Replaces the harness built-in /goal.
+description: Create or manage a persistent thread goal for autonomous work across idle turns.
 ---
 
 # Thread Goals

--- a/google-cloud/SKILL.md
+++ b/google-cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-cloud
-description: Google Cloud REST APIs for projects, IAM, enabled services, Compute Engine, Cloud Storage, BigQuery, Cloud Run, GKE, Cloud Build, Secret Manager, Logging, Monitoring, Pub/Sub, Firestore, Spanner, Cloud SQL, and billing. Use when user mentions "Google Cloud", "GCP", "gcloud", "project", "IAM", "Compute Engine", "GKE", "Cloud Run", "BigQuery", or "Cloud Storage".
+description: Use Google Cloud APIs for projects, IAM, compute, storage, BigQuery, Cloud Run, GKE, logging, and billing.
 ---
 
 # Google Cloud

--- a/issue-triage/SKILL.md
+++ b/issue-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-triage
-description: Classify, prioritize, and route incoming support issues. Activate when sorting new customer tickets, assigning severity levels P1 through P4, detecting duplicate reports, choosing the right team for handling, or deciding initial response approach for bug reports, billing questions, feature requests, account problems, and other inbound support inquiries.
+description: Triage support issues by severity, duplicates, ownership, and first-response approach.
 ---
 
 ## Classification System

--- a/journal-entries/SKILL.md
+++ b/journal-entries/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: journal-entries
-description: Construct and review journal entries with correct debit/credit structure, supporting calculations, and approval workflows. Use for month-end accruals, prepaid amortization, depreciation entries, payroll booking, revenue recognition journal entries, manual adjustments, recurring entries, reversing entries, or intercompany journal entries.
+description: Create or review journal entries, accruals, amortization, depreciation, payroll, revenue, and adjustments.
 ---
 
 ## Core Entry Patterns by Accounting Cycle

--- a/kb-authoring/SKILL.md
+++ b/kb-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kb-authoring
-description: Author and maintain knowledge base articles derived from resolved support cases. Activate when documenting a solution from a closed ticket, writing how-to guides, building troubleshooting walkthroughs, creating FAQ entries, publishing known-issue advisories, updating stale documentation, organizing KB taxonomy, or performing content gap analysis to reduce future ticket volume.
+description: Write or update knowledge base articles, FAQs, troubleshooting guides, and known-issue docs.
 ---
 
 ## Article Anatomy

--- a/legal-briefing/SKILL.md
+++ b/legal-briefing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: legal-briefing
-description: Build structured briefing documents for meetings with legal significance and track resulting action items. Use when preparing for contract negotiations, board meetings, regulatory discussions, vendor calls, deal reviews, compliance meetings, litigation strategy sessions, or any meeting requiring legal context, participant research, talking points, or post-meeting task tracking.
+description: Prepare legal meeting briefs with context, talking points, participant research, and follow-up actions.
 ---
 
 ## Preparation Workflow

--- a/legal-risk-scoring/SKILL.md
+++ b/legal-risk-scoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: legal-risk-scoring
-description: Score and classify legal risks on a severity-times-likelihood matrix, assign GREEN/YELLOW/ORANGE/RED ratings, document findings in structured memos, and determine escalation paths. Use when scoring contract exposure, evaluating deal risk, rating legal issues by severity and probability, deciding whether to involve senior counsel or outside lawyers, or building a legal risk register.
+description: Score legal risks by severity and likelihood, assign ratings, and document escalation paths.
 ---
 
 ## Scoring Model

--- a/marketing-analytics/SKILL.md
+++ b/marketing-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: marketing-analytics
-description: Measure, report on, and optimize marketing performance across channels and campaigns. Trigger on requests for performance dashboards, campaign result analysis, channel metrics review (email, social, paid ads, SEO, content), trend analysis, forecasting, attribution modeling, A/B testing guidance, or actionable optimization recommendations.
+description: Analyze marketing performance, attribution, channel metrics, forecasts, A/B tests, and optimization opportunities.
 ---
 
 ## Channel Metric Reference

--- a/nda-screening/SKILL.md
+++ b/nda-screening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nda-screening
-description: Rapidly evaluate incoming NDAs, classify them as GREEN (sign-ready), YELLOW (minor issues needing review), or RED (material problems requiring negotiation), and route them appropriately. Use when sales or business development sends a new NDA, when triaging confidentiality agreements, when deciding if an NDA can be approved without counsel, or when assessing non-disclosure agreement risk.
+description: Review NDAs, classify risk, and route sign-ready or problematic agreements.
 ---
 
 ## Evaluation Framework

--- a/paid-ads-operator/SKILL.md
+++ b/paid-ads-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paid-ads-operator
-description: Operate paid advertising campaigns across Google Ads, Meta Ads, and other channels. Use when asked to launch, audit, monitor, troubleshoot, or optimize paid ads, PPC, performance marketing, media buying, search terms, negative keywords, ad creative tests, conversion tracking, attribution, budget pacing, CPA, CAC, ROAS, or campaign experiments.
+description: Launch, audit, monitor, or optimize paid advertising campaigns, tracking, budgets, CAC, CPA, and ROAS.
 ---
 
 # Paid Ads Operator

--- a/period-close/SKILL.md
+++ b/period-close/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: period-close
-description: Orchestrate the month-end and quarter-end accounting close with task sequencing, dependency management, and progress tracking. Use for close calendar planning, close checklist management, close task tracking, close timeline optimization, close day activities, hard close procedures, accelerated close planning, or close process improvement.
+description: Plan and track month-end or quarter-end close tasks, timelines, dependencies, and process improvements.
 ---
 
 ## Close Activity Checklist

--- a/prd-writing/SKILL.md
+++ b/prd-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-writing
-description: Author product requirements documents with structured problem framing, user narratives, prioritized requirements, and measurable outcomes. Activate when drafting a PRD, writing a product spec, defining user stories, setting acceptance criteria, scoping MVP requirements, managing feature scope, or documenting what to build and why.
+description: Draft PRDs with problem framing, users, requirements, acceptance criteria, scope, and measurable outcomes.
 ---
 
 ## Document Architecture

--- a/privacy-compliance/SKILL.md
+++ b/privacy-compliance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: privacy-compliance
-description: Guide teams through GDPR, CCPA/CPRA, and international privacy law obligations including DPA reviews, data subject access and deletion requests, cross-border data transfers, breach notification, and regulatory monitoring. Use when evaluating data processing agreements, handling DSAR or right-to-delete requests, assessing international data transfer mechanisms, reviewing privacy notices, or tracking privacy regulation changes.
+description: Handle privacy compliance tasks such as GDPR, CCPA, DPAs, DSARs, deletion, transfers, and breach notices.
 ---
 
 ## Global Privacy Landscape

--- a/product-metrics/SKILL.md
+++ b/product-metrics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: product-metrics
-description: Define, instrument, and analyze product metrics across acquisition, activation, engagement, retention, and monetization. Activate when setting OKRs, designing a metrics dashboard, running a weekly or monthly metrics review, diagnosing metric movements, choosing KPIs for a product area, building a metrics framework, or evaluating product health.
+description: Define, instrument, and analyze product metrics, KPIs, dashboards, OKRs, retention, and growth.
 ---
 
 ## Metrics Architecture

--- a/reply-templates/SKILL.md
+++ b/reply-templates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reply-templates
-description: Build, manage, and generate standardized response templates for recurring legal inquiries. Activate when handling data subject access requests (DSARs), litigation hold notices, NDA workflows, vendor contract questions, subpoena responses, privacy policy inquiries, insurance claim notifications, or when creating and maintaining a library of reusable legal response templates with proper escalation safeguards.
+description: Create and use reusable legal response templates for DSARs, subpoenas, NDAs, policies, and similar requests.
 ---
 
 ## Template Architecture

--- a/research-synthesis/SKILL.md
+++ b/research-synthesis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-synthesis
-description: Transform raw user research data into actionable product insights, personas, and prioritized opportunities. Activate for interview analysis, survey interpretation, usability test findings, support ticket pattern mining, behavioral data synthesis, thematic coding, affinity diagramming, persona building, or opportunity scoring.
+description: Synthesize user research into insights, personas, opportunities, themes, and prioritized actions.
 ---
 
 ## Core Analytical Methods

--- a/roadmap-planning/SKILL.md
+++ b/roadmap-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap-planning
-description: Build and prioritize product roadmaps using scoring models like RICE, ICE, and value-effort matrices. Activate when creating a product roadmap, prioritizing features, sequencing initiatives, mapping dependencies, balancing team capacity, choosing between Now/Next/Later or quarterly planning, or communicating roadmap tradeoffs to executives and stakeholders.
+description: Plan and prioritize roadmaps with RICE, ICE, value-effort scoring, sequencing, and capacity tradeoffs.
 ---
 
 ## Roadmap Formats

--- a/stats-methods/SKILL.md
+++ b/stats-methods/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stats-methods
-description: Apply statistical techniques to data — descriptive statistics, distributions, hypothesis testing, A/B test evaluation, outlier detection, trend analysis, correlation, forecasting, p-values, confidence intervals, significance testing, and avoiding common statistical pitfalls like Simpson's paradox and survivorship bias.
+description: Apply statistics for summaries, tests, distributions, experiments, outliers, and trends.
 ---
 
 ## Summarizing Numeric Data

--- a/status-updates/SKILL.md
+++ b/status-updates/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: status-updates
-description: Draft clear status updates, progress reports, and stakeholder communications for any audience — executives, engineering teams, cross-functional partners, or customers. Trigger on requests for weekly updates, monthly reports, launch announcements, project status emails, risk escalations, decision records (ADRs), meeting agendas, sprint retrospectives, or any structured team communication.
+description: Draft status updates, launch notes, project reports, agendas, retrospectives, and stakeholder comms.
 ---
 
 ## Audience-Specific Update Formats

--- a/steam/SKILL.md
+++ b/steam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: steam
-description: Steam Web API and public Steam Store APIs for player profiles, game libraries, playtime, wishlists, friends, groups, bans, achievements, game stats, app metadata, reviews, prices, featured games, packages, and Steam news. Use when user mentions "Steam", Steam profile, Steam games, playtime, wishlist, achievements, Steam friends, Steam reviews, Steam prices, or asks about a Steam app.
+description: Use Steam APIs for profiles, libraries, playtime, achievements, friends, reviews, prices, and app metadata.
 ---
 
 # Steam

--- a/workflow-setup/SKILL.md
+++ b/workflow-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-setup
-description: Set up and manage Zero workflows and workflow automations through the Zero CLI. Use when the user asks to create, edit, inspect, run, schedule, trigger, enable, disable, copy, or delete a workflow or automation; wants to modify, refine, improve, optimize, or update an existing workflow; or asks for help with workflow/trigger setup. Also use when the user describes a recurring or event-driven task without saying "workflow" — for example running something on a schedule or every morning/day/week, doing something when a new email, message, label, webhook, GitHub event, or calendar event arrives, "whenever X happens", monitoring or watching for something, reminding on a cadence, or keeping data in sync automatically. Keep this generic to all workflow trigger kinds; do not trigger only on a specific connector or event source.
+description: Create, edit, inspect, run, schedule, pause, or delete Zero workflows and automations.
 ---
 
 # Zero Workflow Setup


### PR DESCRIPTION
Summary:
- shorten frontmatter descriptions for 37 high-impact repo-backed skills that were consuming skill discovery context
- preserve the core trigger intent while removing long enumerations from descriptions
- leave skill instruction bodies unchanged

Verification:
- ran git diff --check
- measured changed descriptions from 13,736 to 3,618 characters, a 10,118 character reduction
- confirmed all changed descriptions are 114 characters or shorter