### PR TITLE
feat: add Nintendo Switch Parental Controls skill

### DIFF
--- a/nintendo-switch-parental-controls/SKILL.md
+++ b/nintendo-switch-parental-controls/SKILL.md
@@ -1,31 +1,31 @@
 ---
 name: nintendo-switch-parental-controls
-description: Use the connected Nintendo Switch Parental Controls app API to inspect supervised Nintendo Switch or Switch 2 play activity, announcements, GameChat settings and requests, account data, and explicitly approved parental-control changes. Trigger for family play-time summaries, supervised console activity, Nintendo parental settings, GameChat approvals, play timers, device labels, or troubleshooting the Nintendo Switch Parental Controls connector.
+description: Use the connected Nintendo Switch Parental Controls app API to inspect supervised Nintendo Switch or Switch 2 activity and manage announcements, GameChat, play timers, devices, notifications, restrictions, and account data. Trigger for family play-time summaries, supervised console activity, Nintendo parental settings, GameChat requests, device labels, or troubleshooting the Nintendo Switch Parental Controls connector.
 ---
 
 # Nintendo Switch Parental Controls
 
-Use the vm0 connector for Nintendo Switch Parental Controls app data. Prefer the default-allowed read workflow. Treat PIN-bearing reads, device pairing, and every mutation as sensitive.
+Use the vm0 connector to call the Nintendo Switch Parental Controls app protocol. This skill describes capabilities and request formats; the user controls which firewall permission groups are enabled.
 
-Default allowed means the response is free of known credentials, not that it is non-sensitive. Play summaries and GameChat responses can identify children, local players, friends, and household activity. Return only the data needed for the user's request.
+Play summaries, GameChat data, device records, and account responses can identify children, local players, friends, consoles, and household activity. Return only the data needed for the user's request. Treat unlock codes, synchronized PINs, serial numbers, pairing data, notification tokens, and connector credentials as secrets.
 
-This integration documents the private app protocol observed in Nintendo Switch Parental Controls 2.4.0, build 660. It is not a public Nintendo API and can change without notice.
+This integration documents every API route observed in Nintendo Switch Parental Controls 2.4.0, build 660: one Nintendo Account profile route and all 45 app action routes. It is a private app protocol and can change without notice.
 
-## Prerequisites
+## Prerequisites and Runtime Bindings
 
 - Connect **Nintendo Switch Parental Controls** under vm0.ai -> Settings -> Connectors with the adult Nintendo Account used by the app.
 - Use `https://app.lp1.znma.srv.nintendo.net` for app actions.
-- Use `https://api.accounts.nintendo.com` only for the Nintendo Account profile.
-- Let vm0 inject the app identity, version, language, smart-device ID, and credential headers. Do not replace the `X-Moon-*` headers.
-- Never print, persist, or return token or smart-device-ID environment values.
+- Use `https://api.accounts.nintendo.com` only for the Nintendo Account profile route listed below.
+- Let vm0 inject the app identity, version, language, smart-device ID, and credential headers. Do not add or replace `X-Moon-*` headers.
+- Never print, persist, return, or enable shell tracing around credential environment values.
 
-The connector exposes these runtime bindings:
+The connector exposes:
 
-- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN`: ID token for all `/v2/actions/*` and `/v3/actions/*` requests.
-- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN`: account token for `/2.0.0/users/me` only.
-- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID`: registered app-instance ID; vm0 injects it as a header.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN`: ID token for `/v2/actions/*` and `/v3/actions/*`.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN`: account token for `/2.0.0/users/me`.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID`: registered app-instance ID.
 - `$NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE`: Nintendo profile language.
-- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG`: safe JSON containing only `deviceId` and `label`.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG`: sanitized JSON containing only `deviceId` and `label`.
 
 Check the connection without exposing credentials:
 
@@ -35,194 +35,234 @@ zero doctor check-connector --env-name NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT
 zero doctor check-connector --url https://app.lp1.znma.srv.nintendo.net/v2/actions/user/fetchUser --method GET
 ```
 
-## Safe Read Workflow
+## Request Conventions
 
-### 1. Select a Device
-
-Use the sanitized catalog instead of granting raw device-record access:
+Set non-secret convenience variables:
 
 ```bash
-printf '%s\n' "$NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG" \
-  | jq -r '.devices[] | [.deviceId, .label] | @tsv'
+ACTION_BASE=https://app.lp1.znma.srv.nintendo.net
+ACCOUNT_BASE=https://api.accounts.nintendo.com
 ```
 
-If the catalog is missing after a console was added or renamed, reconnect the connector. Do not request PIN-bearing device permissions merely to discover an ID.
-
-### 2. Read Daily Play Activity
+For an action `GET`, pass query values with `--data-urlencode`:
 
 ```bash
-DEVICE_ID=<device-id>
-curl -fsS -G \
-  "https://app.lp1.znma.srv.nintendo.net/v2/actions/playSummary/fetchDailySummaries" \
+curl -fsS -G "$ACTION_BASE/v2/actions/playSummary/fetchDailySummaries" \
   --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
   --data-urlencode "deviceId=$DEVICE_ID" \
   | jq .
 ```
 
-Daily summaries can provide player identifiers needed by GameChat reads. Do not assume a fixed response shape; inspect the current response before selecting fields.
-
-### 3. Read Monthly Play Activity
-
-Latest summary:
+For an action `POST`, send exactly one JSON object and set its media type:
 
 ```bash
-curl -fsS -G \
-  "https://app.lp1.znma.srv.nintendo.net/v2/actions/playSummary/fetchLatestMonthlySummary" \
+BODY="$(jq -cn \
+  --arg deviceId "$DEVICE_ID" \
+  --arg label "$NEW_LABEL" \
+  '{deviceId: $deviceId, label: $label}')"
+
+curl -fsS -X POST "$ACTION_BASE/v3/actions/device/updateDeviceLabel" \
   --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
-  --data-urlencode "deviceId=$DEVICE_ID" \
+  --header "Content-Type: application/json" \
+  --data "$BODY" \
+  | jq .
+
+unset BODY
+```
+
+For a bodyless `POST`, omit `--data`:
+
+```bash
+curl -fsS -X POST "$ACTION_BASE/v2/actions/user/clearAlarmSettingNotice" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
   | jq .
 ```
 
-Specific month:
+Field names and enum strings are case-sensitive. Encode integers as JSON numbers, booleans as JSON booleans, and nullable fields as explicit `null` when the schema below says they are nullable. Do not turn a bodyless request into `{}`.
+
+## Identifier and State Sources
+
+- Read `deviceId` and `label` from the sanitized catalog:
+
+  ```bash
+  printf '%s\n' "$NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG" \
+    | jq -r '.devices[] | [.deviceId, .label] | @tsv'
+  ```
+
+- Read `playerId` from daily play summaries or GameChat responses.
+- Read `connectionId` from `fetchCameraChatRequests`.
+- Read `targetNsaId` from `fetchChatRequests`, `fetchChatSetting`, or the corresponding GameChat relationship response.
+- Read current restriction objects and etags from `fetchParentalControlSetting` immediately before changing restrictions or play timers.
+- Read current device/federation state from `fetchOwnedDevice`, `fetchOwnedDevices`, or `checkDeviceFederation` before device lifecycle operations.
+- Use `$NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE` for `appLanguage`.
+- Use `$NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID` only where the catalog explicitly requires `smartDeviceId`; never print it.
+
+The verified summary routes are not paginated. An empty list is a valid result. Response fields can vary by console generation and app version, so inspect the response before selecting or aggregating fields.
+
+Before a mutation, confirm the exact target and requested effect with the user. After it succeeds, reread the related resource instead of assuming the returned shape represents final state.
+
+## Complete API Catalog
+
+The permission name above each table is the firewall group to use when the user's current policy does not permit a requested call. Each verified route appears exactly once below.
+
+### `nintendo-switch-parental-controls-account-read`
+
+| Method and route | Inputs | Use |
+|---|---|---|
+| `GET https://api.accounts.nintendo.com/2.0.0/users/me` | None; use the account token | Read Nintendo Account `id`, nickname, country, and language. |
+| `GET /v2/actions/user/fetchUser` | None | Read the Parental Controls app user and notification state. |
+
+Account profile example:
 
 ```bash
-curl -fsS -G \
-  "https://app.lp1.znma.srv.nintendo.net/v2/actions/playSummary/fetchMonthlySummary" \
-  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
-  --data-urlencode "deviceId=$DEVICE_ID" \
-  --data-urlencode "year=<year>" \
-  --data-urlencode "month=<month>" \
-  --data-urlencode "containLatest=true" \
-  | jq .
-```
-
-The verified summary routes are not paginated. An empty summary/list is a valid result; report that no activity was returned for the selected device and period instead of retrying other devices or dates without approval. Response fields can vary by console generation and app version, so inspect the returned structure before aggregating per-title or per-player time and state which fields were used.
-
-### 4. Read Account and App User Data
-
-Nintendo Account profile:
-
-```bash
-curl -fsS "https://api.accounts.nintendo.com/2.0.0/users/me" \
+curl -fsS "$ACCOUNT_BASE/2.0.0/users/me" \
   --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN" \
   | jq '{id, nickname, country, language}'
 ```
 
-Parental Controls app user:
+### `nintendo-switch-parental-controls-announcements-read`
 
-```bash
-curl -fsS "https://app.lp1.znma.srv.nintendo.net/v2/actions/user/fetchUser" \
-  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
-  | jq .
-```
+| Method and route | Inputs | Use |
+|---|---|---|
+| `GET /v2/actions/announcement/fetchAnnouncements` | Query: `appLanguage` | Read app announcements for the profile language. |
 
-### 5. Read Announcements
+### `nintendo-switch-parental-controls-game-chat-read`
 
-```bash
-curl -fsS -G \
-  "https://app.lp1.znma.srv.nintendo.net/v2/actions/announcement/fetchAnnouncements" \
-  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
-  --data-urlencode "appLanguage=$NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE" \
-  | jq .
-```
+| Method and route | Inputs | Use |
+|---|---|---|
+| `GET /v2/actions/chat/fetchCameraChatRequests` | None | List pending camera-chat connections and obtain `connectionId`. |
+| `GET /v2/actions/chat/fetchCameraSetting` | Query: `deviceId`, `playerId` | Read a player's camera setting. |
+| `GET /v2/actions/chat/fetchChatRequests` | Query: `deviceId`, `playerId` | List GameChat relationship requests and obtain `targetNsaId`. |
+| `GET /v2/actions/chat/fetchChatSetting` | Query: `deviceId` | Read GameChat settings and supervised-player relationships for a device. |
+| `GET /v2/actions/chat/fetchTermOfUse` | Query: `appLanguage`, `deviceId`, `playerId` | Read the applicable GameChat terms. |
 
-### 6. Read GameChat Data
+### `nintendo-switch-parental-controls-play-summary-read`
 
-Use a `deviceId` from the safe catalog and a `playerId` from safe play summaries. GameChat may be unavailable for the account, player, or region.
+| Method and route | Inputs | Use |
+|---|---|---|
+| `GET /v2/actions/playSummary/fetchDailySummaries` | Query: `deviceId` | Read daily title/player activity and discover `playerId`. |
+| `GET /v2/actions/playSummary/fetchLatestMonthlySummary` | Query: `deviceId` | Read the latest monthly summary. |
+| `GET /v2/actions/playSummary/fetchMonthlySummary` | Query: `deviceId`, integer `year`, integer `month`, boolean `containLatest` | Read a specific month. Use `containLatest=true` when the current partial month is needed. |
 
-```bash
-PLAYER_ID=<player-id>
-curl -fsS -G \
-  "https://app.lp1.znma.srv.nintendo.net/v2/actions/chat/fetchCameraSetting" \
-  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
-  --data-urlencode "deviceId=$DEVICE_ID" \
-  --data-urlencode "playerId=$PLAYER_ID" \
-  | jq .
-```
+### `nintendo-switch-parental-controls-device-credentials-read`
 
-## Safety Rules for Sensitive Reads and Mutations
+These responses can contain serial numbers, synchronized unlock codes, or pairing state. Extract only fields required for the user's operation.
 
-- Ask for the exact user intent before requesting a default-denied permission.
-- Confirm the target device and effect before every mutation.
-- The firewall validates the method and route, not query-value ownership or date ranges. Confirm `deviceId`, `playerId`, `year`, and `month` from the user's requested target before sending a request.
-- Never retrieve, reveal, guess, or store unlock PINs, synchronized PINs, pairing codes, notification tokens, or serial numbers unless the user explicitly requests the specific sensitive read and has authorized its permission.
-- Do not call raw federation or notification-token routes as routine setup. The connector owns its smart-device lifecycle and does not consume push notifications.
-- Do not guess POST bodies. Use a body verified for app 2.4.0 and the requested operation.
-- Treat raw `POST /v2/actions/logout` as destructive: it can invalidate this connector. Reconnect is the supported recovery.
-- Do not call hidden legacy `/moon/v1` APIs; they are not present in app 2.4.0.
+| Method and route | Inputs | Use |
+|---|---|---|
+| `GET /v3/actions/device/fetchExtraPlayingTimeState` | Query: `deviceId` | Read extra-time status and remaining/current additional time. |
+| `GET /v3/actions/deviceFederation/checkDeviceFederation` | Query: `deviceId` | Read pairing/federation state for one device. |
+| `GET /v3/actions/user/fetchOwnedDevice` | Query: `deviceId` | Read one complete owned-device record. |
+| `GET /v3/actions/user/fetchOwnedDevices` | None | Read all complete owned-device records and their order. |
 
-## Firewall Permissions
+### `nintendo-switch-parental-controls-settings-credentials-read`
 
-Unknown routes are denied. The permission list below covers the account profile and all 45 app action routes.
+The response contains the current unlock code together with restriction state. Do not return the code unless the user specifically requested it.
 
-### Default Allowed Reads
+| Method and route | Inputs | Use |
+|---|---|---|
+| `GET /v3/actions/parentalControlSetting/fetchParentalControlSetting` | Query: `deviceId` | Read `parentalControlSetting`, `ownedDevice`, current etags, restrictions, timer regulations, and extended play time. |
 
-- `nintendo-switch-parental-controls-account-read`
-  - `GET https://api.accounts.nintendo.com/2.0.0/users/me`
-  - `GET /v2/actions/user/fetchUser`
-- `nintendo-switch-parental-controls-announcements-read`
-  - `GET /v2/actions/announcement/fetchAnnouncements`
-- `nintendo-switch-parental-controls-game-chat-read`
-  - `GET /v2/actions/chat/fetchCameraChatRequests`
-  - `GET /v2/actions/chat/fetchCameraSetting`
-  - `GET /v2/actions/chat/fetchChatRequests`
-  - `GET /v2/actions/chat/fetchChatSetting`
-  - `GET /v2/actions/chat/fetchTermOfUse`
-- `nintendo-switch-parental-controls-play-summary-read`
-  - `GET /v2/actions/playSummary/fetchDailySummaries`
-  - `GET /v2/actions/playSummary/fetchLatestMonthlySummary`
-  - `GET /v2/actions/playSummary/fetchMonthlySummary`
+### `nintendo-switch-parental-controls-game-chat-write`
 
-### Default Denied Sensitive Reads
+| Method and route | JSON body | Use and value source |
+|---|---|---|
+| `POST /v2/actions/chat/acceptCameraChatRequest` | `{"deviceId": string, "connectionId": string}` | Accept a connection returned by `fetchCameraChatRequests`. |
+| `POST /v2/actions/chat/acceptChatRequest` | `{"deviceId": string, "playerId": string, "targetNsaId": string, "memo": string\|null}` | Accept a request returned by `fetchChatRequests`; include the user's requested memo or `null`. |
+| `POST /v2/actions/chat/agreeChildTerm` | `{"deviceId": string, "playerId": string}` | Record agreement for the selected supervised player after showing the applicable terms. |
+| `POST /v2/actions/chat/checkRelationship` | `{"deviceId": string, "playerId": string}` | Ask the service which relationship action is applicable. |
+| `POST /v2/actions/chat/rejectCameraChatRequest` | `{"deviceId": string, "connectionId": string}` | Reject a connection returned by `fetchCameraChatRequests`. |
+| `POST /v2/actions/chat/rejectChatRequest` | `{"deviceId": string, "playerId": string, "targetNsaId": string}` | Reject a request returned by `fetchChatRequests`. |
+| `POST /v2/actions/chat/requestRelationshipCorrection` | `{"deviceId": string, "playerId": string, "correction": string}` | Send the correction indicated by `checkRelationship`; do not invent a correction value. |
+| `POST /v2/actions/chat/suspendCameraChat` | `{"deviceId": string, "connectionId": string}` | Suspend an existing camera-chat connection. |
+| `POST /v2/actions/chat/updateCameraChatSetting` | `{"deviceId": string, "connectionId": string, "visibleRange": string}` | Set `visibleRange` to `RECEIVED_ONLY`, `FACE`, `BODY`, or `BACKGROUND`. |
+| `POST /v2/actions/chat/updateCameraSetting` | `{"deviceId": string, "playerId": string, "allowedSpan": string}` | Set `allowedSpan` to `NOT_ALLOWED` or `REQUIRED_CONFIRMED`. |
+| `POST /v2/actions/chat/updateMemo` | `{"deviceId": string, "playerId": string, "targetNsaId": string, "memo": string}` | Replace the memo for the selected relationship. |
+| `POST /v2/actions/chat/withdrawChatRequest` | `{"deviceId": string, "playerId": string, "targetNsaId": string}` | Withdraw a previously sent relationship request. |
 
-These responses can include a serial number, unlock PIN, synchronized PIN, or pairing state.
+Known `correction` strings are `JOIN_FAMILY_AND_BECOME_SUPERVISOR`, `BECOME_SUPERVISOR`, `MAKE_PLAYER_AS_SUPERVISED`, `INVITE_PLAYER_AS_SUPERVISED`, `REQUEST_PLAYER_AS_SUPERVISED`, `SHOW_HELP_FIX_INCORRECT_ROLE`, `SHOW_HELP_FIX_SPITTED_FAMILY`, `SHOW_HELP_FIX_ALONE_FAMILY`, `REQUIRE_PHONE_NUMBER_REGISTRATION`, `REQUIRE_PHONE_NUMBER_AUTHENTICATION`, `SHOW_CHILD_AGREEMENT_FORM`, and `NONE`. Use only the value returned for the current relationship.
 
-- `nintendo-switch-parental-controls-device-credentials-read`
-  - `GET /v3/actions/device/fetchExtraPlayingTimeState`
-  - `GET /v3/actions/deviceFederation/checkDeviceFederation`
-  - `GET /v3/actions/user/fetchOwnedDevice`
-  - `GET /v3/actions/user/fetchOwnedDevices`
-- `nintendo-switch-parental-controls-settings-credentials-read`
-  - `GET /v3/actions/parentalControlSetting/fetchParentalControlSetting`
+### `nintendo-switch-parental-controls-play-time-write`
 
-### Default Denied Writes
+| Method and route | JSON body | Use and value source |
+|---|---|---|
+| `POST /v2/actions/device/confirmExtraPlayingTime` | `{"deviceId": string, "additionalTime": integer, "withBedtime": boolean}` | Confirm the exact extra minutes and bedtime behavior requested by the user. |
+| `POST /v2/actions/device/updateExtraPlayingTime` | `{"deviceId": string, "status": string, "additionalTime": integer\|null}` | Use `TO_ADDED`, `TO_CANCELED`, or `TO_INFINITY`; reread extra-time state first. |
+| `POST /v3/actions/parentalControlSetting/updatePlayTimer` | `{"deviceId": string, "playTimerRegulations": object}` | Copy the current `playTimerRegulations` object from `fetchParentalControlSetting`, modify only requested fields, and preserve the complete object. |
 
-- `nintendo-switch-parental-controls-game-chat-write`
-  - `POST /v2/actions/chat/acceptCameraChatRequest`
-  - `POST /v2/actions/chat/acceptChatRequest`
-  - `POST /v2/actions/chat/agreeChildTerm`
-  - `POST /v2/actions/chat/checkRelationship`
-  - `POST /v2/actions/chat/rejectCameraChatRequest`
-  - `POST /v2/actions/chat/rejectChatRequest`
-  - `POST /v2/actions/chat/requestRelationshipCorrection`
-  - `POST /v2/actions/chat/suspendCameraChat`
-  - `POST /v2/actions/chat/updateCameraChatSetting`
-  - `POST /v2/actions/chat/updateCameraSetting`
-  - `POST /v2/actions/chat/updateMemo`
-  - `POST /v2/actions/chat/withdrawChatRequest`
-- `nintendo-switch-parental-controls-play-time-write`
-  - `POST /v2/actions/device/confirmExtraPlayingTime`
-  - `POST /v2/actions/device/updateExtraPlayingTime`
-  - `POST /v3/actions/parentalControlSetting/updatePlayTimer`
-- `nintendo-switch-parental-controls-device-pairing-write`
-  - `POST /v2/actions/deviceFederation/startDeviceFederation`
-  - `POST /v2/actions/user/confirmCopiedOwnedDevice`
-  - `POST /v3/actions/federation`
-- `nintendo-switch-parental-controls-feedback-write`
-  - `POST /v2/actions/feedback/sendFeedback`
-- `nintendo-switch-parental-controls-smart-device-write`
-  - `POST /v2/actions/logout`
-  - `POST /v2/actions/smartDevice/updateNotificationToken`
-- `nintendo-switch-parental-controls-settings-write`
-  - `POST /v2/actions/parentalControlSetting/updateRestrictionLevel`
-  - `POST /v2/actions/parentalControlSetting/updateUnlockCode`
-- `nintendo-switch-parental-controls-device-write`
-  - `POST /v3/actions/device/unregisterDevice`
-  - `POST /v3/actions/device/updateDeviceLabel`
-  - `POST /v3/actions/user/updateOwnedDeviceSortOrder`
-- `nintendo-switch-parental-controls-notifications-write`
-  - `POST /v2/actions/user/clearAlarmSettingNotice`
-  - `POST /v2/actions/user/updateNotificationSetting`
-- `nintendo-switch-parental-controls-summary-acknowledgement-write`
-  - `POST /v3/actions/user/confirmFirstDailySummary`
-  - `POST /v3/actions/user/confirmNewMonthlySummary`
+`playTimerRegulations` contains `timerMode`, `restrictionMode`, `dailyRegulations`, and `eachDayOfTheWeekRegulations`. Preserve nested `timeToPlayInOneDay` and `bedtime` objects and all weekday keys returned by the service.
+
+### `nintendo-switch-parental-controls-device-pairing-write`
+
+| Method and route | JSON body | Use and value source |
+|---|---|---|
+| `POST /v2/actions/deviceFederation/startDeviceFederation` | No body | Start the official device-pairing flow. |
+| `POST /v2/actions/user/confirmCopiedOwnedDevice` | `{"deviceId": string}` | Confirm an owned-device record copied during migration/pairing. |
+| `POST /v3/actions/federation` | `{"smartDeviceInfo": object}` | Register the connector app instance. This is connector lifecycle infrastructure; routine tasks should not call it. |
+
+The `smartDeviceInfo` object requires `id`, `bundleId`, `os`, `osVersion`, `modelName`, `timeZone`, `appVersion`, `osLanguage`, `appLanguage`, and nullable `notificationToken`. `appVersion` requires `displayedVersion` and integer `internalVersion`. Use the connector's registered values; never create a second identity or substitute another `id`.
+
+### `nintendo-switch-parental-controls-feedback-write`
+
+| Method and route | JSON body | Use |
+|---|---|---|
+| `POST /v2/actions/feedback/sendFeedback` | `{"type": string, "content": string}` | Send user-approved feedback. `type` is `PLAYING_SUMMARY`, `PARENTAL_CONTROL_SETTING`, `CHAT`, `UNLOCK_CODE`, `EXPECTED_FUNCTION`, `BUG`, or `OTHER`. |
+
+### `nintendo-switch-parental-controls-smart-device-write`
+
+| Method and route | JSON body | Use |
+|---|---|---|
+| `POST /v2/actions/logout` | `{"smartDeviceId": string}` | Unregister the current app session. Use the connector smart-device ID; reconnect after logout. |
+| `POST /v2/actions/smartDevice/updateNotificationToken` | `{"smartDeviceId": string, "notificationToken": string}` | Update a real mobile push token. The connector does not provide or consume one, so do not fabricate it. |
+
+### `nintendo-switch-parental-controls-settings-write`
+
+| Method and route | JSON body | Use and value source |
+|---|---|---|
+| `POST /v2/actions/parentalControlSetting/updateRestrictionLevel` | `{"deviceId": string, "vrRestrictionEtag": string, "parentalControlSettingEtag": string, "functionalRestrictionLevel": string, "customSettings": object, "whitelistedApplicationList": array}` | Reread settings, preserve etags and untouched fields, then change only the requested restriction fields. |
+| `POST /v2/actions/parentalControlSetting/updateUnlockCode` | `{"deviceId": string, "unlockCode": string}` | Change the console unlock code after explicit confirmation; never echo the value. |
+
+For `updateRestrictionLevel`, source `parentalControlSettingEtag` from `parentalControlSetting.etag`. Preserve the current `vrRestrictionEtag`, `functionalRestrictionLevel`, `customSettings`, and `whitelistedApplicationList` unless the user requested that specific change. `customSettings` includes age, UGC, social-posting, rating-organization, and VR restriction fields; copy the service object rather than rebuilding it from guesses.
+
+### `nintendo-switch-parental-controls-device-write`
+
+| Method and route | JSON body | Use and value source |
+|---|---|---|
+| `POST /v3/actions/device/unregisterDevice` | `{"deviceId": string}` | Remove the selected console from parental supervision. |
+| `POST /v3/actions/device/updateDeviceLabel` | `{"deviceId": string, "label": string}` | Rename the selected console. |
+| `POST /v3/actions/user/updateOwnedDeviceSortOrder` | `{"deviceIds": string[]}` | Send the complete desired device order, not a partial list. |
+
+### `nintendo-switch-parental-controls-notifications-write`
+
+| Method and route | JSON body | Use |
+|---|---|---|
+| `POST /v2/actions/user/clearAlarmSettingNotice` | No body | Clear the current alarm-setting notice. |
+| `POST /v2/actions/user/updateNotificationSetting` | `{"notificationSetting": {"all": boolean, "relatedChildren": boolean, "announcement": boolean}}` | Replace all three notification flags together; preserve flags the user did not ask to change. |
+
+### `nintendo-switch-parental-controls-summary-acknowledgement-write`
+
+| Method and route | JSON body | Use |
+|---|---|---|
+| `POST /v3/actions/user/confirmFirstDailySummary` | `{"deviceId": string}` | Mark the first daily summary as seen for the selected device. |
+| `POST /v3/actions/user/confirmNewMonthlySummary` | `{"deviceId": string}` | Mark the new monthly summary as seen for the selected device. |
+
+## Operational Safety
+
+- Confirm `deviceId`, `playerId`, `connectionId`, `targetNsaId`, dates, and requested effects; the firewall matches method and route, not ownership or intent.
+- Never reveal, guess, or store unlock codes, synchronized PINs, pairing codes, serial numbers, notification tokens, or credential environment values.
+- Read current state immediately before requests that require etags or replace complete objects.
+- Do not guess POST bodies, omit required keys, or reuse identifiers from another response/account.
+- Do not call federation, notification-token, or logout routes as routine setup. The connector owns its app-instance lifecycle.
+- Do not call hidden legacy `/moon/v1` APIs; none are present in app 2.4.0.
+- If a route or schema changes after an app update, stop and revalidate the protocol instead of probing nearby routes.
 
 ## Troubleshooting
 
 - **401 or expired connection:** let vm0 refresh once, then reconnect if the request still fails. Never expose a token while debugging.
-- **Permission denied:** request only the named permission required for the user's operation. Do not weaken unknown-route or credential-read defaults.
-- **Empty or stale device catalog:** reconnect after confirming the console is linked in the official app.
-- **No play summaries:** confirm the selected device has activity for the requested period. Daily boundaries use the connector's registered app context.
-- **No player ID or GameChat data:** read daily summaries first; the player or region may not support GameChat.
-- **Schema or route error after an app update:** stop rather than guessing. Record the current app version and revalidate the protocol before changing a request.
-- **Raw logout was called:** reconnect the connector; do not silently re-federate and reverse the user's action.
+- **Firewall permission not enabled:** report the exact permission group from the catalog and let the user decide its policy.
+- **Empty or stale device catalog:** confirm the console is linked in the official app, then reconnect the connector.
+- **No play summaries:** confirm the device has activity for the requested period; do not silently try other devices or dates.
+- **No GameChat identifiers/data:** read daily summaries and the relevant GameChat list first; the player, account, or region may not support GameChat.
+- **409 or etag conflict:** reread the current settings and rebuild the requested change once. Do not retry a stale body.
+- **Schema or route error:** record the app version and stop instead of guessing.
+- **Logout completed:** reconnect explicitly; do not silently re-federate.

--- a/nintendo-switch-parental-controls/SKILL.md
+++ b/nintendo-switch-parental-controls/SKILL.md
@@ -7,6 +7,8 @@ description: Use the connected Nintendo Switch Parental Controls app API to insp
 
 Use the vm0 connector for Nintendo Switch Parental Controls app data. Prefer the default-allowed read workflow. Treat PIN-bearing reads, device pairing, and every mutation as sensitive.
 
+Default allowed means the response is free of known credentials, not that it is non-sensitive. Play summaries and GameChat responses can identify children, local players, friends, and household activity. Return only the data needed for the user's request.
+
 This integration documents the private app protocol observed in Nintendo Switch Parental Controls 2.4.0, build 660. It is not a public Nintendo API and can change without notice.
 
 ## Prerequisites
@@ -84,6 +86,8 @@ curl -fsS -G \
   | jq .
 ```
 
+The verified summary routes are not paginated. An empty summary/list is a valid result; report that no activity was returned for the selected device and period instead of retrying other devices or dates without approval. Response fields can vary by console generation and app version, so inspect the returned structure before aggregating per-title or per-player time and state which fields were used.
+
 ### 4. Read Account and App User Data
 
 Nintendo Account profile:
@@ -130,6 +134,7 @@ curl -fsS -G \
 
 - Ask for the exact user intent before requesting a default-denied permission.
 - Confirm the target device and effect before every mutation.
+- The firewall validates the method and route, not query-value ownership or date ranges. Confirm `deviceId`, `playerId`, `year`, and `month` from the user's requested target before sending a request.
 - Never retrieve, reveal, guess, or store unlock PINs, synchronized PINs, pairing codes, notification tokens, or serial numbers unless the user explicitly requests the specific sensitive read and has authorized its permission.
 - Do not call raw federation or notification-token routes as routine setup. The connector owns its smart-device lifecycle and does not consume push notifications.
 - Do not guess POST bodies. Use a body verified for app 2.4.0 and the requested operation.

--- a/nintendo-switch-parental-controls/SKILL.md
+++ b/nintendo-switch-parental-controls/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: nintendo-switch-parental-controls
+description: Use the connected Nintendo Switch Parental Controls app API to inspect supervised Nintendo Switch or Switch 2 play activity, announcements, GameChat settings and requests, account data, and explicitly approved parental-control changes. Trigger for family play-time summaries, supervised console activity, Nintendo parental settings, GameChat approvals, play timers, device labels, or troubleshooting the Nintendo Switch Parental Controls connector.
+---
+
+# Nintendo Switch Parental Controls
+
+Use the vm0 connector for Nintendo Switch Parental Controls app data. Prefer the default-allowed read workflow. Treat PIN-bearing reads, device pairing, and every mutation as sensitive.
+
+This integration documents the private app protocol observed in Nintendo Switch Parental Controls 2.4.0, build 660. It is not a public Nintendo API and can change without notice.
+
+## Prerequisites
+
+- Connect **Nintendo Switch Parental Controls** under vm0.ai -> Settings -> Connectors with the adult Nintendo Account used by the app.
+- Use `https://app.lp1.znma.srv.nintendo.net` for app actions.
+- Use `https://api.accounts.nintendo.com` only for the Nintendo Account profile.
+- Let vm0 inject the app identity, version, language, smart-device ID, and credential headers. Do not replace the `X-Moon-*` headers.
+- Never print, persist, or return token or smart-device-ID environment values.
+
+The connector exposes these runtime bindings:
+
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN`: ID token for all `/v2/actions/*` and `/v3/actions/*` requests.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN`: account token for `/2.0.0/users/me` only.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID`: registered app-instance ID; vm0 injects it as a header.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE`: Nintendo profile language.
+- `$NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG`: safe JSON containing only `deviceId` and `label`.
+
+Check the connection without exposing credentials:
+
+```bash
+zero doctor check-connector --env-name NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN
+zero doctor check-connector --env-name NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN
+zero doctor check-connector --url https://app.lp1.znma.srv.nintendo.net/v2/actions/user/fetchUser --method GET
+```
+
+## Safe Read Workflow
+
+### 1. Select a Device
+
+Use the sanitized catalog instead of granting raw device-record access:
+
+```bash
+printf '%s\n' "$NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG" \
+  | jq -r '.devices[] | [.deviceId, .label] | @tsv'
+```
+
+If the catalog is missing after a console was added or renamed, reconnect the connector. Do not request PIN-bearing device permissions merely to discover an ID.
+
+### 2. Read Daily Play Activity
+
+```bash
+DEVICE_ID=<device-id>
+curl -fsS -G \
+  "https://app.lp1.znma.srv.nintendo.net/v2/actions/playSummary/fetchDailySummaries" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
+  --data-urlencode "deviceId=$DEVICE_ID" \
+  | jq .
+```
+
+Daily summaries can provide player identifiers needed by GameChat reads. Do not assume a fixed response shape; inspect the current response before selecting fields.
+
+### 3. Read Monthly Play Activity
+
+Latest summary:
+
+```bash
+curl -fsS -G \
+  "https://app.lp1.znma.srv.nintendo.net/v2/actions/playSummary/fetchLatestMonthlySummary" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
+  --data-urlencode "deviceId=$DEVICE_ID" \
+  | jq .
+```
+
+Specific month:
+
+```bash
+curl -fsS -G \
+  "https://app.lp1.znma.srv.nintendo.net/v2/actions/playSummary/fetchMonthlySummary" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
+  --data-urlencode "deviceId=$DEVICE_ID" \
+  --data-urlencode "year=<year>" \
+  --data-urlencode "month=<month>" \
+  --data-urlencode "containLatest=true" \
+  | jq .
+```
+
+### 4. Read Account and App User Data
+
+Nintendo Account profile:
+
+```bash
+curl -fsS "https://api.accounts.nintendo.com/2.0.0/users/me" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN" \
+  | jq '{id, nickname, country, language}'
+```
+
+Parental Controls app user:
+
+```bash
+curl -fsS "https://app.lp1.znma.srv.nintendo.net/v2/actions/user/fetchUser" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
+  | jq .
+```
+
+### 5. Read Announcements
+
+```bash
+curl -fsS -G \
+  "https://app.lp1.znma.srv.nintendo.net/v2/actions/announcement/fetchAnnouncements" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
+  --data-urlencode "appLanguage=$NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE" \
+  | jq .
+```
+
+### 6. Read GameChat Data
+
+Use a `deviceId` from the safe catalog and a `playerId` from safe play summaries. GameChat may be unavailable for the account, player, or region.
+
+```bash
+PLAYER_ID=<player-id>
+curl -fsS -G \
+  "https://app.lp1.znma.srv.nintendo.net/v2/actions/chat/fetchCameraSetting" \
+  --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN" \
+  --data-urlencode "deviceId=$DEVICE_ID" \
+  --data-urlencode "playerId=$PLAYER_ID" \
+  | jq .
+```
+
+## Safety Rules for Sensitive Reads and Mutations
+
+- Ask for the exact user intent before requesting a default-denied permission.
+- Confirm the target device and effect before every mutation.
+- Never retrieve, reveal, guess, or store unlock PINs, synchronized PINs, pairing codes, notification tokens, or serial numbers unless the user explicitly requests the specific sensitive read and has authorized its permission.
+- Do not call raw federation or notification-token routes as routine setup. The connector owns its smart-device lifecycle and does not consume push notifications.
+- Do not guess POST bodies. Use a body verified for app 2.4.0 and the requested operation.
+- Treat raw `POST /v2/actions/logout` as destructive: it can invalidate this connector. Reconnect is the supported recovery.
+- Do not call hidden legacy `/moon/v1` APIs; they are not present in app 2.4.0.
+
+## Firewall Permissions
+
+Unknown routes are denied. The permission list below covers the account profile and all 45 app action routes.
+
+### Default Allowed Reads
+
+- `nintendo-switch-parental-controls-account-read`
+  - `GET https://api.accounts.nintendo.com/2.0.0/users/me`
+  - `GET /v2/actions/user/fetchUser`
+- `nintendo-switch-parental-controls-announcements-read`
+  - `GET /v2/actions/announcement/fetchAnnouncements`
+- `nintendo-switch-parental-controls-game-chat-read`
+  - `GET /v2/actions/chat/fetchCameraChatRequests`
+  - `GET /v2/actions/chat/fetchCameraSetting`
+  - `GET /v2/actions/chat/fetchChatRequests`
+  - `GET /v2/actions/chat/fetchChatSetting`
+  - `GET /v2/actions/chat/fetchTermOfUse`
+- `nintendo-switch-parental-controls-play-summary-read`
+  - `GET /v2/actions/playSummary/fetchDailySummaries`
+  - `GET /v2/actions/playSummary/fetchLatestMonthlySummary`
+  - `GET /v2/actions/playSummary/fetchMonthlySummary`
+
+### Default Denied Sensitive Reads
+
+These responses can include a serial number, unlock PIN, synchronized PIN, or pairing state.
+
+- `nintendo-switch-parental-controls-device-credentials-read`
+  - `GET /v3/actions/device/fetchExtraPlayingTimeState`
+  - `GET /v3/actions/deviceFederation/checkDeviceFederation`
+  - `GET /v3/actions/user/fetchOwnedDevice`
+  - `GET /v3/actions/user/fetchOwnedDevices`
+- `nintendo-switch-parental-controls-settings-credentials-read`
+  - `GET /v3/actions/parentalControlSetting/fetchParentalControlSetting`
+
+### Default Denied Writes
+
+- `nintendo-switch-parental-controls-game-chat-write`
+  - `POST /v2/actions/chat/acceptCameraChatRequest`
+  - `POST /v2/actions/chat/acceptChatRequest`
+  - `POST /v2/actions/chat/agreeChildTerm`
+  - `POST /v2/actions/chat/checkRelationship`
+  - `POST /v2/actions/chat/rejectCameraChatRequest`
+  - `POST /v2/actions/chat/rejectChatRequest`
+  - `POST /v2/actions/chat/requestRelationshipCorrection`
+  - `POST /v2/actions/chat/suspendCameraChat`
+  - `POST /v2/actions/chat/updateCameraChatSetting`
+  - `POST /v2/actions/chat/updateCameraSetting`
+  - `POST /v2/actions/chat/updateMemo`
+  - `POST /v2/actions/chat/withdrawChatRequest`
+- `nintendo-switch-parental-controls-play-time-write`
+  - `POST /v2/actions/device/confirmExtraPlayingTime`
+  - `POST /v2/actions/device/updateExtraPlayingTime`
+  - `POST /v3/actions/parentalControlSetting/updatePlayTimer`
+- `nintendo-switch-parental-controls-device-pairing-write`
+  - `POST /v2/actions/deviceFederation/startDeviceFederation`
+  - `POST /v2/actions/user/confirmCopiedOwnedDevice`
+  - `POST /v3/actions/federation`
+- `nintendo-switch-parental-controls-feedback-write`
+  - `POST /v2/actions/feedback/sendFeedback`
+- `nintendo-switch-parental-controls-smart-device-write`
+  - `POST /v2/actions/logout`
+  - `POST /v2/actions/smartDevice/updateNotificationToken`
+- `nintendo-switch-parental-controls-settings-write`
+  - `POST /v2/actions/parentalControlSetting/updateRestrictionLevel`
+  - `POST /v2/actions/parentalControlSetting/updateUnlockCode`
+- `nintendo-switch-parental-controls-device-write`
+  - `POST /v3/actions/device/unregisterDevice`
+  - `POST /v3/actions/device/updateDeviceLabel`
+  - `POST /v3/actions/user/updateOwnedDeviceSortOrder`
+- `nintendo-switch-parental-controls-notifications-write`
+  - `POST /v2/actions/user/clearAlarmSettingNotice`
+  - `POST /v2/actions/user/updateNotificationSetting`
+- `nintendo-switch-parental-controls-summary-acknowledgement-write`
+  - `POST /v3/actions/user/confirmFirstDailySummary`
+  - `POST /v3/actions/user/confirmNewMonthlySummary`
+
+## Troubleshooting
+
+- **401 or expired connection:** let vm0 refresh once, then reconnect if the request still fails. Never expose a token while debugging.
+- **Permission denied:** request only the named permission required for the user's operation. Do not weaken unknown-route or credential-read defaults.
+- **Empty or stale device catalog:** reconnect after confirming the console is linked in the official app.
+- **No play summaries:** confirm the selected device has activity for the requested period. Daily boundaries use the connector's registered app context.
+- **No player ID or GameChat data:** read daily summaries first; the player or region may not support GameChat.
+- **Schema or route error after an app update:** stop rather than guessing. Record the current app version and revalidate the protocol before changing a request.
+- **Raw logout was called:** reconnect the connector; do not silently re-federate and reverse the user's action.


### PR DESCRIPTION
## Summary

- add a security-first skill for the Nintendo Switch Parental Controls connector
- document all 15 firewall permission groups and all 46 verified routes without assuming the user's firewall policy
- provide exact query parameters or JSON request fields for every route, including the two bodyless POST operations
- explain where to obtain device, player, connection, account, federation, and etag values
- include reusable GET, JSON POST, bodyless POST, connector-health, and account-profile examples
- document read-modify-write requirements for play timers, restriction settings, notifications, device ordering, and GameChat relationships
- warn about child and household privacy, credential-bearing responses, connector lifecycle operations, and mutation targeting

## Validation

- skill-creator quick validation passed
- repository frontmatter and token-name requirements passed
- permission names match the vm0 firewall generator exactly (15/15)
- route inventory matches both the vm0 firewall generator and APK 2.4.0 interface exactly (46/46: 16 GET, 30 POST)
- APK request serializers match the documented 28 JSON bodies and 2 bodyless POST operations
- vm0 firewall route/policy integration tests passed (5/5)
- GitHub skill validation passed
- no `_ACCESS_TOKEN` references

Related to vm0-ai/vm0#20610.
