### PR TITLE
fix: use Okou token in Finicity skill

### DIFF
--- a/finicity/SKILL.md
+++ b/finicity/SKILL.md
@@ -5,7 +5,7 @@ description: Use vm0's managed banking gateway backed by Finicity to list enable
 
 ## Prerequisites
 
-1. Authenticate Okou CLI with `ZERO_TOKEN` carrying the `banking:read` capability.
+1. Authenticate Okou CLI with `OKOU_TOKEN` carrying the `banking:read` capability.
 2. The vm0 administrator must enable the relevant Finicity-backed accounts for the current agent.
 3. Finicity credentials and app tokens remain server-side; do not request them from the user.
 


### PR DESCRIPTION
## Summary

- replace the lingering ZERO_TOKEN authentication reference with canonical OKOU_TOKEN
- confirm all seed and first-party skills use the Okou CLI surface

## Validation

- validated frontmatter for all 93 SKILL.md files
- confirmed no legacy ZERO_TOKEN, @vm0/cli, or executable zero CLI references remain
- passed git diff --check