### PR TITLE
feat: add skills for the business connector backlog

### DIFF
--- a/bill/SKILL.md
+++ b/bill/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: bill
+description: BILL Spend & Expense API for budgets, users, cards, transactions, and reimbursements. Use when the user mentions BILL, Bill.com, Divvy, expense cards, budgets, or reimbursements.
+---
+
+## Prerequisites
+
+1. Connect BILL in Zero at Settings > Connectors > BILL.
+2. Requests require `BILL_TOKEN` and use the production base URL `https://gateway.prod.bill.com/connect`.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name BILL_TOKEN` or `zero doctor check-connector --url https://gateway.prod.bill.com/connect/v3/spend/budgets --method GET`.
+
+## Budgets
+
+### List Budgets
+
+```bash
+curl -sS "https://gateway.prod.bill.com/connect/v3/spend/budgets" --header "apiToken: $BILL_TOKEN" --header "Accept: application/json" | jq '[.[] | {uuid, name, limit, recurringLimit, recurringInterval, retired}]'
+```
+
+### Get a Budget
+
+```bash
+curl -sS "https://gateway.prod.bill.com/connect/v3/spend/budgets/<budget-uuid>" --header "apiToken: $BILL_TOKEN" --header "Accept: application/json" | jq '{uuid, name, limit, recurringLimit, recurringInterval, owners, members, retired}'
+```
+
+### Create a Budget
+
+Write to `/tmp/bill_budget.json`:
+
+```json
+{
+  "name": "Engineering tools",
+  "owners": ["<owner-user-uuid>"],
+  "recurringInterval": "MONTHLY",
+  "recurringLimit": 1000,
+  "receiptRequired": true
+}
+```
+
+```bash
+curl -sS -X POST "https://gateway.prod.bill.com/connect/v3/spend/budgets" --header "apiToken: $BILL_TOKEN" --header "Content-Type: application/json" --header "Accept: application/json" -d @/tmp/bill_budget.json | jq '{uuid, name, recurringLimit, recurringInterval}'
+```
+
+## Users and Cards
+
+### List Users
+
+```bash
+curl -sS "https://gateway.prod.bill.com/connect/v3/spend/users" --header "apiToken: $BILL_TOKEN" --header "Accept: application/json" | jq '[.[] | {uuid, firstName, lastName, email, role, retired}]'
+```
+
+### List Vendor Cards
+
+```bash
+curl -sS "https://gateway.prod.bill.com/connect/v3/spend/cards" --header "apiToken: $BILL_TOKEN" --header "Accept: application/json" | jq '[.[] | {uuid, cardName, status, lastFour, userUuid, budgetUuid}]'
+```
+
+## Transactions and Reimbursements
+
+### List Transactions
+
+```bash
+curl -sS "https://gateway.prod.bill.com/connect/v3/spend/transactions" --header "apiToken: $BILL_TOKEN" --header "Accept: application/json" | jq '[.[] | {uuid, transactionType, merchantName, amount, status, transactionTime, userUuid, budgetUuid}]'
+```
+
+### List Reimbursements
+
+```bash
+curl -sS "https://gateway.prod.bill.com/connect/v3/spend/reimbursements" --header "apiToken: $BILL_TOKEN" --header "Accept: application/json" | jq '[.[] | {uuid, amount, status, merchantName, userUuid, createdTime}]'
+```
+
+## Guidelines
+
+1. The `apiToken` header is case-sensitive; do not use Bearer authentication.
+2. Ask before creating users, cards, budgets, or reimbursements because these change financial controls.
+3. Treat card details and transaction data as sensitive financial information.
+4. BILL limits Spend & Expense API traffic to 60 requests per token per minute.
+
+## API Reference
+
+- https://developer.bill.com/docs/spend-expense-api
+- https://developer.bill.com/docs/authentication-with-api-token

--- a/cal-com/SKILL.md
+++ b/cal-com/SKILL.md
@@ -3,6 +3,11 @@ name: cal-com
 description: Cal.com open-source scheduling API. Use when user mentions "Cal.com", "cal.com", "open source scheduling", "booking", "event types", or asks about interview or meeting scheduling.
 ---
 
+## Prerequisites
+
+1. Connect Cal.com in Zero at Settings > Connectors > Cal.com.
+2. Requests require `CALCOM_TOKEN`. Zero supplies the same environment variable for OAuth and API token connections.
+
 ## Troubleshooting
 
 If requests fail, run `zero doctor check-connector --env-name CALCOM_TOKEN` or `zero doctor check-connector --url https://api.cal.com/v2/me --method GET`
@@ -12,7 +17,7 @@ If requests fail, run `zero doctor check-connector --env-name CALCOM_TOKEN` or `
 ### Get Current User
 
 ```bash
-curl -s "https://api.cal.com/v2/me" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '{id, email, name, username, timeZone}'
+curl -s "https://api.cal.com/v2/me" --header "Authorization: Bearer $CALCOM_TOKEN" --header "cal-api-version: 2024-08-13" | jq '.data | {id, email, name, username, timeZone}'
 ```
 
 ### List Event Types
@@ -113,9 +118,9 @@ curl -s -X POST "https://api.cal.com/v2/bookings/<booking-uid>/reschedule" --hea
 ## Guidelines
 
 1. **API version header**: Always include `cal-api-version: 2024-08-13` — requests without this header will fail.
-2. **API key prefix**: Cal.com API keys are prefixed with `cal_live_` (production) or `cal_test_` (test environment).
+2. **Authentication**: Zero refreshes OAuth tokens automatically. API keys use the `cal_live_` prefix for live environments and `cal_` for test environments.
 3. **eventTypeId**: Required when creating a booking — get it from the List Event Types endpoint.
 4. **Timestamps**: Use ISO 8601 format with UTC timezone (e.g., `2025-01-20T14:00:00.000Z`).
 5. **Rate limits**: 120 requests per minute with API key auth. Response headers include `X-RateLimit-Remaining`.
-6. **Self-hosted**: If using a self-hosted Cal.com instance, replace `api.cal.com` with your own domain.
+6. **Hosted API**: The Zero connector allows requests to the hosted `api.cal.com` API.
 7. **Booking confirmation**: If an event type requires manual confirmation, bookings start with `pending` status until confirmed.

--- a/copper/SKILL.md
+++ b/copper/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: copper
+description: Copper CRM Developer API for people, companies, leads, opportunities, projects, tasks, and activities. Use when the user mentions Copper CRM, sales pipelines, leads, or opportunities.
+---
+
+## Prerequisites
+
+1. Connect Copper in Zero at Settings > Connectors > Copper.
+2. Requests require `COPPER_TOKEN` and use `https://api.copper.com/developer_api/v1`.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name COPPER_TOKEN` or `zero doctor check-connector --url https://api.copper.com/developer_api/v1/account --method GET`.
+
+## Account
+
+### Get Account Details
+
+```bash
+curl -sS "https://api.copper.com/developer_api/v1/account" --header "Authorization: Bearer $COPPER_TOKEN" | jq '{id, name, primary_timezone, settings}'
+```
+
+## People and Companies
+
+### Search People
+
+Write to `/tmp/copper_people_search.json`:
+
+```json
+{
+  "page_size": 50,
+  "sort_by": "name",
+  "sort_direction": "asc"
+}
+```
+
+```bash
+curl -sS -X POST "https://api.copper.com/developer_api/v1/people/search" --header "Authorization: Bearer $COPPER_TOKEN" --header "Content-Type: application/json" -d @/tmp/copper_people_search.json | jq '[.[] | {id, name, emails, company_name, title}]'
+```
+
+### Get a Person
+
+```bash
+curl -sS "https://api.copper.com/developer_api/v1/people/<person-id>" --header "Authorization: Bearer $COPPER_TOKEN" | jq '{id, name, emails, phone_numbers, company_name, title, details}'
+```
+
+### Search Companies
+
+```bash
+curl -sS -X POST "https://api.copper.com/developer_api/v1/companies/search" --header "Authorization: Bearer $COPPER_TOKEN" --header "Content-Type: application/json" -d @/tmp/copper_people_search.json | jq '[.[] | {id, name, email_domain, phone_numbers, address}]'
+```
+
+## Leads and Opportunities
+
+### Search Leads
+
+```bash
+curl -sS -X POST "https://api.copper.com/developer_api/v1/leads/search" --header "Authorization: Bearer $COPPER_TOKEN" --header "Content-Type: application/json" -d @/tmp/copper_people_search.json | jq '[.[] | {id, name, company_name, status_id, assignee_id, monetary_value}]'
+```
+
+### Search Opportunities
+
+```bash
+curl -sS -X POST "https://api.copper.com/developer_api/v1/opportunities/search" --header "Authorization: Bearer $COPPER_TOKEN" --header "Content-Type: application/json" -d @/tmp/copper_people_search.json | jq '[.[] | {id, name, company_id, pipeline_id, pipeline_stage_id, status, monetary_value, close_date}]'
+```
+
+### Update an Opportunity
+
+Write only changed fields to `/tmp/copper_opportunity.json`:
+
+```json
+{
+  "name": "Enterprise renewal",
+  "monetary_value": 25000
+}
+```
+
+```bash
+curl -sS -X PUT "https://api.copper.com/developer_api/v1/opportunities/<opportunity-id>" --header "Authorization: Bearer $COPPER_TOKEN" --header "Content-Type: application/json" -d @/tmp/copper_opportunity.json | jq '{id, name, monetary_value, status, close_date}'
+```
+
+## Guidelines
+
+1. Copper search endpoints use `POST` even though they only read data.
+2. Resolve pipeline and stage IDs before changing opportunity stages.
+3. Ask before creating, updating, or deleting CRM records.
+4. Access tokens currently do not expire; never display or log `COPPER_TOKEN`.
+
+## API Reference
+
+- https://developer.copper.com/
+- https://developer.copper.com/introduction/oauth/flow.html

--- a/datadog/SKILL.md
+++ b/datadog/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: datadog
+description: Datadog API for logs, metrics, traces, monitors, dashboards, incidents, events, and service health. Use when the user mentions Datadog, observability, logs, monitors, traces, or incidents.
+---
+
+## Prerequisites
+
+1. Connect Datadog in Zero at Settings > Connectors > Datadog.
+2. Requests require `DATADOG_TOKEN` and `DATADOG_DOMAIN`.
+3. Use `https://api.$DATADOG_DOMAIN`; do not hardcode a Datadog region.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name DATADOG_TOKEN` or check a concrete endpoint with `zero doctor check-connector --url https://api.$DATADOG_DOMAIN/api/v1/dashboard --method GET`.
+
+## Monitors and Dashboards
+
+### List Monitors
+
+```bash
+curl -sS "https://api.$DATADOG_DOMAIN/api/v1/monitor" --header "Authorization: Bearer $DATADOG_TOKEN" --header "Accept: application/json" | jq '[.[] | {id, name, type, overall_state, tags, modified}]'
+```
+
+### Get a Monitor
+
+```bash
+curl -sS "https://api.$DATADOG_DOMAIN/api/v1/monitor/<monitor-id>" --header "Authorization: Bearer $DATADOG_TOKEN" --header "Accept: application/json" | jq '{id, name, type, query, message, overall_state, tags, options}'
+```
+
+### List Dashboards
+
+```bash
+curl -sS "https://api.$DATADOG_DOMAIN/api/v1/dashboard" --header "Authorization: Bearer $DATADOG_TOKEN" --header "Accept: application/json" | jq '[.dashboards[] | {id, title, layout_type, modified_at, author_handle}]'
+```
+
+## Logs
+
+### Search Recent Error Logs
+
+Write to `/tmp/datadog_logs_search.json`:
+
+```json
+{
+  "filter": {
+    "query": "status:error",
+    "from": "now-1h",
+    "to": "now"
+  },
+  "sort": "-timestamp",
+  "page": {
+    "limit": 50
+  }
+}
+```
+
+```bash
+curl -sS -X POST "https://api.$DATADOG_DOMAIN/api/v2/logs/events/search" --header "Authorization: Bearer $DATADOG_TOKEN" --header "Content-Type: application/json" -d @/tmp/datadog_logs_search.json | jq '[.data[] | {id, timestamp: .attributes.timestamp, service: .attributes.service, status: .attributes.status, message: .attributes.message}]'
+```
+
+## Metrics and Events
+
+### Query Metrics
+
+Unix timestamps are required for `from` and `to`.
+
+```bash
+curl -sS --get "https://api.$DATADOG_DOMAIN/api/v1/query" --header "Authorization: Bearer $DATADOG_TOKEN" --data-urlencode "from=<unix-start>" --data-urlencode "to=<unix-end>" --data-urlencode "query=avg:system.cpu.user{*}" | jq '[.series[] | {metric, scope, pointlist}]'
+```
+
+### Search Events
+
+```bash
+curl -sS "https://api.$DATADOG_DOMAIN/api/v2/events?filter[from]=now-1h&filter[to]=now&page[limit]=50" --header "Authorization: Bearer $DATADOG_TOKEN" --header "Accept: application/json" | jq '[.data[] | {id, type, attributes: {title: .attributes.attributes.title, timestamp: .attributes.attributes.timestamp}}]'
+```
+
+## Guidelines
+
+1. Preserve `DATADOG_DOMAIN`; OAuth returns the correct region for the connected organization.
+2. OAuth scopes vary by endpoint. A 403 often means the integration needs an additional scope or the user lacks the corresponding Datadog permission.
+3. Use narrow time ranges for logs and metrics, then paginate with the returned cursor.
+4. Ask before muting, editing, or deleting monitors and incidents.
+
+## API Reference
+
+- https://docs.datadoghq.com/api/latest/
+- https://docs.datadoghq.com/extend/authorization/oauth2_in_datadog/

--- a/docs/saas.md
+++ b/docs/saas.md
@@ -79,7 +79,7 @@
 - [x] [Monday.com](https://developer.monday.com/api-reference/) - Project Management Platform
 - [ ] [IONOS](https://docs.ionos.com/reference) - Cloud Infrastructure Service
 - [x] [short.io](https://developers.short.io/docs) - URL Shortener Service
-- [ ] [NetSuite](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/book_1559132836.html) - Oracle ERP System
+- [x] [NetSuite](https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/book_1559132836.html) - Oracle ERP System
 - [x] [Streak CRM](https://streak.readme.io/) - Gmail CRM
 - [x] [Linear](https://developers.linear.app/docs) - Issue Tracking & Project Management
 - [x] [Jira](https://developer.atlassian.com/cloud/jira/platform/rest/v3/) - Project Management & Issue Tracking
@@ -121,7 +121,7 @@
 - [x] [Semrush](https://developer.semrush.com/api/get-started/quick-start/) - SEO, keyword, backlink, and competitive intelligence API
 - [x] [Profound](https://docs.tryprofound.com/rest-api/introduction) - AI search visibility, citations, sentiment, fanout, and Agent Analytics API
 - [x] [Massive](https://massive.com/docs/rest/quickstart) - Market data API for stocks, options, forex, crypto, and indices
-- [ ] [Datadog](https://docs.datadoghq.com/api/) - Infrastructure Monitoring & APM
+- [x] [Datadog](https://docs.datadoghq.com/api/) - Infrastructure Monitoring & APM
 - [ ] [Airbyte](https://docs.airbyte.com/api-documentation) - Data Integration Platform
 - [ ] [Retool](https://docs.retool.com/docs) - Internal Tool Builder
 - [ ] [Fivetran](https://fivetran.com/docs/rest-api) - Data Pipeline Service

--- a/expensify/SKILL.md
+++ b/expensify/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: expensify
+description: Expensify Integration Server API for exporting expense reports, reconciling transactions, and updating report status. Use when the user mentions Expensify, expense reports, receipts, or reconciliation.
+---
+
+## Prerequisites
+
+1. Connect Expensify in Zero at Settings > Connectors > Expensify.
+2. Requests require `EXPENSIFY_PARTNER_USER_ID` and `EXPENSIFY_PARTNER_USER_SECRET`.
+3. All requests use `https://integrations.expensify.com/Integration-Server/ExpensifyIntegrations`.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --url https://integrations.expensify.com/Integration-Server/ExpensifyIntegrations --method POST`.
+
+## Export Reports
+
+Write the job description template to `/tmp/expensify_job_template.json`:
+
+```json
+{
+  "type": "file",
+  "credentials": {
+    "partnerUserID": "",
+    "partnerUserSecret": ""
+  },
+  "onReceive": {
+    "immediateResponse": ["returnRandomFileName"]
+  },
+  "inputSettings": {
+    "type": "combinedReportData",
+    "filters": {
+      "startDate": "2026-07-01",
+      "endDate": "2026-07-31",
+      "reportState": "APPROVED,REIMBURSED"
+    }
+  },
+  "outputSettings": {
+    "fileExtension": "json"
+  }
+}
+```
+
+Inject the connector credentials into a temporary request without printing them, then run the export:
+
+```bash
+jq --arg user "$EXPENSIFY_PARTNER_USER_ID" --arg secret "$EXPENSIFY_PARTNER_USER_SECRET" '.credentials.partnerUserID = $user | .credentials.partnerUserSecret = $secret' /tmp/expensify_job_template.json > /tmp/expensify_job.json
+```
+
+```bash
+curl -sS -X POST "https://integrations.expensify.com/Integration-Server/ExpensifyIntegrations" --data-urlencode "requestJobDescription@/tmp/expensify_job.json"
+```
+
+The response is a generated file name. Write `/tmp/expensify_download_template.json` with that value:
+
+```json
+{
+  "type": "download",
+  "credentials": {
+    "partnerUserID": "",
+    "partnerUserSecret": ""
+  },
+  "fileName": "<generated-file-name>",
+  "fileSystem": "integrationServer"
+}
+```
+
+Inject the credentials and download the export:
+
+```bash
+jq --arg user "$EXPENSIFY_PARTNER_USER_ID" --arg secret "$EXPENSIFY_PARTNER_USER_SECRET" '.credentials.partnerUserID = $user | .credentials.partnerUserSecret = $secret' /tmp/expensify_download_template.json > /tmp/expensify_download.json
+```
+
+```bash
+curl -sS --get "https://integrations.expensify.com/Integration-Server/ExpensifyIntegrations" --data-urlencode "requestJobDescription@/tmp/expensify_download.json" --output /tmp/expensify_export.json
+```
+
+## Report Templates
+
+For CSV exports, add a `template` field containing an Expensify FreeMarker template and set `fileExtension` to `csv`. Keep templates in a separate file when they are longer than a few lines.
+
+## Guidelines
+
+1. Expensify credentials are embedded in `requestJobDescription`; never log the completed payload.
+2. Exports are asynchronous file jobs. Save the returned file name and download it in a second request.
+3. Use the narrowest date range and report state filter that answers the request.
+4. Ask before marking reports, reimbursing expenses, or changing report state.
+5. Delete local exports after use because they contain sensitive employee and financial data.
+6. Delete completed credential-bearing request files from `/tmp` after each operation.
+
+## API Reference
+
+- https://integrations.expensify.com/Integration-Server/doc/

--- a/finicity/SKILL.md
+++ b/finicity/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: finicity
+description: Use vm0's managed banking gateway backed by Finicity to list enabled bank accounts, balances, and transactions. Use when the user mentions Finicity, connected bank accounts, banking balances, or bank transactions.
+---
+
+## Prerequisites
+
+1. Authenticate Zero CLI with `ZERO_TOKEN` carrying the `banking:read` capability.
+2. The vm0 administrator must enable the relevant Finicity-backed accounts for the current agent.
+3. Finicity credentials and app tokens remain server-side; do not request them from the user.
+
+## List Accounts
+
+```bash
+zero banking accounts --json | jq '{provider, accounts}'
+```
+
+Use the returned account `id` for balance and transaction requests.
+
+## Get an Account Balance
+
+```bash
+zero banking balances --account-id <account-id> --json | jq '{provider, balance}'
+```
+
+## List Transactions
+
+Dates must use `YYYY-MM-DD`. Limits must be between 1 and 1000.
+
+```bash
+zero banking transactions --account-id <account-id> --from 2026-07-01 --to 2026-07-31 --limit 100 --json | jq '{provider, transactions}'
+```
+
+## Guidelines
+
+1. Use `zero banking`; do not call Finicity APIs directly or ask for Finicity partner credentials.
+2. Access is limited to accounts enabled for the current agent.
+3. Treat account identifiers, balances, and transactions as sensitive financial data.
+4. Use the narrowest date range needed and avoid retaining raw banking responses.
+5. Banking commands are read-only; do not imply that transfers or account changes are supported.
+
+## Troubleshooting
+
+If a banking command is unavailable or returns an authorization error, verify the current Zero authentication and ask an administrator to confirm the `banking:read` capability and enabled account access.

--- a/netsuite/SKILL.md
+++ b/netsuite/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: netsuite
+description: Oracle NetSuite REST Web Services, SuiteQL, and RESTlets for ERP, accounting, CRM, inventory, and business operations. Use when the user mentions NetSuite, SuiteQL, SuiteTalk, or RESTlets.
+---
+
+## Prerequisites
+
+1. Connect NetSuite in Zero at Settings > Connectors > NetSuite.
+2. Requests require `NETSUITE_TOKEN` and `NETSUITE_ACCOUNT_SUBDOMAIN`.
+3. REST Web Services use `https://$NETSUITE_ACCOUNT_SUBDOMAIN.suitetalk.api.netsuite.com`.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name NETSUITE_TOKEN` or `zero doctor check-connector --url https://$NETSUITE_ACCOUNT_SUBDOMAIN.suitetalk.api.netsuite.com/services/rest/record/v1/metadata-catalog --method GET`.
+
+## SuiteQL
+
+### Run a Query
+
+Write to `/tmp/netsuite_suiteql.json`:
+
+```json
+{
+  "q": "SELECT id, companyname, email FROM customer ORDER BY id FETCH FIRST 50 ROWS ONLY"
+}
+```
+
+```bash
+curl -sS -X POST "https://$NETSUITE_ACCOUNT_SUBDOMAIN.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=50" --header "Authorization: Bearer $NETSUITE_TOKEN" --header "Content-Type: application/json" --header "Prefer: transient" -d @/tmp/netsuite_suiteql.json | jq '{count, hasMore, items}'
+```
+
+### Paginate SuiteQL Results
+
+```bash
+curl -sS -X POST "https://$NETSUITE_ACCOUNT_SUBDOMAIN.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=100&offset=<offset>" --header "Authorization: Bearer $NETSUITE_TOKEN" --header "Content-Type: application/json" --header "Prefer: transient" -d @/tmp/netsuite_suiteql.json | jq '{count, offset, totalResults, hasMore, items}'
+```
+
+## Records
+
+### List Customers
+
+```bash
+curl -sS "https://$NETSUITE_ACCOUNT_SUBDOMAIN.suitetalk.api.netsuite.com/services/rest/record/v1/customer?limit=50" --header "Authorization: Bearer $NETSUITE_TOKEN" --header "Accept: application/json" | jq '{count, hasMore, items: [.items[] | {id, refName, links}]}'
+```
+
+### Get a Record
+
+```bash
+curl -sS "https://$NETSUITE_ACCOUNT_SUBDOMAIN.suitetalk.api.netsuite.com/services/rest/record/v1/<record-type>/<record-id>" --header "Authorization: Bearer $NETSUITE_TOKEN" --header "Accept: application/json" | jq '{id, externalId, entityId, companyName, email, links}'
+```
+
+### Create a Customer
+
+Write to `/tmp/netsuite_customer.json`:
+
+```json
+{
+  "companyName": "Acme Corp",
+  "email": "billing@example.com",
+  "subsidiary": {
+    "id": "<subsidiary-id>"
+  }
+}
+```
+
+```bash
+curl -sS -D /tmp/netsuite_headers.txt -o /tmp/netsuite_response.json -X POST "https://$NETSUITE_ACCOUNT_SUBDOMAIN.suitetalk.api.netsuite.com/services/rest/record/v1/customer" --header "Authorization: Bearer $NETSUITE_TOKEN" --header "Content-Type: application/json" -d @/tmp/netsuite_customer.json
+```
+
+The created record URL is returned in the `Location` response header.
+
+## RESTlets
+
+```bash
+curl -sS "https://$NETSUITE_ACCOUNT_SUBDOMAIN.restlets.api.netsuite.com/app/site/hosting/restlet.nl?script=<script-id>&deploy=<deployment-id>" --header "Authorization: Bearer $NETSUITE_TOKEN" --header "Accept: application/json" | jq '{status, data, error}'
+```
+
+## Guidelines
+
+1. Use the account domain prefix such as `1234567-sb1`, not the display account ID `1234567_SB1`.
+2. SuiteQL requests require `Prefer: transient`.
+3. Record schemas and required fields vary by enabled features and subsidiaries; inspect the metadata catalog before writes.
+4. Ask before creating, updating, or deleting ERP records.
+5. NetSuite governance limits apply. Paginate and back off on 429 responses.
+
+## API Reference
+
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/book_1559132836.html

--- a/paypal/SKILL.md
+++ b/paypal/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: paypal
+description: PayPal REST APIs for orders, payments, invoices, payouts, disputes, and transaction reporting. Use when the user mentions PayPal, payment orders, captures, invoices, payouts, or disputes.
+---
+
+## Prerequisites
+
+1. Connect PayPal in Zero at Settings > Connectors > PayPal.
+2. Requests require `PAYPAL_TOKEN` and use `https://api-m.paypal.com`.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name PAYPAL_TOKEN` or `zero doctor check-connector --url https://api-m.paypal.com/v1/reporting/balances --method GET`.
+
+## Orders
+
+### Get an Order
+
+```bash
+curl -sS "https://api-m.paypal.com/v2/checkout/orders/<order-id>" --header "Authorization: Bearer $PAYPAL_TOKEN" --header "Accept: application/json" | jq '{id, status, intent, purchase_units, payer}'
+```
+
+### Create an Order
+
+Write to `/tmp/paypal_order.json`:
+
+```json
+{
+  "intent": "CAPTURE",
+  "purchase_units": [
+    {
+      "reference_id": "order-123",
+      "amount": {
+        "currency_code": "USD",
+        "value": "25.00"
+      }
+    }
+  ]
+}
+```
+
+```bash
+curl -sS -X POST "https://api-m.paypal.com/v2/checkout/orders" --header "Authorization: Bearer $PAYPAL_TOKEN" --header "Content-Type: application/json" --header "PayPal-Request-Id: <unique-idempotency-key>" -d @/tmp/paypal_order.json | jq '{id, status, links}'
+```
+
+### Capture an Approved Order
+
+```bash
+curl -sS -X POST "https://api-m.paypal.com/v2/checkout/orders/<order-id>/capture" --header "Authorization: Bearer $PAYPAL_TOKEN" --header "Content-Type: application/json" --header "PayPal-Request-Id: <unique-idempotency-key>" | jq '{id, status, purchase_units}'
+```
+
+## Reporting
+
+### List Transactions
+
+Timestamps must be RFC 3339 and the date range must not exceed the endpoint limit.
+
+```bash
+curl -sS --get "https://api-m.paypal.com/v1/reporting/transactions" --header "Authorization: Bearer $PAYPAL_TOKEN" --data-urlencode "start_date=2026-07-01T00:00:00Z" --data-urlencode "end_date=2026-07-31T23:59:59Z" --data-urlencode "fields=all" --data-urlencode "page_size=100" | jq '{total_items, total_pages, transaction_details: [.transaction_details[] | {transaction_info, payer_info, cart_info}]}'
+```
+
+### Get Balances
+
+```bash
+curl -sS "https://api-m.paypal.com/v1/reporting/balances" --header "Authorization: Bearer $PAYPAL_TOKEN" --header "Accept: application/json" | jq '{balances, account_id, as_of_time}'
+```
+
+## Invoices
+
+### List Invoices
+
+```bash
+curl -sS "https://api-m.paypal.com/v2/invoicing/invoices?page=1&page_size=20&total_required=true" --header "Authorization: Bearer $PAYPAL_TOKEN" --header "Accept: application/json" | jq '{total_items, total_pages, items: [.items[] | {id, status, detail, amount}]}'
+```
+
+## Guidelines
+
+1. This connector uses live PayPal APIs. Confirm amounts, currency, recipient, and intent before any payment mutation.
+2. Use a unique `PayPal-Request-Id` for idempotent create and capture operations.
+3. Never capture, refund, or send a payout without explicit user authorization.
+4. A 403 can mean the PayPal REST app lacks the product permission required by the endpoint.
+
+## API Reference
+
+- https://developer.paypal.com/api/rest/
+- https://developer.paypal.com/api/rest/authentication/

--- a/ramp/SKILL.md
+++ b/ramp/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: ramp
+description: Ramp developer API for cards, transactions, receipts, reimbursements, users, and spend controls. Use when the user mentions Ramp, corporate cards, spend management, receipts, or reimbursements.
+---
+
+## Prerequisites
+
+1. Connect Ramp in Zero at Settings > Connectors > Ramp.
+2. Requests require `RAMP_TOKEN` and use `https://api.ramp.com/developer/v1`.
+3. The connected app must include the OAuth scopes required by each endpoint.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name RAMP_TOKEN` or `zero doctor check-connector --url https://api.ramp.com/developer/v1/users --method GET`.
+
+## Users and Cards
+
+### List Users
+
+```bash
+curl -sS "https://api.ramp.com/developer/v1/users?page_size=50" --header "Authorization: Bearer $RAMP_TOKEN" --header "Accept: application/json" | jq '{page, data: [.data[] | {id, first_name, last_name, email, status, department_id, location_id}]}'
+```
+
+### List Cards
+
+```bash
+curl -sS "https://api.ramp.com/developer/v1/cards?page_size=50" --header "Authorization: Bearer $RAMP_TOKEN" --header "Accept: application/json" | jq '{page, data: [.data[] | {id, display_name, state, cardholder_id, card_program_id, spending_restrictions}]}'
+```
+
+## Transactions and Receipts
+
+### List Transactions
+
+```bash
+curl -sS --get "https://api.ramp.com/developer/v1/transactions" --header "Authorization: Bearer $RAMP_TOKEN" --data-urlencode "page_size=50" --data-urlencode "from_date=2026-07-01T00:00:00Z" --data-urlencode "to_date=2026-07-31T23:59:59Z" | jq '{page, data: [.data[] | {id, amount, merchant_name, state, transaction_date, card_id, user_id}]}'
+```
+
+### Get a Transaction
+
+```bash
+curl -sS "https://api.ramp.com/developer/v1/transactions/<transaction-id>" --header "Authorization: Bearer $RAMP_TOKEN" --header "Accept: application/json" | jq '{id, amount, merchant_name, state, transaction_date, card_id, user_id, receipts, accounting_category}'
+```
+
+### List Receipts
+
+```bash
+curl -sS "https://api.ramp.com/developer/v1/receipts?page_size=50" --header "Authorization: Bearer $RAMP_TOKEN" --header "Accept: application/json" | jq '{page, data: [.data[] | {id, transaction_id, user_id, receipt_url, created_at}]}'
+```
+
+## Reimbursements
+
+### List Reimbursements
+
+```bash
+curl -sS "https://api.ramp.com/developer/v1/reimbursements?page_size=50" --header "Authorization: Bearer $RAMP_TOKEN" --header "Accept: application/json" | jq '{page, data: [.data[] | {id, amount, merchant_name, status, user_id, created_at}]}'
+```
+
+## Guidelines
+
+1. Ramp uses short-lived access tokens; Zero refreshes the client-credentials token automatically.
+2. A 403 usually means the connected app is missing the endpoint's scope.
+3. Follow pagination links or cursors from the response instead of assuming all records fit in one page.
+4. Ask before changing spend controls, cards, users, or reimbursements.
+5. Treat card, receipt, and transaction data as sensitive financial information.
+
+## API Reference
+
+- https://docs.ramp.com/developer-api/v1/
+- https://docs.ramp.com/developer-api/v1/authentication/

--- a/workday/SKILL.md
+++ b/workday/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: workday
+description: Workday REST APIs for HCM, staffing, recruiting, finance, and tenant data. Use when the user mentions Workday, workers, staffing, recruiting, HRIS, or Workday finance.
+---
+
+## Prerequisites
+
+1. Connect Workday in Zero at Settings > Connectors > Workday.
+2. Requests require `WORKDAY_TOKEN`, `WORKDAY_HOST`, and `WORKDAY_TENANT`.
+3. API service names and versions depend on the connected Workday tenant.
+
+## Troubleshooting
+
+If requests fail, run `zero doctor check-connector --env-name WORKDAY_TOKEN` or check a concrete tenant endpoint with `zero doctor check-connector --url https://$WORKDAY_HOST/api/staffing/v7/$WORKDAY_TENANT/workers --method GET`.
+
+## Workers
+
+### List Workers
+
+Replace `<staffing-version>` with a version enabled in the tenant.
+
+```bash
+curl -sS --get "https://$WORKDAY_HOST/api/staffing/<staffing-version>/$WORKDAY_TENANT/workers" --header "Authorization: Bearer $WORKDAY_TOKEN" --header "Accept: application/json" --data-urlencode "limit=50" | jq '{total, data: [.data[] | {id, descriptor, href}]}'
+```
+
+### Get a Worker
+
+```bash
+curl -sS "https://$WORKDAY_HOST/api/staffing/<staffing-version>/$WORKDAY_TENANT/workers/<worker-id>" --header "Authorization: Bearer $WORKDAY_TOKEN" --header "Accept: application/json" | jq '{id, descriptor, person, position, organization, status}'
+```
+
+## Workday Query Language
+
+### List Available Data Sources
+
+```bash
+curl -sS "https://$WORKDAY_HOST/api/wql/v1/$WORKDAY_TENANT/dataSources" --header "Authorization: Bearer $WORKDAY_TOKEN" --header "Accept: application/json" | jq '{total, data: [.data[] | {id, name, description}]}'
+```
+
+### Run a WQL Query
+
+```bash
+curl -sS --get "https://$WORKDAY_HOST/api/wql/v1/$WORKDAY_TENANT/data" --header "Authorization: Bearer $WORKDAY_TOKEN" --header "Accept: application/json" --data-urlencode "query=SELECT worker FROM allWorkers LIMIT 50" | jq '{total, data}'
+```
+
+## Other Tenant Services
+
+Use the same URL structure for enabled APIs:
+
+```text
+https://$WORKDAY_HOST/api/<service>/<version>/$WORKDAY_TENANT/<resource>
+```
+
+Common services include `staffing`, `recruiting`, `organizations`, and finance APIs. Discover the exact service version and resource schema from the Workday REST API Explorer for the tenant.
+
+## Guidelines
+
+1. Zero refreshes the Workday access token automatically with the integration user's refresh token.
+2. Do not infer service versions or field schemas; Workday availability varies by release, tenant configuration, and security group.
+3. Use narrow WQL projections and limits because worker and finance data can be large and sensitive.
+4. Ask before changing worker, recruiting, payroll, or finance records.
+5. Never expose worker personal data, compensation, or credentials in logs.
+
+## API Reference
+
+- https://community.workday.com/sites/default/files/file-hosting/restapi/index.html
+- https://community.workday.com/sites/default/files/file-hosting/restapi/index.html#workday-query-language-wql


### PR DESCRIPTION
## Summary

- add agent-ready API instructions for BILL, Copper, Datadog, Expensify, NetSuite, PayPal, Ramp, and Workday
- document the managed Finicity-backed `zero banking` gateway without exposing provider credentials
- update Cal.com guidance for OAuth token refresh, hosted API access, and the corrected v2 response shape
- mark Datadog and NetSuite complete in the SaaS coverage checklist

## User impact

Agents get practical read and guarded-write examples for every new connector in the paired vm0 catalog change. Financial and HR mutations explicitly require confirmation, and credential-bearing Expensify payloads stay in temporary files.

## Verification

- all 10 affected skill folders pass `quick_validate.py`
- all repository `SKILL.md` frontmatter parses and contains required fields
- no banned `_ACCESS_TOKEN` references
- `git diff --check`

## Related

- vm0-ai/vm0#21277
- vm0-ai/static-files#40