### PR TITLE
docs(nintendo): add connector intent to shared profile

### DIFF
--- a/nintendo-store/SKILL.md
+++ b/nintendo-store/SKILL.md
@@ -144,6 +144,7 @@ curl -s -G "https://api.ec.nintendo.com/v1/price" \
 
 Use connected endpoints when the user asks about account-specific data. Connect Nintendo Store under vm0.ai -> Settings -> Connectors before calling these endpoints.
 
+- Because the Nintendo Account profile route is shared with Nintendo Switch Parental Controls, include `X-VM0-Connector-Intent: nintendo-store` on `GET https://api.accounts.nintendo.com/2.0.0/users/me`. VM0 consumes and removes this private routing hint before forwarding the request to Nintendo; it is not authentication, authorization, or firewall permission policy.
 - Send `Authorization: Bearer $NINTENDO_STORE_TOKEN`.
 - vm0 injects Nintendo Store app headers, including `User-Agent` and `gentry-locale`, for allowed Store app endpoints.
 - Use `productType` values `DIGITAL` or `PHYSICAL` where required.
@@ -233,6 +234,7 @@ curl -s -X POST "https://app-api.znej.nintendo.com/api/v2.0/product_details" \
 ```bash
 curl -s "https://api.accounts.nintendo.com/2.0.0/users/me" \
   --header "Authorization: Bearer $NINTENDO_STORE_TOKEN" \
+  --header "X-VM0-Connector-Intent: nintendo-store" \
   | jq '{id, nickname, country, language, birthday, mii}'
 ```
 

--- a/nintendo-store/SKILL.md
+++ b/nintendo-store/SKILL.md
@@ -144,7 +144,7 @@ curl -s -G "https://api.ec.nintendo.com/v1/price" \
 
 Use connected endpoints when the user asks about account-specific data. Connect Nintendo Store under vm0.ai -> Settings -> Connectors before calling these endpoints.
 
-- Because the Nintendo Account profile route is shared with Nintendo Switch Parental Controls, include `X-VM0-Connector-Intent: nintendo-store` on `GET https://api.accounts.nintendo.com/2.0.0/users/me`. VM0 consumes and removes this private routing hint before forwarding the request to Nintendo; it is not authentication, authorization, or firewall permission policy.
+- For the special Nintendo Account profile request `GET https://api.accounts.nintendo.com/2.0.0/users/me`, include `X-VM0-Connector-Intent: nintendo-store`.
 - Send `Authorization: Bearer $NINTENDO_STORE_TOKEN`.
 - vm0 injects Nintendo Store app headers, including `User-Agent` and `gentry-locale`, for allowed Store app endpoints.
 - Use `productType` values `DIGITAL` or `PHYSICAL` where required.

--- a/nintendo-switch-parental-controls/SKILL.md
+++ b/nintendo-switch-parental-controls/SKILL.md
@@ -44,7 +44,7 @@ ACTION_BASE=https://app.lp1.znma.srv.nintendo.net
 ACCOUNT_BASE=https://api.accounts.nintendo.com
 ```
 
-Because the Nintendo Account profile route is shared with Nintendo Store, include `X-VM0-Connector-Intent: nintendo-switch-parental-controls` on `GET $ACCOUNT_BASE/2.0.0/users/me`. VM0 consumes and removes this private routing hint before forwarding the request to Nintendo; it is not authentication, authorization, or firewall permission policy. App actions use the separate `$ACTION_BASE` origin and do not need this selector.
+For the special Nintendo Account profile request `GET $ACCOUNT_BASE/2.0.0/users/me`, include `X-VM0-Connector-Intent: nintendo-switch-parental-controls`.
 
 For an action `GET`, pass query values with `--data-urlencode`:
 

--- a/nintendo-switch-parental-controls/SKILL.md
+++ b/nintendo-switch-parental-controls/SKILL.md
@@ -44,6 +44,8 @@ ACTION_BASE=https://app.lp1.znma.srv.nintendo.net
 ACCOUNT_BASE=https://api.accounts.nintendo.com
 ```
 
+Because the Nintendo Account profile route is shared with Nintendo Store, include `X-VM0-Connector-Intent: nintendo-switch-parental-controls` on `GET $ACCOUNT_BASE/2.0.0/users/me`. VM0 consumes and removes this private routing hint before forwarding the request to Nintendo; it is not authentication, authorization, or firewall permission policy. App actions use the separate `$ACTION_BASE` origin and do not need this selector.
+
 For an action `GET`, pass query values with `--data-urlencode`:
 
 ```bash
@@ -117,6 +119,7 @@ Account profile example:
 ```bash
 curl -fsS "$ACCOUNT_BASE/2.0.0/users/me" \
   --header "Authorization: Bearer $NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN" \
+  --header "X-VM0-Connector-Intent: nintendo-switch-parental-controls" \
   | jq '{id, nickname, country, language}'
 ```
 


### PR DESCRIPTION
## Summary

- mark the Nintendo Account profile request as a special request in both Nintendo skills
- require each connector's canonical `X-VM0-Connector-Intent` in its copyable profile request
- preserve the existing credential headers and leave all other examples unchanged

## Shared-route audit

- Railway and Railway Project: all GraphQL request examples already include canonical intent
- Instagram and Meta Ads: all Graph API request examples already include canonical intent
- Microsoft 365: all Graph request examples already include canonical intent; this repository has no Outlook skill directories
- Alchemy, Cloudflare, and the secondary Meta Ads overlap are same-owner cases
- only the two Nintendo profile provider requests required changes

## Validation

- `python3 /home/vscode/.codex/skills/.system/skill-creator/scripts/quick_validate.py nintendo-store`
- `python3 /home/vscode/.codex/skills/.system/skill-creator/scripts/quick_validate.py nintendo-switch-parental-controls`
- repository frontmatter validation: 359 `SKILL.md` files passed
- repository `_ACCESS_TOKEN` ban passed
- shared-route Bash-block audit passed for Railway, Railway Project, Microsoft 365, Instagram, Meta Ads, and both Nintendo skills
- modified skill code-fence checks passed
- `git diff --check`

## Rollout and remaining verification

- merge/rollout should follow the compatible runtime behavior in vm0-ai/vm0#21098 / vm0-ai/vm0#21109
- `cron-sync-skills` is a post-merge check because it fetches `vm0-ai/vm0-skills` from `main`; it cannot ingest this PR branch before merge
- live two-account Nintendo credential selection remains a rollout gate in delivery parent vm0-ai/vm0#21094

Closes #301

Delivery parent: vm0-ai/vm0#21094
