### PR TITLE
feat: add Google Contacts and Forms agent skills

### DIFF
--- a/google-contacts/SKILL.md
+++ b/google-contacts/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: google-contacts
+description: Google Contacts management through the People API. Use when user mentions "Google Contacts", "contacts.google.com", address books, contact groups, or asks to list, create, update, or delete Google contacts.
+---
+
+# Google Contacts
+
+Use the Google People API to read and manage the authenticated user's contacts
+and contact groups.
+
+> Official docs: `https://developers.google.com/people/api/rest/`
+
+## Prerequisites
+
+Connect the **Google Contacts** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+
+> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GOOGLE_CONTACTS_TOKEN` or `zero doctor check-connector --url https://people.googleapis.com/v1/contactGroups --method GET`
+
+## How to Use
+
+Base URL: `https://people.googleapis.com/v1`
+
+### List Contacts
+
+```bash
+curl -s "https://people.googleapis.com/v1/people/me/connections?personFields=names,emailAddresses,phoneNumbers,organizations,metadata&pageSize=1000" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN" | jq '.connections[]? | {resourceName, etag, names, emailAddresses, phoneNumbers, organizations}'
+```
+
+Use `nextPageToken` as `pageToken` to fetch another page when the response is
+paginated.
+
+### Get a Contact
+
+Replace `<person-id>` with the ID from a resource name such as
+`people/<person-id>`.
+
+```bash
+curl -s "https://people.googleapis.com/v1/people/<person-id>?personFields=names,emailAddresses,phoneNumbers,organizations,memberships,metadata" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN" | jq '{resourceName, etag, metadata, names, emailAddresses, phoneNumbers, organizations, memberships}'
+```
+
+### Create a Contact
+
+Write to `/tmp/google_contacts_request.json`:
+
+```json
+{
+  "names": [
+    {
+      "givenName": "Ada",
+      "familyName": "Lovelace"
+    }
+  ],
+  "emailAddresses": [
+    {
+      "value": "ada@example.com",
+      "type": "work"
+    }
+  ],
+  "phoneNumbers": [
+    {
+      "value": "+1 555 0100",
+      "type": "work"
+    }
+  ],
+  "organizations": [
+    {
+      "name": "Analytical Engines",
+      "title": "Mathematician",
+      "type": "work"
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://people.googleapis.com/v1/people:createContact?personFields=names,emailAddresses,phoneNumbers,organizations,metadata" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_contacts_request.json | jq '.error // {resourceName, etag, names, emailAddresses, phoneNumbers, organizations}'
+```
+
+### Update a Contact
+
+First get the contact and copy its current `metadata` object into the update
+body. Google rejects stale updates when the contact source `etag` has changed.
+
+Write to `/tmp/google_contacts_request.json`:
+
+```json
+{
+  "metadata": {
+    "sources": [
+      {
+        "type": "CONTACT",
+        "id": "<contact-source-id>",
+        "etag": "<current-source-etag>"
+      }
+    ]
+  },
+  "emailAddresses": [
+    {
+      "value": "new-address@example.com",
+      "type": "work"
+    }
+  ],
+  "phoneNumbers": [
+    {
+      "value": "+1 555 0199",
+      "type": "mobile"
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+curl -s -X PATCH "https://people.googleapis.com/v1/people/<person-id>:updateContact?updatePersonFields=emailAddresses,phoneNumbers&personFields=names,emailAddresses,phoneNumbers,metadata" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_contacts_request.json | jq '.error // {resourceName, etag, names, emailAddresses, phoneNumbers}'
+```
+
+Fields named in `updatePersonFields` are replaced, so include every value that
+should remain in those fields.
+
+### Delete a Contact
+
+```bash
+curl -s -X DELETE "https://people.googleapis.com/v1/people/<person-id>:deleteContact" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN"
+```
+
+### List Contact Groups
+
+```bash
+curl -s "https://people.googleapis.com/v1/contactGroups?pageSize=1000&groupFields=name,groupType,memberCount,metadata" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN" | jq '.contactGroups[]? | {resourceName, name, groupType, memberCount, metadata}'
+```
+
+### Create a Contact Group
+
+Write to `/tmp/google_contacts_group_request.json`:
+
+```json
+{
+  "contactGroup": {
+    "name": "Project Team"
+  }
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://people.googleapis.com/v1/contactGroups" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_contacts_group_request.json | jq '.error // {resourceName, name, groupType}'
+```
+
+### Add Contacts to a Group
+
+Write to `/tmp/google_contacts_group_members_request.json`:
+
+```json
+{
+  "resourceNamesToAdd": [
+    "people/<person-id>"
+  ]
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://people.googleapis.com/v1/contactGroups/<group-id>/members:modify" --header "Authorization: Bearer $GOOGLE_CONTACTS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_contacts_group_members_request.json | jq '.error // {notFoundResourceNames, canNotRemoveLastContactGroupResourceNames}'
+```
+
+## Guidelines
+
+1. Send mutation requests for the same Google account sequentially; the People API warns that concurrent mutations can increase latency and failures.
+2. Always request only the needed `personFields` to reduce response size.
+3. Preserve the latest contact source metadata and `etag` when updating a contact.
+4. Treat field masks as replacements: omitted values inside an updated field are removed.
+5. Use `people/<person-id>` resource names exactly as returned by the API.

--- a/google-forms/SKILL.md
+++ b/google-forms/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: google-forms
+description: Google Forms API for creating and editing forms, publishing forms, and reading responses. Use when user mentions "Google Forms", "forms.google.com", surveys, questionnaires, quizzes, or asks to manage form responses.
+---
+
+# Google Forms
+
+Use the Google Forms API to create and edit forms, control publishing, and read
+submitted responses.
+
+> Official docs: `https://developers.google.com/workspace/forms/api/reference/rest`
+
+## Prerequisites
+
+Connect the **Google Forms** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+
+> **Troubleshooting:** If requests fail, run `zero doctor check-connector --env-name GOOGLE_FORMS_TOKEN` or `zero doctor check-connector --url https://forms.googleapis.com/v1/forms/<form-id> --method GET`
+
+## How to Use
+
+Base URL: `https://forms.googleapis.com/v1`
+
+The Forms API does not provide a list endpoint. Get a form ID from a Forms URL
+(`https://docs.google.com/forms/d/<form-id>/edit`) or from `forms.create`.
+
+### Get a Form
+
+```bash
+curl -s "https://forms.googleapis.com/v1/forms/<form-id>" --header "Authorization: Bearer $GOOGLE_FORMS_TOKEN" | jq '{formId, info, settings, items, responderUri, revisionId, publishSettings}'
+```
+
+### Create an Unpublished Form
+
+The create request accepts only a title and optional document title. Add
+questions and settings afterward with `batchUpdate`.
+
+Write to `/tmp/google_forms_request.json`:
+
+```json
+{
+  "info": {
+    "title": "Customer Feedback",
+    "documentTitle": "Customer Feedback Responses"
+  }
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://forms.googleapis.com/v1/forms?unpublished=true" --header "Authorization: Bearer $GOOGLE_FORMS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_forms_request.json | jq '.error // {formId, info, responderUri, revisionId, publishSettings}'
+```
+
+### Add a Multiple-Choice Question
+
+Write to `/tmp/google_forms_batch_update.json`:
+
+```json
+{
+  "includeFormInResponse": true,
+  "requests": [
+    {
+      "createItem": {
+        "item": {
+          "title": "How satisfied are you?",
+          "questionItem": {
+            "question": {
+              "required": true,
+              "choiceQuestion": {
+                "type": "RADIO",
+                "options": [
+                  { "value": "Very satisfied" },
+                  { "value": "Satisfied" },
+                  { "value": "Neutral" },
+                  { "value": "Dissatisfied" }
+                ],
+                "shuffle": false
+              }
+            }
+          }
+        },
+        "location": {
+          "index": 0
+        }
+      }
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://forms.googleapis.com/v1/forms/<form-id>:batchUpdate" --header "Authorization: Bearer $GOOGLE_FORMS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_forms_batch_update.json | jq '.error // {form: .form, replies: .replies, writeControl: .writeControl}'
+```
+
+### Update Form Title and Description
+
+Write to `/tmp/google_forms_batch_update.json`:
+
+```json
+{
+  "includeFormInResponse": true,
+  "requests": [
+    {
+      "updateFormInfo": {
+        "info": {
+          "title": "Updated Customer Feedback",
+          "description": "Tell us about your latest experience."
+        },
+        "updateMask": "title,description"
+      }
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://forms.googleapis.com/v1/forms/<form-id>:batchUpdate" --header "Authorization: Bearer $GOOGLE_FORMS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_forms_batch_update.json | jq '.error // {info: .form.info, writeControl: .writeControl}'
+```
+
+### Publish a Form and Accept Responses
+
+Forms created through the API after June 30, 2026 are unpublished by default.
+Set both publishing state fields explicitly.
+
+Write to `/tmp/google_forms_publish.json`:
+
+```json
+{
+  "publishSettings": {
+    "publishState": {
+      "isPublished": true,
+      "isAcceptingResponses": true
+    }
+  },
+  "updateMask": "publishState"
+}
+```
+
+Then run:
+
+```bash
+curl -s -X POST "https://forms.googleapis.com/v1/forms/<form-id>:setPublishSettings" --header "Authorization: Bearer $GOOGLE_FORMS_TOKEN" --header "Content-Type: application/json" -d @/tmp/google_forms_publish.json | jq '.error // {formId, publishSettings}'
+```
+
+To stop accepting responses without unpublishing the form, set
+`isPublished` to `true` and `isAcceptingResponses` to `false`.
+
+### List Form Responses
+
+```bash
+curl -s "https://forms.googleapis.com/v1/forms/<form-id>/responses?pageSize=5000" --header "Authorization: Bearer $GOOGLE_FORMS_TOKEN" | jq '.responses[]? | {responseId, createTime, lastSubmittedTime, respondentEmail, answers}'
+```
+
+Use `nextPageToken` as `pageToken` to retrieve another page. The API also
+supports RFC 3339 timestamp filters such as `timestamp >= 2026-07-01T00:00:00Z`.
+
+### Get One Response
+
+```bash
+curl -s "https://forms.googleapis.com/v1/forms/<form-id>/responses/<response-id>" --header "Authorization: Bearer $GOOGLE_FORMS_TOKEN" | jq '{responseId, createTime, lastSubmittedTime, respondentEmail, answers}'
+```
+
+## Guidelines
+
+1. Create the empty form first, then add items and settings through `batchUpdate`.
+2. Explicitly publish new forms before sharing their responder URL.
+3. Use `writeControl.requiredRevisionId` for edits that must fail instead of overwriting a newer revision.
+4. Keep question and response IDs as opaque strings returned by the API.
+5. Use `pageToken` to paginate response collections and timestamp filters for incremental reads.


### PR DESCRIPTION
## Summary

- add a Google Contacts skill backed by the People API, covering contact and contact-group reads and mutations
- add a Google Forms skill covering form creation, batch updates, publishing, and response reads
- document connector prerequisites, runtime token names, pagination, field-mask, revision, and etag safety requirements

## User impact

Agents can use the new Google Contacts and Google Forms connectors through audited, copy-ready API examples once the companion connector change is enabled.

## Related changes

- Connector implementation: https://github.com/vm0-ai/vm0/pull/21242
- Official product icons: https://github.com/vm0-ai/static-files/pull/39

## Verification

- checked both skills against `docs/skill-template.md` and `docs/bad-smell.md`
- verified all curl examples are single-line and mutation bodies use temporary JSON files
- verified frontmatter names, connector links, token environment names, API hosts, and troubleshooting commands
