### PR TITLE
fix(rebranding): neutralize shared skill brand copy

### DIFF
--- a/computer-use/SKILL.md
+++ b/computer-use/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: computer-use
-description: Operate apps on the desktop host the user connected to Zero Computer Use, when APIs are not enough. Not for remote browser sessions, which are Zero Browser (`okou browser use`).
+description: Operate apps on a desktop host through Computer Use, whether surfaced as Okou Desktop or the still-supported legacy Zero Desktop, when APIs are not enough. Not for remote browser sessions (`okou browser use`), surfaced as Okou Browser or legacy Zero Browser.
 ---
 
 # Computer Use
 
 ## Overview
 
-Use `okou computer-use <command>` to inspect and operate apps on the connected Zero Desktop host. Treat it as an accessibility-first GUI control surface: read the app state, act through accessibility elements, and inspect screenshots only when visual information is required or the accessibility state is insufficient.
+Use `okou computer-use <command>` to inspect and operate apps on the connected desktop host. Current clients present this as Okou Desktop; still-supported legacy clients may call it Zero Desktop. Treat it as an accessibility-first GUI control surface: read the app state, act through accessibility elements, and inspect screenshots only when visual information is required or the accessibility state is insufficient.
 
 `--app` accepts an app bundle id only, such as `com.apple.Safari` or `com.google.Chrome`. App names like `Safari`, `Google Chrome`, `Slack`, or `WeChat` are display labels only and must not be passed to `--app`.
 

--- a/finicity/SKILL.md
+++ b/finicity/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: finicity
-description: Use vm0's managed banking gateway backed by Finicity to list enabled bank accounts, balances, and transactions. Use when the user mentions Finicity, connected bank accounts, banking balances, or bank transactions.
+description: Use the platform-managed banking gateway backed by Finicity to list enabled bank accounts, balances, and transactions. Use when the user mentions Finicity, connected bank accounts, banking balances, or bank transactions.
 ---
 
 ## Prerequisites
 
 1. Authenticate Okou CLI with `OKOU_TOKEN` carrying the `banking:read` capability.
-2. The vm0 administrator must enable the relevant Finicity-backed accounts for the current agent.
+2. A platform administrator must enable the relevant Finicity-backed accounts for the current agent.
 3. Finicity credentials and app tokens remain server-side; do not request them from the user.
 
 ## List Accounts

--- a/gen/SKILL.md
+++ b/gen/SKILL.md
@@ -22,7 +22,7 @@ okou generate -h
 - `okou generate presentation` - returns an Open Design resource-selection packet for an HTML presentation that the agent authors and hosts.
 - `okou generate website` - returns website authoring instructions / an Open Design packet that the agent uses to build and host a static site.
 - `okou generate report`, `docs-design`, `poster`, `dashboard-design`, `mobile-app-design` - return Open Design resource-selection packets for static HTML artifacts.
-- `okou generate text`, `code`, `document`, `audio` - list connector-backed options and print connector skill-invocation guidance; these do not have built-in vm0 pipelines unless the CLI help says otherwise.
+- `okou generate text`, `code`, `document`, `audio` - list connector-backed options and print connector skill-invocation guidance; these do not have built-in platform pipelines unless the CLI help says otherwise.
 
 Run `okou generate <type>` with no generation input to list available providers for that artifact type. Add `--all` when unavailable or not-yet-authorized connectors are relevant.
 

--- a/goal/SKILL.md
+++ b/goal/SKILL.md
@@ -11,7 +11,7 @@ a fresh turn to make concrete progress toward the objective, then ends the turn.
 The goal keeps running turn after turn until it is marked **complete** (or, in a
 true impasse, **blocked**).
 
-This is the vm0 equivalent of the Codex `/goal` command, driven by the
+This is the CLI equivalent of the Codex `/goal` command, driven by the
 `okou goal` CLI instead of a built-in tool. Use this skill in place of any
 built-in goal command.
 

--- a/google-slides/SKILL.md
+++ b/google-slides/SKILL.md
@@ -25,7 +25,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-Connect the **Google Drive** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors).
+Connect the **Google Drive** connector at [app.okou.ai/connectors](https://app.okou.ai/connectors).
 
 > **Troubleshooting:** If requests fail, run `okou doctor check-connector --env-name GOOGLE_DRIVE_TOKEN` or `okou doctor check-connector --url https://slides.googleapis.com/v1/presentations/<presentation-id> --method GET`
 

--- a/illustration-template/flat-poster/SKILL.md
+++ b/illustration-template/flat-poster/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: flat-poster
-description: Vertical flat-color editorial poster style — a single saturated solid background, one centered hand-drawn vector subject in bold deep-navy outlines with a strict two-tone fill (white + a slightly darker bg-tint accent), small floating accent marks, a bold rounded sans-serif headline pinned top-left, and a small wordmark pinned bottom-right. Portrait 2:3 canvas. Trigger when the user says /flat-poster, asks for a "flat-color editorial poster", a "brand benefit card", a "marketing card in the bold outline + flat color style", or briefs with a palette + subject + headline shape.
+description: Vertical flat-color editorial poster style — a single saturated solid background, one centered hand-drawn vector subject in bold deep-navy outlines with a strict two-tone fill (white + a slightly darker bg-tint accent), small floating accent marks, a bold rounded sans-serif headline pinned top-left, and an optional user-supplied wordmark pinned bottom-right. Portrait 2:3 canvas. Trigger when the user says /flat-poster, asks for a "flat-color editorial poster", a "brand benefit card", a "marketing card in the bold outline + flat color style", or briefs with a palette + subject + headline shape.
 ---
 
 # /flat-poster — locked flat-color editorial poster style
 
-This style produces vertical brand-marketing posters in a single locked recipe: one saturated flat background, one centered hand-drawn vector subject, a bold short headline pinned to the top-left, and a small wordmark pinned to the bottom-right. The visual frame never moves — only six creative dials swap between pieces.
+This style produces vertical brand-marketing posters in a single locked recipe: one saturated flat background, one centered hand-drawn vector subject, a bold short headline pinned to the top-left, and an optional user-supplied wordmark pinned to the bottom-right. The visual frame never moves — only six creative dials swap between pieces.
 
 Think Wisevest "core benefits" card meets early-Mailchimp app illustration: confident vector linework with just enough hand-drawn imperfection to feel warm, on a flat color field that does the emotional heavy lifting.
 
@@ -16,7 +16,7 @@ The user will usually give a short brief — sometimes just a concept ("savings"
 1. **Pick a hero subject** from the brief — a single object, character, or scene element that visually carries the concept. One thing, never two.
 2. **Choose a saturated background hex** that matches the subject's mood (see palette families below).
 3. **Write or refine the headline** — 1–4 words per line, ≤ 3 lines total, deep-navy bold rounded sans-serif. Tight punchy phrasing.
-4. **Pick a wordmark** — short brand text for the bottom-right. Default `VM0` unless the user names another (keep ≤ 4 characters; longer names get garbled).
+4. **Use a wordmark only when supplied** — place the user's short brand text in the bottom-right (keep ≤ 4 characters; longer names get garbled). Omit the wordmark when the user does not provide one.
 5. **Pick accent marks** — 1–3 categories of hand-drawn dust (dashes, dots, sparkles, curly trails, rays, plus signs, etc.) that fit the subject's emotional world.
 6. **Pick a composition preset** — where the subject sits on the canvas (centered-hero by default).
 
@@ -51,9 +51,10 @@ Bias toward subjects that are concrete and iconic: things you can name in one wo
 
 ### Wordmark (bottom-right)
 
+- Optional; include only a wordmark supplied by the user
 - Same deep-navy sans-serif as the headline, **smaller**
 - Pinned to the **bottom-right corner**
-- Default text `VM0` — short, 2–4 character brand acronym
+- Keep supplied text to a short 2–4 character brand acronym
 
 ### Accent marks
 
@@ -135,7 +136,7 @@ Subject:      <one specific object/character with pose and detail>
 Composition:  <one of the six presets>
 Accents:      <1–3 accent categories>
 Headline:     <short phrase, 1–3 lines, deep-navy bold sans-serif, top-left>
-Wordmark:     <2–4 char brand, deep-navy bold sans-serif, bottom-right>
+Wordmark:     <user-supplied 2–4 char brand, deep-navy bold sans-serif, bottom-right; omit if none>
 Mood:         <one short phrase>
 ```
 
@@ -144,11 +145,11 @@ Mood:         <one short phrase>
 Models with strong typography and clean flat-vector handling (e.g. gpt-image-2) produce the most reliable output here. When briefing the model:
 
 - State **explicitly** that the canvas is portrait 2:3, with the flat color filling edge to edge.
-- State **explicitly** that the only text on the canvas is the top-left headline and the bottom-right wordmark — no captions, no body copy, no subtitle.
+- State **explicitly** that the only text on the canvas is the top-left headline plus the user-supplied bottom-right wordmark when present — no captions, no body copy, no subtitle.
 - State **explicitly** that the fill is two-tone: pure white + one darker tint of the background.
 - State **explicitly** the stroke style (deep-navy, ~7px, hand-drawn with tiny gaps).
 - Name the accent vocabulary explicitly — models otherwise default to generic stars / sparkles everywhere.
-- Keep the wordmark short (2–4 chars). Longer brand names get garbled regardless of model.
+- When a wordmark is supplied, keep it short (2–4 chars). Longer brand names get garbled regardless of model.
 
 If the model adds extra body text, regenerate or reduce the subject brief to make room.
 

--- a/illustration-template/jade-blockprint/SKILL.md
+++ b/illustration-template/jade-blockprint/SKILL.md
@@ -82,7 +82,7 @@ If unspecified, infer:
 - Cool / editorial / intellectual → cobalt or slate
 - Calm / botanical / refined → sage or rose
 - Moody / premium → plum
-- Signature / fresh / vm0 launch context → jade
+- Signature / fresh / launch context → jade
 
 Custom accent: honor any hex the user provides verbatim.
 

--- a/illustration-template/postcard-illustration/SKILL.md
+++ b/illustration-template/postcard-illustration/SKILL.md
@@ -147,7 +147,7 @@ Pass both locked reference images as style anchors (image-to-image / multi-image
 
 See the **Required model** section near the top of this file for the locked model and required generation parameters. Additional notes:
 
-- Do not request `--style` chaining with another vm0 image style — this style is self-contained and the resource is selected as the primary style.
+- Do not request `--style` chaining with another registered image style — this style is self-contained and the resource is selected as the primary style.
 - Do not silently fall back to a different image model if `gpt-image-2` is unavailable. Surface the unavailability and ask the caller before substituting — the locked look will not survive on a weaker model.
 
 ## Evaluation cues

--- a/nano-banana/SKILL.md
+++ b/nano-banana/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when you need to:
 
 ## Prerequisites
 
-Connect the **Nano Banana** connector at [app.vm0.ai/connectors](https://app.vm0.ai/connectors). Enabling the connector provisions `NANO_BANANA_TOKEN` — no Google Cloud account or user-supplied key is required.
+Connect the **Nano Banana** connector at [app.okou.ai/connectors](https://app.okou.ai/connectors). Enabling the connector provisions `NANO_BANANA_TOKEN` — no Google Cloud account or user-supplied key is required.
 
 > **Troubleshooting:** If requests fail, run `okou doctor check-connector --env-name NANO_BANANA_TOKEN` or `okou doctor check-connector --url https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent --method POST`
 

--- a/video-template/chinese-ink-art/SKILL.md
+++ b/video-template/chinese-ink-art/SKILL.md
@@ -5,7 +5,7 @@ description: A Chinese ink-wash (shuimo) video style — monochrome ink gradient
 
 # Chinese Ink Painting
 
-A **Chinese ink-wash (shuimo) style**, not a fixed scene. Keep the user's subject exactly as briefed — a mountain, a crane, a figure, an object — and render it as flowing ink on paper in the look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+A **Chinese ink-wash (shuimo) style**, not a fixed scene. Keep the user's subject exactly as briefed — a mountain, a crane, a figure, an object — and render it as flowing ink on paper in the look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
 
 ## What this style is
 

--- a/video-template/cyberpunk-anime/SKILL.md
+++ b/video-template/cyberpunk-anime/SKILL.md
@@ -5,7 +5,7 @@ description: A 2D cyberpunk anime video style — hand-drawn cel-look characters
 
 # Cyberpunk Anime
 
-A **2D cyberpunk anime style**, not a fixed scene. Keep the user's character or subject exactly as briefed — and render it as hand-drawn anime in the neon-city look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and the look is **2D animation** (state this explicitly so the model doesn't drift to live action / 3D).
+A **2D cyberpunk anime style**, not a fixed scene. Keep the user's character or subject exactly as briefed — and render it as hand-drawn anime in the neon-city look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and the look is **2D animation** (state this explicitly so the model doesn't drift to live action / 3D).
 
 ## What this style is
 

--- a/video-template/epic-grandeur/SKILL.md
+++ b/video-template/epic-grandeur/SKILL.md
@@ -5,7 +5,7 @@ description: A large-format epic cinematic video style — wide-to-extreme-wide 
 
 # Epic Grandeur
 
-A trailer-grade, large-format cinematic **style**, not a fixed scene. Keep the user's subject exactly as briefed — a city, a product, a person, a landscape — and render it through the look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and framing/scale/negatives are expressed the way Seedance follows most reliably.
+A trailer-grade, large-format cinematic **style**, not a fixed scene. Keep the user's subject exactly as briefed — a city, a product, a person, a landscape — and render it through the look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and framing/scale/negatives are expressed the way Seedance follows most reliably.
 
 ## What this style is
 

--- a/video-template/fashion-editorial/SKILL.md
+++ b/video-template/fashion-editorial/SKILL.md
@@ -5,7 +5,7 @@ description: A high-fashion editorial video style - cold desaturated grade, dram
 
 # Fashion Editorial
 
-A **high-fashion editorial style**, not a fixed model or outfit. Keep the user's subject exactly as briefed - a garment, model, accessory, beauty look, or luxury brand - and stage it in the locked editorial look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
+A **high-fashion editorial style**, not a fixed model or outfit. Keep the user's subject exactly as briefed - a garment, model, accessory, beauty look, or luxury brand - and stage it in the locked editorial look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
 
 ## What this style is
 

--- a/video-template/gourmet-documentary/SKILL.md
+++ b/video-template/gourmet-documentary/SKILL.md
@@ -5,7 +5,7 @@ description: A sensory culinary-documentary video style — macro food texture, 
 
 # Gourmet Documentary
 
-A **sensory food-documentary style**, not a fixed dish. Keep the user's food or craft exactly as briefed — sashimi, coffee, bread, a cocktail — and shoot it in the intimate macro look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+A **sensory food-documentary style**, not a fixed dish. Keep the user's food or craft exactly as briefed — sashimi, coffee, bread, a cocktail — and shoot it in the intimate macro look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
 
 ## What this style is
 

--- a/video-template/hand-drawn-fantasy-anime/SKILL.md
+++ b/video-template/hand-drawn-fantasy-anime/SKILL.md
@@ -5,7 +5,7 @@ description: A hand-drawn fantasy animation video style - painterly 2D backgroun
 
 # Hand Drawn Fantasy Anime
 
-A **hand-drawn fantasy animation style**, not a fixed character, studio, or franchise. Keep the user's subject exactly as briefed - a child, creature, village, forest path, airship, animal companion, or magical object - and render it in the locked painterly 2D fantasy look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
+A **hand-drawn fantasy animation style**, not a fixed character, studio, or franchise. Keep the user's subject exactly as briefed - a child, creature, village, forest path, airship, animal companion, or magical object - and render it in the locked painterly 2D fantasy look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
 
 ## What this style is
 

--- a/video-template/japanese-wabi-sabi/SKILL.md
+++ b/video-template/japanese-wabi-sabi/SKILL.md
@@ -5,7 +5,7 @@ description: A Japanese wabi-sabi lifestyle video style — natural imperfection
 
 # Japanese Wabi-Sabi
 
-A **wabi-sabi lifestyle style**, not a fixed scene. Keep the user's subject exactly as briefed — an object, a corner, a moment — and render it in the quiet, imperfect, softly-lit look below. The style supplies the *mood*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+A **wabi-sabi lifestyle style**, not a fixed scene. Keep the user's subject exactly as briefed — an object, a corner, a moment — and render it in the quiet, imperfect, softly-lit look below. The style supplies the *mood*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
 
 ## What this style is
 

--- a/video-template/luxury-product/SKILL.md
+++ b/video-template/luxury-product/SKILL.md
@@ -5,7 +5,7 @@ description: A dark luxury product macro video style - premium materials in extr
 
 # Luxury Product Macro
 
-A **dark luxury product macro style**, not a watch template. Keep the user's object exactly as briefed - a watch, pen, ring, camera, fragrance cap, lighter, bottle detail, or machined component - and render it in the locked premium macro look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
+A **dark luxury product macro style**, not a watch template. Keep the user's object exactly as briefed - a watch, pen, ring, camera, fragrance cap, lighter, bottle detail, or machined component - and render it in the locked premium macro look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
 
 ## What this style is
 

--- a/video-template/shortform-viral/SKILL.md
+++ b/video-template/shortform-viral/SKILL.md
@@ -5,7 +5,7 @@ description: A short-form viral video style — vertical 9:16, fast hook, authen
 
 # Shortform Viral
 
-A **social short-form style**, not a fixed scene. Keep the user's subject exactly as briefed — a product, a moment, people, a place — and shoot it like a creator's phone clip below. The style supplies the *energy*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
+A **social short-form style**, not a fixed scene. Keep the user's subject exactly as briefed — a product, a moment, people, a place — and shoot it like a creator's phone clip below. The style supplies the *energy*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering.
 
 ## What this style is
 

--- a/video-template/sports-performance-ad/SKILL.md
+++ b/video-template/sports-performance-ad/SKILL.md
@@ -5,7 +5,7 @@ description: A sports performance advertising video style - athlete effort, gear
 
 # Sports Performance Ad
 
-A **sports performance advertising style**, not a fixed sport and not a generic motivation montage. Keep the user's athlete, action, or performance product exactly as briefed - running, boxing, cycling, lifting, climbing, team drills, shoes, gloves, a racket, or training gear - and shoot it in the locked commercial look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
+A **sports performance advertising style**, not a fixed sport and not a generic motivation montage. Keep the user's athlete, action, or performance product exactly as briefed - running, boxing, cycling, lifting, climbing, team drills, shoes, gloves, a racket, or training gear - and shoot it in the locked commercial look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject -> scene -> motion -> camera -> light -> style` ordering.
 
 ## What this style is
 

--- a/video-template/tech-minimalist-reveal/SKILL.md
+++ b/video-template/tech-minimalist-reveal/SKILL.md
@@ -5,7 +5,7 @@ description: A minimalist tech/product reveal video style — a single product f
 
 # Phone Product Showcase
 
-A premium **product-reveal style**, not a fixed product. Keep the user's product exactly as briefed — a phone, a watch, a bottle, a gadget — and present it in the locked studio look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (vm0's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and framing/negatives are expressed the way Seedance follows most reliably.
+A premium **product-reveal style**, not a fixed product. Keep the user's product exactly as briefed — a phone, a watch, a bottle, a gadget — and present it in the locked studio look below. The style supplies the *look*; the user supplies the *what*. Tuned for **Seedance** (the platform's default video model): the prompt follows Seedance's `subject → scene → motion → camera → light → style` ordering, and framing/negatives are expressed the way Seedance follows most reliably.
 
 ## What this style is
 

--- a/workflow-setup/SKILL.md
+++ b/workflow-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: workflow-setup
-description: Create, edit, inspect, run, schedule, pause, or delete vm0 workflows and automations.
+description: Create, edit, inspect, run, schedule, pause, or delete workflows and automations.
 ---
 
-# Okou Workflow Setup
+# Workflow Setup
 
-Use this skill to help users create and manage vm0 workflows and their
+Use this skill to help users create and manage workflows and their
 automations. A workflow is the reusable SOP/skill body. An automation is a
 trigger attached to a workflow. The CLI represents automations as
 `okou workflow trigger ...`; the user-facing conversation should usually call


### PR DESCRIPTION
## Summary

- neutralize reader-facing brand prose in workflow setup, generation, goals, Finicity, image styles, and video templates
- point connector setup guidance to `https://app.okou.ai/connectors`
- make Flat Poster use only a user-supplied wordmark and omit it when none is provided
- describe Computer Use with current Okou naming while retaining explicit legacy Zero Desktop and Zero Browser compatibility

## Preserved VM0/Zero classifications

- **Repository and metadata identities:** `vm0-ai/vm0-skills`, vm0 connector repository references, and `vm0_secrets`/`vm0_vars` metadata remain technical identifiers; the repository README remains factual ownership/setup documentation.
- **Named resource identity:** `vm0 Illustration`, its `vm0-illustration` path, palette language, and cross-style references remain the registered style identity.
- **Historical fact:** Flat Poster's existing reference section still identifies the first four pieces as the VM0 launch set.
- **Immutable artifacts:** existing `cdn.vm0.io` reference assets remain unchanged.
- **Compatibility and fixtures:** legacy Zero Desktop/Browser language remains explicitly labeled as legacy; `/tmp/vm0/computer-use` and `sites.vm0` examples remain runtime paths/test fixtures.
- **Unrelated semantics:** ordinary uses of “zero” and Cloudflare Zero Trust naming remain unchanged.

## Verification

- per-skill `quick_validate.py` validation for all 21 changed skills
- repository CI-equivalent frontmatter validation for all 93 `SKILL.md` files
- `_ACCESS_TOKEN` naming guard
- `git diff --check`

## Coordination

Companion application/catalog PR: vm0-ai/vm0#29167

No strict merge order: each PR is independently compatible.

Refs vm0-ai/vm0#27750
