### PR TITLE
fix(computer-use): scope the description to the connected desktop host

### DIFF
--- a/computer-use/SKILL.md
+++ b/computer-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: computer-use
-description: Operate connected desktop apps or GUI workflows through Zero Computer Use when APIs are not enough.
+description: Operate apps on the desktop host the user connected to Zero Computer Use, when APIs are not enough. Not for remote browser sessions, which are Zero Browser (`zero browser use`).
 ---
 
 # Computer Use


### PR DESCRIPTION
## Why

Agents pick `computer-use` for explicit "zero browser" requests. Run logs show the choice being made **before** the skill body is read, so the routing signal is the one-line description, not the instructions.

The old description — "Operate connected desktop apps or GUI workflows through Zero Computer Use" — is the most visible browser-shaped capability in the skill list, and nothing in it says the desktop host is a separate surface from Zero's managed remote browser.

## What changed

One line. The description now names the surface it actually drives (the desktop host the user connected) and points remote browser work at Zero Browser.

## Companion PR

vm0-ai/vm0#23037 adds the matching stable facts to the Zero system prompt: Zero Browser and Zero Computer Use are separate surfaces, and running `agent-browser` alone creates no managed session. The two changes are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)